### PR TITLE
Edit Selection + Skills (opt-in, lazy, model-invoked)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -112,6 +112,27 @@ Two run modes, toggleable per tab from the status line:
 - Role prompts are markdown files bundled with the extension and overridable per workspace
   (`.fowlplay/roles/*.md`).
 
+### Skills (opt-in, lazy, model-invoked)
+
+Adapted from the Safe Agentic Workflow's model-invoked skills. A **skill** is a reusable
+markdown instruction doc (e.g. "commit-message", "test-writing") the model can pull in on
+demand. Unlike an always-on `AGENTS.md` (a Dino non-goal, see §8), skills are deliberately
+**lazy**: only each skill's name + one-line description is injected into the system prompt (a
+compact catalog). The full body stays out of context until the model explicitly calls the
+`load_skill` tool — preserving FowlPlay's context-GC philosophy (§1) rather than dumping
+instructions on every turn.
+
+- Skills come from two places, merged with **workspace overriding bundled by name**:
+  a couple of short **bundled defaults** (so the feature is demoable with zero setup) and
+  workspace files at **`.fowlplay/skills/*.md`**. A skill's name/description come from YAML
+  frontmatter (`name:` / `description:`), falling back to the first `#` heading / first prose
+  line / the filename.
+- The `load_skill` tool is offered **only when skills exist** — with no skills, the toolset is
+  unchanged. It is surfaced to the **Builder** (Coop) and the **Solo** loop, where
+  implementation happens; Scout/Inspector/Sentry do not get skills.
+- The Harness settings tab lists the discovered skills so you can see what is available and
+  where to add more.
+
 ## 7. Settings
 
 Settings panel (from the chat title bar), three tabs:

--- a/e2e/mockBridge.js
+++ b/e2e/mockBridge.js
@@ -89,6 +89,10 @@
         harness: { defaultMode: 'coop', qasRetryBudget: 2 },
         providers: hasProviders ? providers() : [],
         defaultModel: hasProviders ? { providerId: 'prov-ollama', modelId: 'qwen2.5-coder:32b' } : null,
+        skills: [
+          { name: 'commit-message', description: 'Write a clear, conventional commit message for a staged changeset.' },
+          { name: 'test-writing', description: 'Write focused, deterministic tests that pin the behavior a change introduces.' },
+        ],
       },
     };
   }

--- a/e2e/mockBridge.js
+++ b/e2e/mockBridge.js
@@ -34,6 +34,10 @@
       if (msg && msg.type === 'openDiff' && msg.changesetId === 'cs-hist-1') {
         emit({ type: 'changeset', view: historicalView() });
       }
+      // "Edit Selection" chip dismissed → the host clears the pinned selection.
+      if (msg && msg.type === 'clearSelection') {
+        emit({ type: 'selectionContext', context: null });
+      }
     },
     onMessage(handler) {
       handlers.push(handler);
@@ -384,6 +388,20 @@
         emit(settings(true));
         emit(conversationList());
         setView('history');
+        break;
+      case 'selection':
+        emit(settings(true));
+        emit(conversation());
+        emit({
+          type: 'selectionContext',
+          context: {
+            path: 'src/auth/authService.ts',
+            startLine: 12,
+            endLine: 20,
+            text: 'export async function login(u, p) {\n  return api.post("/login", { u, p });\n}',
+            languageId: 'typescript',
+          },
+        });
         break;
       case 'chat':
       default:

--- a/e2e/run.mjs
+++ b/e2e/run.mjs
@@ -124,6 +124,17 @@ if (await review.isVisible().catch(() => false)) {
   ok(false, 'Review Changes button visible');
 }
 
+// ============================== EDIT SELECTION ===============================
+console.log('\n# edit selection');
+await open('selection');
+await waitFor(page, () => document.body.innerText.includes('authService.ts:12-20'), 'selection chip shows basename:range');
+const chip = page.locator('.fp-selection-chip').first();
+ok(await chip.isVisible().catch(() => false), 'selection chip visible above composer');
+await page.screenshot({ path: join(SHOTS, 'selection.png'), fullPage: false });
+await chip.getByRole('button', { name: /clear selection/i }).click();
+ok((await sent(page, 'clearSelection')).length === 1, 'clicking × posts clearSelection');
+await waitFor(page, () => !document.body.innerText.includes('authService.ts:12-20'), 'chip clears after dismiss');
+
 // ============================== DIFF =========================================
 console.log('\n# diff');
 await open('diff');

--- a/e2e/run.mjs
+++ b/e2e/run.mjs
@@ -190,6 +190,8 @@ for (const tab of ['Appearance', 'Harness']) {
   } else ok(false, `${tab} tab clickable`);
 }
 await waitFor(page, () => /Scout|Inspector|Sentry/.test(document.body.innerText), 'harness tab explains Coop pipeline');
+await waitFor(page, () => document.body.innerText.includes('commit-message'), 'harness tab lists discovered skills');
+await waitFor(page, () => /\.fowlplay\/skills/.test(document.body.innerText), 'harness tab documents .fowlplay/skills location');
 await page.screenshot({ path: join(SHOTS, 'settings.png'), fullPage: false });
 
 // ============================== ONBOARDING ===================================

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
         "title": "FowlPlay: Settings"
       },
       {
+        "command": "fowlplay.editSelection",
+        "title": "FowlPlay: Edit Selection"
+      },
+      {
         "command": "fowlplay.resetSettings",
         "title": "FowlPlay: Reset Settings and Providers"
       }
@@ -41,6 +45,12 @@
         "command": "fowlplay.openTab",
         "key": "ctrl+alt+f",
         "mac": "cmd+alt+f"
+      },
+      {
+        "command": "fowlplay.editSelection",
+        "key": "ctrl+alt+e",
+        "mac": "cmd+alt+e",
+        "when": "editorHasSelection"
       }
     ],
     "viewsContainers": {
@@ -66,6 +76,13 @@
         {
           "command": "fowlplay.openTab",
           "group": "navigation"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "fowlplay.editSelection",
+          "when": "editorHasSelection",
+          "group": "1_modification"
         }
       ]
     },

