### PR TITLE
Fix: persist picked model as default so new conversations inherit it

### DIFF
--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -212,6 +212,10 @@ export class SessionCore {
         this.conv = { ...this.conv, model: msg.model, updatedAt: this.clock() };
         this.sendConversation();
         void this.persist();
+        // Remember this as the default so new conversations (and onboarding's
+        // model pick) inherit it instead of reopening on "Select model".
+        void this.deps.settings.saveDefaultModel(msg.model);
+        if (this.settingsCache) this.settingsCache = { ...this.settingsCache, defaultModel: msg.model };
         return;
       case 'setHarnessMode':
         this.conv = { ...this.conv, harnessMode: msg.mode, updatedAt: this.clock() };

--- a/test/extension-session.test.ts
+++ b/test/extension-session.test.ts
@@ -102,7 +102,11 @@ class FakeSettings implements SettingsPort {
   async saveProviders(p: ProviderConfig[]) {
     this.providers = p;
   }
-  async saveDefaultModel() {}
+  savedDefault: { providerId: string; modelId: string } | null | undefined = undefined;
+  async saveDefaultModel(model: { providerId: string; modelId: string } | null) {
+    this.savedDefault = model;
+    this.defaultModel = model as typeof this.defaultModel;
+  }
 }
 
 class FakeHistory implements HistoryPort {
@@ -191,10 +195,11 @@ function makeSession(opts: { mode?: HarnessMode; path?: string; content?: string
   const io = new FakeIo();
   const posted: HostToWebview[] = [];
   const { adapter, requests } = scriptedAdapter(opts.path, opts.content);
+  const settings = new FakeSettings(opts.mode ?? 'solo');
   const deps: SessionDeps = {
     io,
     secrets: new FakeSecrets(),
-    settings: new FakeSettings(opts.mode ?? 'solo'),
+    settings,
     history: new FakeHistory(),
     git: fakeGit,
     post: (m) => posted.push(m),
@@ -203,7 +208,7 @@ function makeSession(opts: { mode?: HarnessMode; path?: string; content?: string
     clock: () => Date.now(),
   };
   const session = createSessionCore(deps);
-  return { session, posted, io, requests };
+  return { session, posted, io, requests, settings };
 }
 
 function lastConversation(posted: HostToWebview[]): Conversation | undefined {
@@ -232,6 +237,20 @@ describe('session ready handshake', () => {
     expect(conv).toBeDefined();
     expect(conv!.model).toEqual({ providerId: 'p1', modelId: 'm1' });
     expect(conv!.harnessMode).toBe('solo');
+  });
+});
+
+describe('setModel', () => {
+  it('persists the picked model as the default so new conversations inherit it', async () => {
+    const { session, posted, settings } = makeSession();
+    await session.handle({ type: 'ready' });
+    const pick = { providerId: 'p1', modelId: 'm2' };
+    await session.handle({ type: 'setModel', model: pick });
+
+    // Current conversation reflects the pick...
+    expect(lastConversation(posted)!.model).toEqual(pick);
+    // ...and it was persisted as the default for future conversations.
+    expect(settings.savedDefault).toEqual(pick);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the reported "can't load the model" gap. The model picker itself works (verified in-browser: the status-line dropdown lists the provider's fetched models and picking one posts `setModel`), but the choice never persisted as a default — `saveDefaultModel` existed but was never called. So `onReady` always seeded new conversations with a `null` default and the status line reopened on "Select model" every time.

`setModel` now persists the model via `settings.saveDefaultModel` and updates the cached settings, so onboarding's model pick and every future conversation inherit it.

## Testing

- 112 unit tests green (+1 regression test asserting the pick is persisted as the default)
- 48 Playwright checks green; typecheck + build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2kQhmZ4jQUgwkcLm1rGrW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2kQhmZ4jQUgwkcLm1rGrW)_