--- a/src/core/agent/skills.ts
+++ b/src/core/agent/skills.ts
@@ -1,0 +1,158 @@
+/**
+ * Skills — reusable, model-invoked instruction docs.
+ *
+ * A skill is a markdown file (bundled with FowlPlay or dropped into a workspace
+ * under `.fowlplay/skills/*.md`). Skills are LAZY: only their name + one-line
+ * description are ever injected into a system prompt (see {@link formatSkillCatalog}).
+ * The model loads a skill's full body on demand via the `load_skill` tool — which
+ * keeps FowlPlay's context-GC philosophy intact (no always-on instruction dump).
+ *
+ * Pure TypeScript — no `vscode`, no filesystem. The extension discovers the raw
+ * markdown and calls {@link parseSkill}; this module never touches disk.
+ */
+
+import type { Skill, SkillMeta } from '../../shared/types';
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a skill from its filename + raw markdown.
+ *
+ *  - name:        YAML frontmatter `name:` → first `# heading` → filename (sans path/ext)
+ *  - description: YAML frontmatter `description:` → first non-heading, non-empty body line
+ *  - body:        the markdown with any leading frontmatter stripped
+ */
+export function parseSkill(filename: string, raw: string): Skill {
+  const { frontmatter, body } = splitFrontmatter(raw ?? '');
+
+  const fmName = frontmatter.name?.trim();
+  const fmDesc = frontmatter.description?.trim();
+
+  const baseName = filename
+    .replace(/\\/g, '/')
+    .replace(/^.*\//, '')
+    .replace(/\.md$/i, '')
+    .trim();
+
+  const name = firstNonEmpty(fmName, firstHeading(body), baseName) || 'skill';
+  const description = firstNonEmpty(fmDesc, firstNonHeadingLine(body)) || '';
+
+  return { name, description, body: body.trim() };
+}
+
+/** Split a leading `---` frontmatter block (if any). Values are trimmed + de-quoted. */
+function splitFrontmatter(raw: string): { frontmatter: Record<string, string>; body: string } {
+  const text = raw.replace(/^﻿/, '');
+  const m = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n?/.exec(text);
+  if (!m) return { frontmatter: {}, body: text };
+
+  const fm: Record<string, string> = {};
+  for (const line of m[1].split(/\r?\n/)) {
+    const idx = line.indexOf(':');
+    if (idx <= 0) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line
+      .slice(idx + 1)
+      .trim()
+      .replace(/^["']|["']$/g, '');
+    if (key) fm[key] = value;
+  }
+  return { frontmatter: fm, body: text.slice(m[0].length) };
+}
+
+function firstHeading(body: string): string | undefined {
+  for (const line of body.split(/\r?\n/)) {
+    const m = /^#{1,6}\s+(.+?)\s*$/.exec(line.trim());
+    if (m) return m[1].trim();
+  }
+  return undefined;
+}
+
+function firstNonHeadingLine(body: string): string | undefined {
+  for (const line of body.split(/\r?\n/)) {
+    const t = line.trim();
+    if (!t || t.startsWith('#')) continue;
+    return t;
+  }
+  return undefined;
+}
+
+function firstNonEmpty(...values: (string | undefined)[]): string | undefined {
+  for (const v of values) if (v && v.trim()) return v.trim();
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Catalog formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a compact catalog block for injection into a system prompt: one line per
+ * skill (name + description) plus an instruction to call `load_skill` before relying
+ * on a skill. Returns an empty string when there are no skills (so callers can
+ * inject unconditionally without leaking an empty header).
+ */
+export function formatSkillCatalog(metas: SkillMeta[]): string {
+  if (metas.length === 0) return '';
+  const lines = metas.map((m) => (m.description ? `- ${m.name}: ${m.description}` : `- ${m.name}`));
+  return `AVAILABLE SKILLS
+Reusable instruction docs are available but NOT yet loaded. When a task matches one,
+call the \`load_skill\` tool with its exact name to load the full instructions BEFORE you
+rely on it — do not guess a skill's contents.
+
+${lines.join('\n')}`;
+}
+
+// ---------------------------------------------------------------------------
+// Bundled default skills
+// ---------------------------------------------------------------------------
+
+const COMMIT_MESSAGE_SKILL = `---
+name: commit-message
+description: Write a clear, conventional commit message for a staged changeset.
+---
+
+# Commit message
+
+Write a single-line commit subject that describes the *intent* of the change, then an
+optional body for the *why*.
+
+- Subject: imperative mood, <= 72 chars, no trailing period (e.g. "Add retry to fetch").
+- Prefer a Conventional Commits type prefix when it fits: \`feat:\`, \`fix:\`, \`refactor:\`,
+  \`test:\`, \`docs:\`, \`chore:\`. Add a scope in parentheses when it clarifies (e.g.
+  \`fix(auth): reject expired tokens\`).
+- Body (optional, wrapped at ~72 cols): explain *why* the change was made and any
+  consequences a reviewer should know. Skip it for trivial changes.
+- Describe what the diff actually does — never invent changes that are not staged.`;
+
+const TEST_WRITING_SKILL = `---
+name: test-writing
+description: Write focused, deterministic tests that pin the behavior a change introduces.
+---
+
+# Test writing
+
+Add tests that would fail before the change and pass after it.
+
+- Cover the behavior the acceptance criteria describe, not the implementation details.
+- One clear assertion of intent per test; name the test after the behavior it proves.
+- Include the important edge cases: empty input, error/failure paths, and boundaries.
+- Keep tests deterministic — no real network, clock, or filesystem unless injected/faked;
+  match the surrounding suite's framework and style rather than introducing a new one.
+- Prefer small, readable fixtures over large opaque ones.`;
+
+/** Raw markdown for each bundled skill, keyed by a synthetic filename. */
+export const BUNDLED_SKILL_SOURCES: Record<string, string> = {
+  'commit-message.md': COMMIT_MESSAGE_SKILL,
+  'test-writing.md': TEST_WRITING_SKILL,
+};
+
+/**
+ * Parsed bundled skills, so the feature is demoable with zero workspace setup.
+ * Workspace skills (`.fowlplay/skills/*.md`) override these by name.
+ */
+export const BUNDLED_SKILLS: Skill[] = Object.entries(BUNDLED_SKILL_SOURCES).map(([file, raw]) =>
+  parseSkill(file, raw),
+);

--- a/src/core/agent/tools.ts
+++ b/src/core/agent/tools.ts
@@ -6,7 +6,7 @@
  * Tools accept batch inputs (open N files, apply N edits) to minimize round-trips.
  */
 
-import type { ToolResult, ToolSpec } from '../../shared/types';
+import type { SkillMeta, ToolResult, ToolSpec } from '../../shared/types';
 import { applyFindReplace } from './edits';
 
 // ---------------------------------------------------------------------------
@@ -49,14 +49,31 @@ export interface ToolHost {
   stageEdit(ops: StageOp[]): Promise<void>;
   /** Paths currently staged (for diagnostics / summaries). */
   listStaged(): Promise<string[]>;
+  /**
+   * Load a skill's full instruction body by name, or `null` if no such skill.
+   * Optional: hosts without the skills capability simply omit it (the `load_skill`
+   * tool is only ever offered when skills exist).
+   */
+  loadSkill?(name: string): Promise<string | null>;
+  /** Skills available to load, used to list valid names in error messages. */
+  skills?: SkillMeta[];
 }
 
 // ---------------------------------------------------------------------------
 // Tool schemas
 // ---------------------------------------------------------------------------
 
-export function buildToolSpecs(): ToolSpec[] {
-  return [
+export interface BuildToolSpecsOptions {
+  /**
+   * When non-empty, a `load_skill` tool is appended (with the available skill names
+   * listed in its description). With no skills the toolset is exactly today's — the
+   * skills capability is strictly opt-in.
+   */
+  skills?: SkillMeta[];
+}
+
+export function buildToolSpecs(opts?: BuildToolSpecsOptions): ToolSpec[] {
+  const specs: ToolSpec[] = [
     {
       name: 'open_files',
       description:
@@ -142,6 +159,25 @@ export function buildToolSpecs(): ToolSpec[] {
       },
     },
   ];
+
+  const skills = opts?.skills;
+  if (skills && skills.length > 0) {
+    specs.push({
+      name: 'load_skill',
+      description:
+        'Load the full instructions for a reusable skill before you rely on it. ' +
+        `Available skills: ${skills.map((s) => s.name).join(', ')}.`,
+      parameters: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', description: 'The exact name of the skill to load.' },
+        },
+        required: ['name'],
+      },
+    });
+  }
+
+  return specs;
 }
 
 // ---------------------------------------------------------------------------
@@ -165,6 +201,8 @@ export async function dispatchToolCall(
         return await grepTool(host, args);
       case 'edit_files':
         return await editFiles(host, args);
+      case 'load_skill':
+        return await loadSkillTool(host, args);
       default:
         return { ok: false, content: `Unknown tool: ${name}` };
     }
@@ -330,6 +368,29 @@ async function editFiles(host: ToolHost, args: unknown): Promise<ToolResult> {
   }
 
   return { ok: allOk, content: results.join('\n'), gcClass: 'other' };
+}
+
+// --- load_skill -------------------------------------------------------------
+
+async function loadSkillTool(host: ToolHost, args: unknown): Promise<ToolResult> {
+  const name = asString((args as { name?: unknown })?.name)?.trim();
+  if (!name) {
+    return { ok: false, content: 'load_skill requires a "name" string' };
+  }
+  if (!host.loadSkill) {
+    return { ok: false, content: 'skills are not available in this session' };
+  }
+  const body = await host.loadSkill(name);
+  if (body === null) {
+    const available = host.skills?.map((s) => s.name).join(', ');
+    return {
+      ok: false,
+      content: available
+        ? `unknown skill: ${name}. Available skills: ${available}`
+        : `unknown skill: ${name}`,
+    };
+  }
+  return { ok: true, content: body, gcClass: 'other' };
 }
 
 function normalizeEdit(raw: unknown): EditSpec | null {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -27,10 +27,21 @@ export function activate(context: vscode.ExtensionContext): void {
         return;
       }
       const sel = editor.selection;
+      const uri = editor.document.uri;
+      // asRelativePath returns the (absolute) path unchanged for files outside
+      // any workspace folder — which would leak the home dir to the model. Use a
+      // basename in that case.
+      const inWorkspace = vscode.workspace.getWorkspaceFolder(uri) !== undefined;
+      const path = inWorkspace
+        ? vscode.workspace.asRelativePath(uri, false)
+        : uri.path.replace(/^.*\//, '');
+      // A whole-line selection ends at column 0 of the line *after* the last
+      // highlighted line; don't count that trailing line in the reported range.
+      const endLine = sel.end.character === 0 && sel.end.line > sel.start.line ? sel.end.line : sel.end.line + 1;
       const ctx: SelectionContext = {
-        path: vscode.workspace.asRelativePath(editor.document.uri, false),
+        path,
         startLine: sel.start.line + 1,
-        endLine: sel.end.line + 1,
+        endLine,
         text: editor.document.getText(sel),
         languageId: editor.document.languageId,
       };

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -4,6 +4,7 @@
  */
 
 import * as vscode from 'vscode';
+import type { SelectionContext } from '../shared/types';
 import { TabManager } from './tabManager';
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -18,6 +19,22 @@ export function activate(context: vscode.ExtensionContext): void {
     }),
     vscode.commands.registerCommand('fowlplay.openSettings', () => {
       tabs.openSettings();
+    }),
+    vscode.commands.registerCommand('fowlplay.editSelection', () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor || editor.selection.isEmpty) {
+        void vscode.window.showInformationMessage('Select some code (or Markdown) first, then run FowlPlay: Edit Selection.');
+        return;
+      }
+      const sel = editor.selection;
+      const ctx: SelectionContext = {
+        path: vscode.workspace.asRelativePath(editor.document.uri, false),
+        startLine: sel.start.line + 1,
+        endLine: sel.end.line + 1,
+        text: editor.document.getText(sel),
+        languageId: editor.document.languageId,
+      };
+      tabs.editSelection(ctx);
     }),
     vscode.commands.registerCommand('fowlplay.resetSettings', async () => {
       const choice = await vscode.window.showWarningMessage(

--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -30,6 +30,8 @@ import type {
   SdkType,
   SelectionContext,
   SerializedOverlay,
+  Skill,
+  SkillMeta,
   StreamEvent,
   TokenUsage,
   ToolSpec,
@@ -40,6 +42,7 @@ import { createAdapter as coreCreateAdapter, type ProviderAdapter, type WireAssi
 import { fetchModels as coreFetchModels, type FetchModelsConfig } from '../core/providers/registry';
 import { runAgentLoop } from '../core/agent/loop';
 import { buildToolSpecs, type DirEntry, type GrepMatch, type GrepOptions, type StageOp, type ToolHost } from '../core/agent/tools';
+import { BUNDLED_SKILLS, formatSkillCatalog, parseSkill } from '../core/agent/skills';
 import { gcHistory } from '../core/agent/contextGc';
 import { StagingOverlay, type DiskReader } from '../core/staging/overlay';
 import { ChangeSet } from '../core/staging/changeset';
@@ -154,6 +157,13 @@ export class SessionCore {
 
   /** A highlighted editor region pinned as scoped context for the NEXT prompt. */
   private pendingSelection: SelectionContext | null = null;
+
+  /**
+   * Skills available for the current turn (bundled defaults + workspace
+   * `.fowlplay/skills/*.md`), rediscovered at the start of each turn. Consumed by
+   * `toolHost()` (for `load_skill`) and the system-prompt catalog injection.
+   */
+  private turnSkills: Skill[] = [];
 
   /** Full (un-GC'd) wire history ending at each assistant node id, for follow-up turns. */
   private wireByNode = new Map<string, WireMessage[]>();
@@ -344,7 +354,10 @@ export class SessionCore {
   private async sendSettings(forceReload = false): Promise<void> {
     if (forceReload) this.settingsCache = null;
     const settings = await this.ensureSettings();
-    this.deps.post({ type: 'settings', settings });
+    // Attach discovered skills so the Settings UI can show what is available.
+    // Not part of the persisted settings — recomputed on demand, never cached.
+    const skills = toSkillMetas(await this.discoverSkills());
+    this.deps.post({ type: 'settings', settings: { ...settings, skills } });
   }
 
   private sendConversation(): void {
@@ -457,6 +470,10 @@ export class SessionCore {
       return;
     }
 
+    // Discover skills once for this turn (bundled + workspace). Both run modes
+    // read this via `toolHost()` and the system-prompt catalog.
+    this.turnSkills = await this.discoverSkills();
+
     const userNode = this.conv.nodes[userNodeId];
     const userText = firstText(userNode?.blocks ?? []) ?? '';
     const baseWire = this.wireBaseFor(userNodeId);
@@ -527,9 +544,9 @@ export class SessionCore {
       baseUrl: resolved.baseUrl,
       apiKey: resolved.apiKey,
       modelId: resolved.modelId,
-      system: SOLO_SYSTEM,
+      system: this.systemWithSkills(SOLO_SYSTEM),
       history: sent,
-      tools: this.allTools,
+      tools: this.toolsWithSkills(),
       toolHost: this.toolHost(),
       onEvent: (e) => this.deps.post({ type: 'stream', event: e }),
       signal,
@@ -587,9 +604,9 @@ export class SessionCore {
         baseUrl: resolved.baseUrl,
         apiKey: resolved.apiKey,
         modelId: resolved.modelId,
-        system: SOLO_SYSTEM,
+        system: this.systemWithSkills(SOLO_SYSTEM),
         history: gcHistory(base),
-        tools: this.allTools,
+        tools: this.toolsWithSkills(),
         toolHost: this.toolHost(),
         onEvent: (e) => this.deps.post({ type: 'stream', event: e }),
         signal: s,
@@ -979,6 +996,7 @@ export class SessionCore {
   private toolHost(): ToolHost {
     const overlay = this.overlay;
     const io = this.deps.io;
+    const skills = this.turnSkills;
     return {
       async readFile(path: string): Promise<string> {
         const content = await overlay.read(path);
@@ -998,7 +1016,48 @@ export class SessionCore {
       async listStaged(): Promise<string[]> {
         return overlay.ops().map((o) => o.path);
       },
+      skills: toSkillMetas(skills),
+      async loadSkill(name: string): Promise<string | null> {
+        const target = name.trim();
+        const match =
+          skills.find((s) => s.name === target) ??
+          skills.find((s) => s.name.toLowerCase() === target.toLowerCase());
+        return match ? match.body : null;
+      },
     };
+  }
+
+  /**
+   * Discover skills for a turn: the bundled defaults, overlaid by any workspace
+   * skills under `.fowlplay/skills/*.md` (workspace wins on a name collision).
+   */
+  private async discoverSkills(): Promise<Skill[]> {
+    const byName = new Map<string, Skill>();
+    for (const s of BUNDLED_SKILLS) byName.set(s.name, s);
+    try {
+      const files = await this.deps.io.glob('.fowlplay/skills/*.md');
+      for (const file of files) {
+        const raw = await this.deps.io.read(file);
+        if (raw === null) continue;
+        const skill = parseSkill(file, raw);
+        byName.set(skill.name, skill);
+      }
+    } catch {
+      /* skills are best-effort; fall back to bundled defaults */
+    }
+    return [...byName.values()];
+  }
+
+  /** Prepend the skill catalog to a base system prompt (no-op when no skills). */
+  private systemWithSkills(base: string): string {
+    const catalog = formatSkillCatalog(toSkillMetas(this.turnSkills));
+    return catalog ? `${catalog}\n\n${base}` : base;
+  }
+
+  /** The base toolset, plus `load_skill` when skills are available this turn. */
+  private toolsWithSkills(): ToolSpec[] {
+    const metas = toSkillMetas(this.turnSkills);
+    return metas.length > 0 ? buildToolSpecs({ skills: metas }) : this.allTools;
   }
 
   private async resolveModel(): Promise<ResolvedModel | null> {
@@ -1113,6 +1172,11 @@ export function createSessionCore(
 
 function emptyUsage(): TokenUsage {
   return { inputTokens: 0, outputTokens: 0, cachedTokens: 0 };
+}
+
+/** Strip skill bodies down to catalog metadata (name + description). */
+function toSkillMetas(skills: Skill[]): SkillMeta[] {
+  return skills.map(({ name, description }) => ({ name, description }));
 }
 
 function addUsage(a: TokenUsage, b: TokenUsage): TokenUsage {

--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -28,6 +28,7 @@ import type {
   ModelRef,
   ProviderConfig,
   SdkType,
+  SelectionContext,
   SerializedOverlay,
   StreamEvent,
   TokenUsage,
@@ -151,6 +152,9 @@ export class SessionCore {
   /** Monotonic counter for disk-only applies that have no commit sha. */
   private appliedSeq = 0;
 
+  /** A highlighted editor region pinned as scoped context for the NEXT prompt. */
+  private pendingSelection: SelectionContext | null = null;
+
   /** Full (un-GC'd) wire history ending at each assistant node id, for follow-up turns. */
   private wireByNode = new Map<string, WireMessage[]>();
 
@@ -175,6 +179,16 @@ export class SessionCore {
     return this.conv;
   }
 
+  /**
+   * Pin a highlighted editor region as scoped context for the next prompt
+   * ("Edit Selection"). Stored host-side so it survives even if the webview
+   * misses the chip message; consumed once by the next `sendPrompt`.
+   */
+  receiveSelection(ctx: SelectionContext): void {
+    this.pendingSelection = ctx;
+    this.deps.post({ type: 'selectionContext', context: ctx });
+  }
+
   // -------------------------------------------------------------------------
   // Message dispatch
   // -------------------------------------------------------------------------
@@ -189,6 +203,10 @@ export class SessionCore {
         return;
       case 'cancelResponse':
         this.abort?.abort();
+        return;
+      case 'clearSelection':
+        this.pendingSelection = null;
+        this.deps.post({ type: 'selectionContext', context: null });
         return;
       case 'editMessage':
         await this.onEditMessage(msg.nodeId, msg.text);
@@ -369,13 +387,26 @@ export class SessionCore {
     const atts = attachments ?? [];
     if (!trimmed && atts.length === 0) return;
 
+    // A pinned "Edit Selection" region applies to exactly one turn. Consume it
+    // now so a follow-up prompt without a fresh selection is unscoped.
+    const selection = this.pendingSelection;
+    this.pendingSelection = null;
+
     // Text-like files are inlined into the prompt so they persist in the tree
     // and replay on branch/resume; images are passed as image wire parts for
     // this turn (there is no image content block to persist them in).
     const images = atts.filter((a) => a.mimeType.startsWith('image/'));
     const textFiles = atts.filter((a) => !a.mimeType.startsWith('image/'));
 
+    // Prepend the highlighted region as a pinned context block (mirrors the
+    // attachment-inlining style) so it folds into the user node's text and
+    // naturally persists / replays on branch or resume.
     let displayText = trimmed;
+    if (selection) {
+      const fence = selection.languageId || selection.path;
+      const header = `The user highlighted lines ${selection.startLine}–${selection.endLine} of \`${selection.path}\`. Scope the change to this selection unless related code must change too.`;
+      displayText = `${header}\n\n\`\`\`${fence}\n${selection.text}\n\`\`\`\n\n${displayText}`;
+    }
     for (const f of textFiles) {
       displayText += `\n\n\`\`\`${f.name}\n${f.data}\n\`\`\``;
     }
@@ -387,6 +418,9 @@ export class SessionCore {
       type: 'image',
       image: { mimeType: a.mimeType, data: a.data },
     }));
+
+    // The selection has been folded into this turn's prompt — clear the chip.
+    if (selection) this.deps.post({ type: 'selectionContext', context: null });
 
     const { conv, nodeId } = appendUser(this.conv, [{ type: 'text', text: displayText || '(see attachments)' }]);
     this.conv = conv;

--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -344,6 +344,9 @@ export class SessionCore {
     }
     this.sendConversation();
     if (!this.overlay.isEmpty()) this.sendChangeset();
+    // A selection delivered before the webview mounted (freshly opened tab) had
+    // its chip message dropped; re-surface it now that the webview is listening.
+    if (this.pendingSelection) this.deps.post({ type: 'selectionContext', context: this.pendingSelection });
   }
 
   private async ensureSettings(): Promise<FowlPlaySettings> {
@@ -416,12 +419,12 @@ export class SessionCore {
     // naturally persists / replays on branch or resume.
     let displayText = trimmed;
     if (selection) {
-      const fence = selection.languageId || selection.path;
+      const label = selection.languageId || selection.path;
       const header = `The user highlighted lines ${selection.startLine}–${selection.endLine} of \`${selection.path}\`. Scope the change to this selection unless related code must change too.`;
-      displayText = `${header}\n\n\`\`\`${fence}\n${selection.text}\n\`\`\`\n\n${displayText}`;
+      displayText = `${header}\n\n${fencedBlock(label, selection.text)}\n\n${displayText}`;
     }
     for (const f of textFiles) {
-      displayText += `\n\n\`\`\`${f.name}\n${f.data}\n\`\`\``;
+      displayText += `\n\n${fencedBlock(f.name, f.data)}`;
     }
     for (const img of images) {
       displayText += `\n\n_[Attached image: ${img.name}]_`;
@@ -1190,6 +1193,19 @@ function addUsage(a: TokenUsage, b: TokenUsage): TokenUsage {
 function firstText(blocks: ContentBlock[]): string | null {
   for (const b of blocks) if (b.type === 'text' && b.text.trim()) return b.text;
   return null;
+}
+
+/**
+ * Wrap arbitrary content in a fenced code block whose backtick run is longer
+ * than any run inside the content, so selected text or a file that itself
+ * contains ``` cannot break out of the fence (which would corrupt the pinned
+ * context / open a prompt-injection seam).
+ */
+function fencedBlock(info: string, content: string): string {
+  let longest = 0;
+  for (const m of content.matchAll(/`+/g)) longest = Math.max(longest, m[0].length);
+  const fence = '`'.repeat(Math.max(3, longest + 1));
+  return `${fence}${info}\n${content}\n${fence}`;
 }
 
 function joinText(blocks: ContentBlock[]): string {

--- a/src/extension/tabManager.ts
+++ b/src/extension/tabManager.ts
@@ -10,7 +10,7 @@
 
 import * as vscode from 'vscode';
 import { randomBytes } from 'node:crypto';
-import type { Conversation, SerializedOverlay } from '../shared/types';
+import type { Conversation, SelectionContext, SerializedOverlay } from '../shared/types';
 import type { WebviewToHost } from '../shared/protocol';
 import { createSessionCore, type SessionCore, type SessionDeps } from './session';
 import { WorkspaceIo } from './workspaceIo';
@@ -90,6 +90,27 @@ export class TabManager {
       void session?.handle({ type: 'newConversation' });
     } else {
       this.openTab();
+    }
+  }
+
+  /**
+   * Deliver a highlighted editor region to a session as scoped context for its
+   * next change, targeting the active/most-recent panel (opening one if none).
+   */
+  editSelection(ctx: SelectionContext): void {
+    const active = [...this.panels].find((p) => p.active) ?? [...this.panels].pop();
+    if (active) {
+      active.reveal();
+      this.sessions.get(active)?.receiveSelection(ctx);
+      return;
+    }
+    const panel = this.openTab();
+    panel.reveal();
+    const session = this.sessions.get(panel);
+    // A freshly created webview may not have subscribed yet and would drop the
+    // chip message; re-deliver a few times. receiveSelection is idempotent.
+    for (const delay of [0, 600, 1500]) {
+      setTimeout(() => session?.receiveSelection(ctx), delay);
     }
   }
 

--- a/src/extension/tabManager.ts
+++ b/src/extension/tabManager.ts
@@ -106,12 +106,12 @@ export class TabManager {
     }
     const panel = this.openTab();
     panel.reveal();
-    const session = this.sessions.get(panel);
-    // A freshly created webview may not have subscribed yet and would drop the
-    // chip message; re-deliver a few times. receiveSelection is idempotent.
-    for (const delay of [0, 600, 1500]) {
-      setTimeout(() => session?.receiveSelection(ctx), delay);
-    }
+    // The session stores the selection immediately; the chip message it posts is
+    // dropped because the new webview hasn't subscribed yet, but the session
+    // re-surfaces the pending selection on the webview's `ready` handshake. No
+    // timer retry — that could re-arm a selection the user already sent or
+    // dismissed in the interim.
+    this.sessions.get(panel)?.receiveSelection(ctx);
   }
 
   /** Reset providers + keys + workspace settings (history is preserved). */

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -15,6 +15,7 @@ import type {
   ModelRef,
   ProviderConfig,
   RebaseState,
+  SelectionContext,
   StreamEvent,
   TokenUsage,
 } from './types';
@@ -29,6 +30,7 @@ export type WebviewToHost =
   // chat
   | { type: 'sendPrompt'; text: string; attachments?: Attachment[] }
   | { type: 'cancelResponse' }
+  | { type: 'clearSelection' }                                    // dismiss the pinned selection chip
   | { type: 'editMessage'; nodeId: string; text: string }        // branches
   | { type: 'rerunMessage'; nodeId: string }                      // sibling response
   | { type: 'rewindTo'; nodeId: string }
@@ -81,6 +83,7 @@ export type HostToWebview =
   | { type: 'stream'; event: StreamEvent }
   | { type: 'gateUpdate'; card: GateCard }
   | { type: 'turnStarted'; nodeId: string }                       // assistant node created
+  | { type: 'selectionContext'; context: SelectionContext | null } // scoped editor selection (null clears the chip)
   | { type: 'turnFinished'; nodeId: string; usage: TokenUsage }
   // diff review
   | { type: 'changeset'; view: ChangeSetView | null }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -221,6 +221,26 @@ export interface HarnessSettings {
 }
 
 // ---------------------------------------------------------------------------
+// Skills (model-invoked, lazy-loaded instruction docs)
+// ---------------------------------------------------------------------------
+
+/**
+ * A skill's catalog entry — name + one-line description. This is what is listed
+ * in a system prompt so the model can decide, cheaply, whether to load a skill's
+ * full instructions via the `load_skill` tool. Bodies are NOT included here (that
+ * is the whole point — skills stay out of context until explicitly loaded).
+ */
+export interface SkillMeta {
+  name: string;
+  description: string;
+}
+
+/** A full skill: its catalog metadata plus the markdown instructions to inject on load. */
+export interface Skill extends SkillMeta {
+  body: string;
+}
+
+// ---------------------------------------------------------------------------
 // Agent tools (model-facing)
 // ---------------------------------------------------------------------------
 
@@ -271,4 +291,10 @@ export interface FowlPlaySettings {
   harness: HarnessSettings;
   providers: ProviderConfig[]; // keys stored separately in SecretStorage
   defaultModel: ModelRef | null;
+  /**
+   * Skills discovered for the active workspace (bundled defaults + `.fowlplay/skills/*.md`),
+   * attached by the host when it posts settings so the UI can show what is available.
+   * Not persisted — recomputed on demand.
+   */
+  skills?: SkillMeta[];
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -35,6 +35,19 @@ export interface ModelRef {
   modelId: string;
 }
 
+/**
+ * A region the user highlighted in the editor, passed to a session as scoped
+ * context for the next change ("Edit Selection"). Line numbers are 1-based and
+ * inclusive.
+ */
+export interface SelectionContext {
+  path: string;               // workspace-relative
+  startLine: number;
+  endLine: number;
+  text: string;
+  languageId?: string;
+}
+
 export interface TokenUsage {
   inputTokens: number;
   outputTokens: number;

--- a/src/webview/components/Composer.tsx
+++ b/src/webview/components/Composer.tsx
@@ -1,12 +1,13 @@
 /** Auto-growing composer with attachments, send / stop. */
 import { useRef, useState } from 'preact/hooks';
 import type { Attachment } from '../../shared/protocol';
-import { post } from './store';
+import { post, useStore } from './store';
 import { IconPaperclip, IconArrowUp, IconStop, IconX } from './icons';
 
 export function Composer({ streaming }: { streaming: boolean }) {
   const [text, setText] = useState('');
   const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const selection = useStore((s) => s.selectionContext);
   const taRef = useRef<HTMLTextAreaElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
 
@@ -60,6 +61,16 @@ export function Composer({ streaming }: { streaming: boolean }) {
 
   return (
     <div class="fp-composer-wrap">
+      {selection && (
+        <div class="fp-attachments">
+          <span class="fp-attach-chip fp-selection-chip" title={`${selection.path}:${selection.startLine}-${selection.endLine}`}>
+            ⌗ {(selection.path.split('/').pop() || selection.path)}:{selection.startLine}-{selection.endLine}
+            <button type="button" class="fp-btn-ghost" style={{ padding: 0 }} onClick={() => post({ type: 'clearSelection' })} aria-label="Clear selection">
+              <IconX size={13} />
+            </button>
+          </span>
+        </div>
+      )}
       {attachments.length > 0 && (
         <div class="fp-attachments">
           {attachments.map((a, i) => (

--- a/src/webview/components/Settings.tsx
+++ b/src/webview/components/Settings.tsx
@@ -186,6 +186,31 @@ function HarnessTab({ settings }: { settings: FowlPlaySettings | null }) {
           ))}
         </div>
       </div>
+
+      <SkillsSection settings={settings} />
     </>
+  );
+}
+
+function SkillsSection({ settings }: { settings: FowlPlaySettings | null }) {
+  const skills = settings?.skills ?? [];
+  return (
+    <div class="fp-section">
+      <h2>Skills</h2>
+      <div class="fp-section-desc">
+        Reusable instruction docs the model loads on demand (Solo and Builder). Add your own as
+        {' '}<code>.fowlplay/skills/*.md</code> — they override bundled skills of the same name.
+      </div>
+      {skills.length === 0 ? (
+        <div class="fp-empty">No skills discovered.</div>
+      ) : (
+        skills.map((s) => (
+          <div class="fp-provider-row" key={s.name}>
+            <span class="fp-provider-name">{s.name}</span>
+            <span style={{ color: 'var(--fp-fg-muted)', fontSize: 12 }}>{s.description}</span>
+          </div>
+        ))
+      )}
+    </div>
   );
 }

--- a/src/webview/components/store.tsx
+++ b/src/webview/components/store.tsx
@@ -12,6 +12,7 @@ import type {
   FowlPlaySettings,
   MessageNode,
   ContentBlock,
+  SelectionContext,
   TokenUsage,
   ToolCallRecord,
 } from '../../shared/types';
@@ -32,6 +33,7 @@ export interface AppState {
   conversation: Conversation | null;
   streaming: boolean;
   streamNodeId: string | null;
+  selectionContext: SelectionContext | null;
   changeset: ChangeSetView | null;
   diffReadOnly: boolean;
   rebase: RebaseState;
@@ -51,6 +53,7 @@ const initialState: AppState = {
   conversation: null,
   streaming: false,
   streamNodeId: null,
+  selectionContext: null,
   changeset: null,
   diffReadOnly: false,
   rebase: { needed: false, conflictedPaths: [] },
@@ -119,6 +122,9 @@ class Store {
         break;
       case 'turnStarted':
         this.beginTurn(msg.nodeId);
+        break;
+      case 'selectionContext':
+        this.patch({ selectionContext: msg.context });
         break;
       case 'stream':
         this.applyStream(msg.event);

--- a/src/webview/theme.css
+++ b/src/webview/theme.css
@@ -414,6 +414,7 @@ a:hover { text-decoration: underline; }
 }
 .fp-attachments { display: flex; flex-wrap: wrap; gap: 6px; padding: 0 24px 4px; max-width: 820px; margin: 0 auto; }
 .fp-attach-chip { display: inline-flex; align-items: center; gap: 6px; padding: 3px 8px; border-radius: var(--fp-radius-sm); background: var(--fp-bg-sunken); border: 1px solid var(--fp-border); font-size: calc(12px * var(--fp-scale)); }
+.fp-selection-chip { color: var(--fp-accent); border-color: var(--fp-accent); background: rgba(65, 102, 245, 0.08); font-family: var(--fp-font); }
 .fp-send-btn {
   width: 36px; height: 36px; border-radius: 50%; flex-shrink: 0;
   background: var(--fp-gradient); color: #fff; display: flex; align-items: center; justify-content: center;

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -127,6 +127,58 @@ describe('tools', () => {
   });
 });
 
+// --- load_skill ------------------------------------------------------------
+
+describe('load_skill tool', () => {
+  const metas = [
+    { name: 'commit-message', description: 'write a commit message' },
+    { name: 'test-writing', description: 'write tests' },
+  ];
+
+  function skillHost(bodies: Record<string, string>): ToolHost {
+    return {
+      ...makeHost({}),
+      skills: metas,
+      async loadSkill(name: string) {
+        return name in bodies ? bodies[name] : null;
+      },
+    };
+  }
+
+  it('is omitted from the toolset when no skills exist (backward-compatible)', () => {
+    expect(buildToolSpecs().map((t) => t.name)).not.toContain('load_skill');
+    expect(buildToolSpecs({}).map((t) => t.name)).not.toContain('load_skill');
+    expect(buildToolSpecs({ skills: [] }).map((t) => t.name)).not.toContain('load_skill');
+  });
+
+  it('is appended (with skill names in its description) when skills exist', () => {
+    const specs = buildToolSpecs({ skills: metas });
+    const loadSkill = specs.find((t) => t.name === 'load_skill');
+    expect(loadSkill).toBeDefined();
+    expect(loadSkill!.description).toContain('commit-message');
+    expect(loadSkill!.description).toContain('test-writing');
+    // The base toolset is otherwise untouched.
+    expect(specs.slice(0, 5).map((t) => t.name)).toEqual(['open_files', 'list_dir', 'glob', 'grep', 'edit_files']);
+  });
+
+  it('dispatch returns the skill body', async () => {
+    const host = skillHost({ 'commit-message': 'BODY: how to write a commit' });
+    const res = await dispatchToolCall(host, 'load_skill', { name: 'commit-message' });
+    expect(res.ok).toBe(true);
+    expect(res.content).toBe('BODY: how to write a commit');
+    expect(res.gcClass).toBe('other');
+  });
+
+  it('dispatch reports an unknown skill and lists available names', async () => {
+    const host = skillHost({ 'commit-message': 'x' });
+    const res = await dispatchToolCall(host, 'load_skill', { name: 'nope' });
+    expect(res.ok).toBe(false);
+    expect(res.content).toContain('unknown skill: nope');
+    expect(res.content).toContain('commit-message');
+    expect(res.content).toContain('test-writing');
+  });
+});
+
 // --- loop.ts ---------------------------------------------------------------
 
 /** Adapter that replays a scripted list of events per chat() call. */

--- a/test/extension-session.test.ts
+++ b/test/extension-session.test.ts
@@ -360,6 +360,42 @@ describe('edit selection context', () => {
     expect(userText).not.toContain('a.ts');
     expect(userText).not.toContain('noop();');
   });
+
+  it('fences a selection that itself contains ``` without breaking out', async () => {
+    const { session, requests } = makeSession({ path: 'foo.txt', content: 'x\n' });
+    await session.handle({ type: 'ready' });
+
+    // A markdown selection containing its own fenced block.
+    const md = 'Example:\n```ts\nconst x = 1;\n```\nEnd.';
+    session.receiveSelection({ path: 'README.md', startLine: 1, endLine: 5, text: md, languageId: 'markdown' });
+
+    const idx = requests.length;
+    await session.handle({ type: 'sendPrompt', text: 'tighten this doc' });
+    const text = userWireText(requests[idx]);
+    // The outer fence must be longer than the inner ``` so the selection is
+    // fully enclosed and the user's request stays outside the quoted block.
+    expect(text).toContain('````'); // >=4 backticks chosen for the wrapper
+    expect(text).toContain('const x = 1;');
+    expect(text).toContain('tighten this doc');
+    // The wrapper fence encloses the inner block: the segment between the first
+    // and last 4-backtick runs contains the inner triple-fence and the text.
+    const first = text.indexOf('````');
+    const last = text.lastIndexOf('````');
+    expect(last).toBeGreaterThan(first);
+    expect(text.slice(first, last)).toContain('```ts');
+  });
+
+  it('re-surfaces a selection delivered before the webview mounted, on ready', async () => {
+    const { session, posted } = makeSession({ path: 'foo.txt', content: 'x\n' });
+    // Selection arrives BEFORE ready (freshly opened tab); the initial chip post
+    // may be dropped by the not-yet-subscribed webview.
+    session.receiveSelection({ path: 'a.ts', startLine: 1, endLine: 2, text: 'noop();', languageId: 'typescript' });
+    const before = posted.filter((m) => m.type === 'selectionContext' && m.context?.path === 'a.ts').length;
+    await session.handle({ type: 'ready' });
+    const after = posted.filter((m) => m.type === 'selectionContext' && m.context?.path === 'a.ts').length;
+    // ready re-posts the pending chip so it isn't lost.
+    expect(after).toBeGreaterThan(before);
+  });
 });
 
 describe('diff review — toggleRevert then sendFeedback', () => {

--- a/test/extension-session.test.ts
+++ b/test/extension-session.test.ts
@@ -223,6 +223,20 @@ function assistantLeaf(conv: Conversation) {
   return conv.currentLeafId ? conv.nodes[conv.currentLeafId] : undefined;
 }
 
+/** Concatenated text of the last user message in a wire request. */
+function userWireText(req: ChatRequest): string {
+  for (let i = req.messages.length - 1; i >= 0; i--) {
+    const m = req.messages[i];
+    if (m.role === 'user') {
+      return m.content
+        .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+        .map((p) => p.text)
+        .join('\n');
+    }
+  }
+  return '';
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -291,6 +305,60 @@ describe('solo prompt turn', () => {
         ),
     );
     expect(userVisibleEarly).toBe(true);
+  });
+});
+
+describe('edit selection context', () => {
+  it('prepends the highlighted region to the prompt once, then does not leak into later turns', async () => {
+    const { session, posted, requests } = makeSession({ path: 'foo.txt', content: 'x\n' });
+    await session.handle({ type: 'ready' });
+
+    session.receiveSelection({
+      path: 'src/auth/login.ts',
+      startLine: 10,
+      endLine: 14,
+      text: 'const token = res.data.token;',
+      languageId: 'typescript',
+    });
+    // receiveSelection surfaces the chip to the webview.
+    expect(posted.some((m) => m.type === 'selectionContext' && m.context?.path === 'src/auth/login.ts')).toBe(true);
+
+    const firstReqIdx = requests.length;
+    await session.handle({ type: 'sendPrompt', text: 'rename token to session' });
+
+    const firstUserText = userWireText(requests[firstReqIdx]);
+    expect(firstUserText).toContain('src/auth/login.ts');       // file path
+    expect(firstUserText).toContain('10');                       // start line
+    expect(firstUserText).toContain('14');                       // end line
+    expect(firstUserText).toContain('const token = res.data.token;'); // selected text
+    expect(firstUserText).toContain('rename token to session');  // the user's request
+
+    // The host clears the chip after consuming the selection.
+    const clears = posted.filter((m) => m.type === 'selectionContext' && m.context === null);
+    expect(clears.length).toBeGreaterThan(0);
+
+    // A follow-up prompt WITHOUT a new selection must not carry stale context.
+    const secondReqIdx = requests.length;
+    await session.handle({ type: 'sendPrompt', text: 'now add a test' });
+    const secondUserText = userWireText(requests[secondReqIdx]);
+    expect(secondUserText).toContain('now add a test');
+    expect(secondUserText).not.toContain('src/auth/login.ts');
+    expect(secondUserText).not.toContain('const token = res.data.token;');
+  });
+
+  it('clearSelection drops the pending selection and posts a null chip', async () => {
+    const { session, posted, requests } = makeSession({ path: 'foo.txt', content: 'x\n' });
+    await session.handle({ type: 'ready' });
+
+    session.receiveSelection({ path: 'a.ts', startLine: 1, endLine: 2, text: 'noop();', languageId: 'typescript' });
+    await session.handle({ type: 'clearSelection' });
+    expect(posted.some((m) => m.type === 'selectionContext' && m.context === null)).toBe(true);
+
+    const reqIdx = requests.length;
+    await session.handle({ type: 'sendPrompt', text: 'do the thing' });
+    const userText = userWireText(requests[reqIdx]);
+    expect(userText).not.toContain('a.ts');
+    expect(userText).not.toContain('noop();');
   });
 });
 

--- a/test/extension-session.test.ts
+++ b/test/extension-session.test.ts
@@ -487,6 +487,79 @@ describe('View Changes on historical commits', () => {
   });
 });
 
+describe('skills', () => {
+  it('injects the skill catalog into the solo system prompt and offers load_skill', async () => {
+    const { session, io, requests } = makeSession({ path: 'foo.txt', content: 'x\n' });
+    io.files.set('.fowlplay/skills/foo.md', '---\nname: foo-skill\ndescription: does foo things\n---\n\n# Foo\n\nBody of foo.');
+    await session.handle({ type: 'ready' });
+
+    const reqIdx = requests.length;
+    await session.handle({ type: 'sendPrompt', text: 'create foo.txt' });
+
+    // The opening request's system prompt carries the catalog (bundled + workspace).
+    const sys = requests[reqIdx].system;
+    expect(sys).toContain('AVAILABLE SKILLS');
+    expect(sys).toContain('foo-skill');
+    expect(sys).toContain('does foo things');
+    expect(sys).toContain('commit-message'); // a bundled default is present too
+
+    // load_skill is offered as a tool when skills exist.
+    expect(requests[reqIdx].tools.map((t) => t.name)).toContain('load_skill');
+  });
+
+  it('a load_skill tool call returns the skill body to the model', async () => {
+    const io = new FakeIo();
+    io.files.set('.fowlplay/skills/foo.md', '---\nname: foo-skill\ndescription: does foo\n---\n\nBODY-OF-FOO-SKILL');
+    const posted: HostToWebview[] = [];
+    const requests: ChatRequest[] = [];
+    // Round 1: call load_skill. Round 2 (after the tool result arrives): finish.
+    const adapter: ProviderAdapter = {
+      chat(request: ChatRequest) {
+        requests.push(request);
+        const hasToolResult = request.messages.some((m) => m.role === 'tool');
+        const events: StreamEvent[] = hasToolResult
+          ? textEvents('done')
+          : [
+              { type: 'tool_call_start', id: 's1', name: 'load_skill' },
+              { type: 'tool_call_args', id: 's1', delta: JSON.stringify({ name: 'foo-skill' }) },
+              { type: 'tool_call_end', id: 's1' },
+              USAGE,
+              { type: 'done', stopReason: 'tool_use' },
+            ];
+        return (async function* () {
+          for (const e of events) yield e;
+        })();
+      },
+    };
+    const deps: SessionDeps = {
+      io,
+      secrets: new FakeSecrets(),
+      settings: new FakeSettings('solo'),
+      history: new FakeHistory(),
+      git: fakeGit,
+      post: (m) => posted.push(m),
+      createAdapter: () => adapter,
+      fetchModels: async () => [{ id: 'm1' }],
+      clock: () => Date.now(),
+    };
+    const session = createSessionCore(deps);
+
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'use the foo skill' });
+
+    // The continuation request carries the tool result with the skill body.
+    const continuation = requests.find((r) => r.messages.some((m) => m.role === 'tool'));
+    expect(continuation).toBeDefined();
+    const toolMsg = continuation!.messages.find((m) => m.role === 'tool');
+    const content = toolMsg && toolMsg.role === 'tool' ? toolMsg.results.map((r) => r.content).join('\n') : '';
+    expect(content).toContain('BODY-OF-FOO-SKILL');
+
+    // The tool call was surfaced to the UI and reported ok.
+    const toolStream = posted.some((m) => m.type === 'stream' && m.event.type === 'tool_call_start');
+    expect(toolStream).toBe(true);
+  });
+});
+
 describe('coop pipeline', () => {
   it('emits gate cards in Scout → Gate → Builder → Inspector → Sentry → HITL order', async () => {
     const { session, posted } = makeSession({ mode: 'coop', path: 'foo.txt', content: 'x\n' });

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Skills registry tests — parsing (frontmatter / heading / filename fallbacks,
+ * description extraction) and catalog formatting.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  BUNDLED_SKILLS,
+  formatSkillCatalog,
+  parseSkill,
+} from '../src/core/agent/skills';
+
+describe('parseSkill', () => {
+  it('reads name + description from YAML frontmatter and strips it from the body', () => {
+    const raw = `---
+name: commit-message
+description: Write a good commit message.
+---
+
+# Heading in body
+
+Do the thing.`;
+    const skill = parseSkill('whatever.md', raw);
+    expect(skill.name).toBe('commit-message');
+    expect(skill.description).toBe('Write a good commit message.');
+    expect(skill.body.startsWith('# Heading in body')).toBe(true);
+    expect(skill.body).not.toContain('name:');
+  });
+
+  it('de-quotes frontmatter values', () => {
+    const raw = `---
+name: "quoted-name"
+description: 'single quoted'
+---
+body`;
+    const skill = parseSkill('f.md', raw);
+    expect(skill.name).toBe('quoted-name');
+    expect(skill.description).toBe('single quoted');
+  });
+
+  it('falls back to the first heading for the name when no frontmatter', () => {
+    const raw = `# My Skill Title
+
+Some intro line describing it.`;
+    const skill = parseSkill('some-file.md', raw);
+    expect(skill.name).toBe('My Skill Title');
+    // Description comes from the first non-heading, non-empty line.
+    expect(skill.description).toBe('Some intro line describing it.');
+  });
+
+  it('falls back to the filename (sans path + .md) when there is no heading', () => {
+    const skill = parseSkill('src/skills/my-cool-skill.md', 'just prose, no heading here');
+    expect(skill.name).toBe('my-cool-skill');
+    expect(skill.description).toBe('just prose, no heading here');
+  });
+
+  it('extracts the description from the first non-heading line, skipping headings', () => {
+    const raw = `# Title
+## Subtitle
+
+The real description sentence.`;
+    const skill = parseSkill('x.md', raw);
+    expect(skill.name).toBe('Title');
+    expect(skill.description).toBe('The real description sentence.');
+  });
+
+  it('tolerates an empty description', () => {
+    const skill = parseSkill('empty.md', '# Only A Heading');
+    expect(skill.name).toBe('Only A Heading');
+    expect(skill.description).toBe('');
+  });
+});
+
+describe('formatSkillCatalog', () => {
+  it('returns an empty string when there are no skills', () => {
+    expect(formatSkillCatalog([])).toBe('');
+  });
+
+  it('lists each skill and instructs the model to call load_skill', () => {
+    const out = formatSkillCatalog([
+      { name: 'a', description: 'does a' },
+      { name: 'b', description: 'does b' },
+    ]);
+    expect(out).toContain('load_skill');
+    expect(out).toContain('- a: does a');
+    expect(out).toContain('- b: does b');
+  });
+});
+
+describe('bundled skills', () => {
+  it('ship at least commit-message and test-writing, each with a description and body', () => {
+    const names = BUNDLED_SKILLS.map((s) => s.name);
+    expect(names).toContain('commit-message');
+    expect(names).toContain('test-writing');
+    for (const s of BUNDLED_SKILLS) {
+      expect(s.description.length).toBeGreaterThan(0);
+      expect(s.body.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two features, built with Opus, reviewed by Sonnet 5, adjudicated by Fable.

**Edit Selection** — right-click a highlighted region (or `Ctrl/Cmd+Alt+E`) → "FowlPlay: Edit Selection". Captures the active editor's file, 1-based line range, text, and languageId, pins it to the active tab as a dismissible chip, and folds it into the next prompt as a scoped context block, consumed exactly once. Works for code and Markdown.

**Skills** — opt-in, lazy, model-invoked markdown instruction docs (`.fowlplay/skills/*.md` + bundled `commit-message` / `test-writing` defaults). Only a name+description catalog is injected into the Solo system prompt and the Coop Builder; the full body loads on demand via a new `load_skill` tool, preserving the context-GC philosophy. `buildToolSpecs` stays backward-compatible.

## Review

Sonnet 5 code review of the combined diff surfaced one HIGH and three lower findings; all fixed with regression tests:
- **Race (HIGH)**: removed a `setTimeout` retry that could re-arm a consumed/dismissed selection; the session now re-surfaces a pending selection on the webview `ready` handshake instead.
- **Fence injection**: selection/attachment text is now wrapped in a backtick run longer than any inside it, so a Markdown selection containing a code fence can't break out of the pinned-context block.
- **Path privacy**: basename fallback when the file is outside the workspace (no absolute home-dir path leaked to the model).
- **endLine** off-by-one for whole-line selections.

## Testing

- 131 unit tests + 54 Playwright checks green; typecheck + build clean; packages to a `.vsix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2kQhmZ4jQUgwkcLm1rGrW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2kQhmZ4jQUgwkcLm1rGrW)_