### PR TITLE
Slash commands, context-window surfacing, markdown rendering fixes

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -135,6 +135,31 @@ Open FowlPlay any time with **Ctrl/Cmd+Alt+F**, the phoenix icon in the activity
 - **Status line** (bottom) — the **model switcher** (click the model name to swap
   provider/model mid-conversation), the **Solo/Coop** toggle, and live token usage.
 
+### Slash commands
+
+Type **`/`** as the first character in the composer to open a command menu — most of
+the status-line and title-bar actions, without leaving the keyboard. Keep typing to
+filter (by name or description); **↑/↓** move the highlight, **Enter** or **Tab** runs the
+highlighted command, **Esc** closes the menu, and a click runs a command directly. If what
+you typed isn't a command, just press **Enter** to send it as an ordinary prompt.
+
+| Command | What it does |
+|---|---|
+| `/clear` (`/new`) | Start a new conversation |
+| `/model` | Switch the active model (opens a provider/model picker) |
+| `/solo` | Switch to Solo (direct single-agent) mode |
+| `/coop` | Switch to Coop (cooperative pipeline) mode |
+| `/diff` (`/review`) | Review the staged changes |
+| `/fork` | Fork this conversation into a new tab |
+| `/export` | Copy the conversation as Markdown or JSON |
+| `/settings` | Open settings |
+| `/history` | Browse past conversations |
+| `/status` | Show a session-status card (model, mode, context usage, token totals) |
+| `/skills` | Pick a discovered skill; the composer is pre-filled so you can add details before sending |
+
+`/model`, `/export`, and `/skills` open a second-level list in the same popup — keep typing
+to filter it, or press **Esc** to step back to the command list.
+
 ---
 
 ## 6. Making your first change
@@ -260,6 +285,7 @@ Open settings from the gear in the title bar. Three tabs:
 | Open FowlPlay tab | `Ctrl/Cmd+Alt+F` |
 | Send message | `Enter` |
 | New line | `Shift+Enter` |
+| Open slash-command menu | `/` (as the first character) |
 | Cancel response | `Escape` |
 | Next / previous change (diff) | `j` / `k` or `↓` / `↑` |
 | Save inline comment | `Enter` |

--- a/e2e/mockBridge.js
+++ b/e2e/mockBridge.js
@@ -379,7 +379,7 @@
         break;
       case 'settings':
         emit(settings(true));
-        emit({ type: 'modelsFetched', providerId: 'prov-ollama', models: [{ id: 'qwen2.5-coder:32b' }, { id: 'llama3.1:8b' }, { id: 'deepseek-r1:14b' }] });
+        emit({ type: 'modelsFetched', providerId: 'prov-ollama', models: [{ id: 'qwen2.5-coder:32b', contextWindow: 32768 }, { id: 'llama3.1:8b', contextWindow: 131072 }, { id: 'deepseek-r1:14b' }] });
         setView('settings');
         break;
       case 'onboarding':

--- a/src/core/providers/registry.ts
+++ b/src/core/providers/registry.ts
@@ -105,19 +105,36 @@ export const PRESETS: ProviderPreset[] = [
   },
 ];
 
+/** A model as surfaced by `fetchModels`: its id plus context window if known. */
+export interface FetchedModel {
+  id: string;
+  contextWindow?: number;
+}
+
 /** Just enough of a provider config to fetch its model list. */
-export type FetchModelsConfig = Pick<ProviderConfig, 'sdkType' | 'baseUrl'>;
+export type FetchModelsConfig = Pick<ProviderConfig, 'sdkType' | 'baseUrl'> & {
+  /** Provider kind; when 'local' we run best-effort local context-window enrichment. */
+  kind?: ProviderConfig['kind'];
+};
+
+/** Best-effort local probes get a short deadline so they never stall the list. */
+const LOCAL_PROBE_TIMEOUT_MS = 1500;
+/** Ollama needs one /api/show call per model; cap it so a big list stays cheap. */
+const OLLAMA_SHOW_LIMIT = 16;
 
 /**
  * List available models for a provider.
  * - openai-completions: GET {baseUrl}/models, Bearer auth if a key is given.
  * - anthropic:          GET {baseUrl}/v1/models (no double /v1), x-api-key auth.
- * Returns `{ id }[]` sorted by id. Throws with a useful message on failure.
+ * Returns `{ id, contextWindow? }[]` sorted by id. Throws with a useful message
+ * on failure. For local providers (kind==='local' or a localhost baseUrl) it
+ * then runs best-effort probes to enrich each model's context window; those
+ * probes never break or meaningfully slow the primary list.
  */
 export async function fetchModels(
   config: FetchModelsConfig,
   apiKey?: string,
-): Promise<{ id: string }[]> {
+): Promise<FetchedModel[]> {
   const { url, headers } = modelsRequest(config, apiKey);
 
   let res: Response;
@@ -152,13 +169,30 @@ export async function fetchModels(
     );
   }
 
-  const ids = extractModelIds(payload);
-  if (ids.length === 0) {
+  const models = extractModels(payload);
+  if (models.length === 0) {
     throw new Error(`Model list from ${url} contained no models`);
   }
-  return ids
-    .map((id) => ({ id }))
-    .sort((a, b) => a.id.localeCompare(b.id));
+  models.sort((a, b) => a.id.localeCompare(b.id));
+
+  // Local providers rarely advertise context length on /models — enrich from
+  // native endpoints. Strictly additive and best-effort: it only fills gaps and
+  // any failure (or the ~1.5s deadline) leaves the primary list untouched.
+  if (config.kind === 'local' || isLocalHost(config.baseUrl)) {
+    try {
+      const byId = await enrichLocalContext(config.baseUrl, models.map((m) => m.id));
+      for (const m of models) {
+        if (m.contextWindow === undefined) {
+          const ctx = byId.get(m.id);
+          if (typeof ctx === 'number' && ctx > 0) m.contextWindow = ctx;
+        }
+      }
+    } catch {
+      /* enrichment is best-effort — never let it break the primary list */
+    }
+  }
+
+  return models;
 }
 
 function modelsRequest(
@@ -181,17 +215,168 @@ function modelsRequest(
   return { url, headers };
 }
 
-/** Both OpenAI and Anthropic return `{ data: [{ id }] }`. Be lenient. */
-function extractModelIds(payload: unknown): string[] {
+/**
+ * Both OpenAI and Anthropic return `{ data: [{ id }] }`. Be lenient, and pick up
+ * a context length if the provider volunteers one under any of the common field
+ * names (OpenRouter: `context_length`; vLLM: `max_model_len`; others).
+ */
+function extractModels(payload: unknown): FetchedModel[] {
   if (typeof payload !== 'object' || payload === null) return [];
   const data = (payload as { data?: unknown }).data;
   if (!Array.isArray(data)) return [];
-  const ids: string[] = [];
+  const out: FetchedModel[] = [];
   for (const entry of data) {
     if (entry && typeof entry === 'object') {
       const id = (entry as { id?: unknown }).id;
-      if (typeof id === 'string' && id.length > 0) ids.push(id);
+      if (typeof id === 'string' && id.length > 0) {
+        const ctx = readContextLength(entry as Record<string, unknown>, [
+          'context_length',
+          'context_window',
+          'max_context_length',
+          'max_model_len',
+        ]);
+        out.push(ctx !== undefined ? { id, contextWindow: ctx } : { id });
+      }
     }
   }
-  return ids;
+  return out;
+}
+
+/** First positive integer found among `keys` on `obj`, else undefined. */
+function readContextLength(obj: Record<string, unknown>, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const v = obj[key];
+    if (typeof v === 'number' && Number.isFinite(v) && v > 0) return Math.floor(v);
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Local context-window enrichment
+// ---------------------------------------------------------------------------
+
+/** Is this baseUrl pointed at the local machine? */
+function isLocalHost(baseUrl: string): boolean {
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    return host === 'localhost' || host === '127.0.0.1' || host === '0.0.0.0' || host === '[::1]';
+  } catch {
+    return false;
+  }
+}
+
+/** baseUrl minus a trailing `/v1` and any trailing slashes → the server origin. */
+function toOrigin(baseUrl: string): string {
+  return baseUrl
+    .replace(/\/+$/, '')
+    .replace(/\/v1$/, '')
+    .replace(/\/+$/, '');
+}
+
+/**
+ * Probe the local server's native endpoints (LM Studio, llama.cpp, Ollama)
+ * concurrently and merge their context-length findings by model id. Every probe
+ * is independently guarded, so a server that isn't running (or answers slowly)
+ * simply contributes nothing.
+ */
+async function enrichLocalContext(baseUrl: string, ids: string[]): Promise<Map<string, number>> {
+  const origin = toOrigin(baseUrl);
+  const merged = new Map<string, number>();
+
+  const results = await Promise.all([
+    probeLmStudio(origin).catch(() => new Map<string, number>()),
+    probeLlamaCpp(origin, ids).catch(() => new Map<string, number>()),
+    probeOllama(origin, ids).catch(() => new Map<string, number>()),
+  ]);
+
+  for (const src of results) {
+    for (const [id, ctx] of src) {
+      if (ctx > 0 && !merged.has(id)) merged.set(id, ctx);
+    }
+  }
+  return merged;
+}
+
+/** GET a JSON body with the local probe deadline; throws on non-2xx or timeout. */
+async function probeJson(url: string, init?: RequestInit): Promise<unknown> {
+  const res = await fetch(url, { ...init, signal: AbortSignal.timeout(LOCAL_PROBE_TIMEOUT_MS) });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
+/**
+ * LM Studio REST API: GET /api/v0/models → entries carry `max_context_length`
+ * and, when a model is loaded, `loaded_context_length`. Prefer the loaded value.
+ */
+async function probeLmStudio(origin: string): Promise<Map<string, number>> {
+  const payload = await probeJson(`${origin}/api/v0/models`);
+  const out = new Map<string, number>();
+  const data = Array.isArray(payload)
+    ? payload
+    : Array.isArray((payload as { data?: unknown })?.data)
+      ? (payload as { data: unknown[] }).data
+      : [];
+  for (const entry of data) {
+    if (entry && typeof entry === 'object') {
+      const rec = entry as Record<string, unknown>;
+      const id = rec.id;
+      if (typeof id !== 'string' || !id) continue;
+      const ctx = readContextLength(rec, ['loaded_context_length', 'max_context_length']);
+      if (ctx !== undefined) out.set(id, ctx);
+    }
+  }
+  return out;
+}
+
+/**
+ * llama.cpp server: GET /props → `default_generation_settings.n_ctx` is the
+ * context size of the single loaded model, so it applies to every listed id.
+ */
+async function probeLlamaCpp(origin: string, ids: string[]): Promise<Map<string, number>> {
+  const payload = await probeJson(`${origin}/props`);
+  const out = new Map<string, number>();
+  const settings = (payload as { default_generation_settings?: unknown })?.default_generation_settings;
+  if (settings && typeof settings === 'object') {
+    const ctx = readContextLength(settings as Record<string, unknown>, ['n_ctx']);
+    if (ctx !== undefined) for (const id of ids) out.set(id, ctx);
+  }
+  return out;
+}
+
+/**
+ * Ollama: POST /api/show {"model": id} per model (capped) → `model_info` holds a
+ * `<arch>.context_length` key (e.g. `llama.context_length`). This is the model's
+ * max; the running num_ctx may be smaller, so treat it as an upper bound.
+ */
+async function probeOllama(origin: string, ids: string[]): Promise<Map<string, number>> {
+  const out = new Map<string, number>();
+  const targets = ids.slice(0, OLLAMA_SHOW_LIMIT);
+  await Promise.all(
+    targets.map(async (id) => {
+      try {
+        const payload = await probeJson(`${origin}/api/show`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ model: id }),
+        });
+        const info = (payload as { model_info?: unknown })?.model_info;
+        if (info && typeof info === 'object') {
+          for (const [key, value] of Object.entries(info as Record<string, unknown>)) {
+            if (
+              key.endsWith('.context_length') &&
+              typeof value === 'number' &&
+              Number.isFinite(value) &&
+              value > 0
+            ) {
+              out.set(id, Math.floor(value));
+              break;
+            }
+          }
+        }
+      } catch {
+        /* this model's probe failed — skip it, others may still succeed */
+      }
+    }),
+  );
+  return out;
 }

--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -120,7 +120,7 @@ export interface SessionDeps {
   openTab?: (conv: Conversation, overlay: SerializedOverlay) => void;
   /** Injectable for tests; defaults to the real core factory. */
   createAdapter?: (sdk: SdkType) => ProviderAdapter;
-  fetchModels?: (cfg: FetchModelsConfig, apiKey?: string) => Promise<{ id: string }[]>;
+  fetchModels?: (cfg: FetchModelsConfig, apiKey?: string) => Promise<{ id: string; contextWindow?: number }[]>;
   clock?: () => number;
 }
 
@@ -144,7 +144,7 @@ const READONLY_TOOL_NAMES = new Set(['open_files', 'list_dir', 'glob', 'grep']);
 export class SessionCore {
   private readonly deps: SessionDeps;
   private readonly createAdapter: (sdk: SdkType) => ProviderAdapter;
-  private readonly fetchModels: (cfg: FetchModelsConfig, apiKey?: string) => Promise<{ id: string }[]>;
+  private readonly fetchModels: (cfg: FetchModelsConfig, apiKey?: string) => Promise<{ id: string; contextWindow?: number }[]>;
   private readonly clock: () => number;
 
   private conv: Conversation;
@@ -985,7 +985,10 @@ export class SessionCore {
     }
     try {
       const key = provider.requiresApiKey ? await this.deps.secrets.get(providerId) : undefined;
-      const models = await this.fetchModels({ sdkType: provider.sdkType, baseUrl: provider.baseUrl }, key);
+      const models = await this.fetchModels(
+        { sdkType: provider.sdkType, baseUrl: provider.baseUrl, kind: provider.kind },
+        key,
+      );
       this.deps.post({ type: 'modelsFetched', providerId, models });
     } catch (err) {
       this.deps.post({ type: 'modelsFetched', providerId, models: [], error: errMessage(err) });

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -95,7 +95,7 @@ export type HostToWebview =
   | { type: 'exported'; format: 'markdown' | 'json'; content: string }
   // settings & providers
   | { type: 'settings'; settings: FowlPlaySettings }
-  | { type: 'modelsFetched'; providerId: string; models: { id: string }[]; error?: string }
+  | { type: 'modelsFetched'; providerId: string; models: { id: string; contextWindow?: number }[]; error?: string }
   // misc
   | { type: 'showView'; view: 'chat' | 'diff' | 'settings' | 'history' }
   | { type: 'toast'; level: 'info' | 'warn' | 'error'; message: string };

--- a/src/webview/components/Composer.tsx
+++ b/src/webview/components/Composer.tsx
@@ -1,13 +1,46 @@
-/** Auto-growing composer with attachments, send / stop. */
+/** Auto-growing composer with attachments, slash commands, send / stop. */
 import { useRef, useState } from 'preact/hooks';
 import type { Attachment } from '../../shared/protocol';
-import { post, useStore } from './store';
+import type { Conversation, FowlPlaySettings, ModelRef, TokenUsage } from '../../shared/types';
+import { post, store, useStore } from './store';
+import { filterCommands, type SlashCommand } from '../slashCommands';
+import { SlashMenu, type SlashItem } from './SlashMenu';
 import { IconPaperclip, IconArrowUp, IconStop, IconX } from './icons';
+
+type MenuMode = 'closed' | 'commands' | 'model' | 'export' | 'skills';
+
+/** A rendered menu row plus the action to run when it is chosen. */
+interface MenuEntry extends SlashItem {
+  run: () => void;
+}
+
+function modelLabel(settings: FowlPlaySettings | null, ref: ModelRef | null): string {
+  if (!ref) return 'No model selected';
+  const p = settings?.providers.find((x) => x.id === ref.providerId);
+  const m = p?.models.find((x) => x.id === ref.modelId);
+  return m?.displayName || m?.id || ref.modelId;
+}
+
+function contextWindowFor(settings: FowlPlaySettings | null, ref: ModelRef | null): number | undefined {
+  if (!ref) return undefined;
+  const p = settings?.providers.find((x) => x.id === ref.providerId);
+  return p?.models.find((x) => x.id === ref.modelId)?.contextWindow;
+}
+
+function fmt(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k`;
+  return String(n);
+}
 
 export function Composer({ streaming }: { streaming: boolean }) {
   const [text, setText] = useState('');
   const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [menuMode, setMenuMode] = useState<MenuMode>('closed');
+  const [highlight, setHighlight] = useState(0);
+  const [showStatus, setShowStatus] = useState(false);
   const selection = useStore((s) => s.selectionContext);
+  const settings = useStore((s) => s.settings);
+  const conv = useStore((s) => s.conversation);
   const taRef = useRef<HTMLTextAreaElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
 
@@ -18,18 +51,232 @@ export function Composer({ streaming }: { streaming: boolean }) {
     ta.style.height = Math.min(220, ta.scrollHeight) + 'px';
   };
 
+  const resetHeight = () => {
+    requestAnimationFrame(() => {
+      if (taRef.current) taRef.current.style.height = 'auto';
+    });
+  };
+
   const send = () => {
     const t = text.trim();
     if (!t && attachments.length === 0) return;
     post({ type: 'sendPrompt', text: t, attachments: attachments.length ? attachments : undefined });
     setText('');
     setAttachments([]);
+    setMenuMode('closed');
+    resetHeight();
+  };
+
+  // -- slash-menu plumbing ----------------------------------------------------
+  const clearAndClose = () => {
+    setText('');
+    setMenuMode('closed');
+    setHighlight(0);
+    resetHeight();
+  };
+
+  const openSubmenu = (mode: Exclude<MenuMode, 'closed' | 'commands'>) => {
+    setText('');
+    setMenuMode(mode);
+    setHighlight(0);
+    resetHeight();
+  };
+
+  /** /skills: prefill the composer (do not send) and hand focus back. */
+  const prefillSkill = (name: string) => {
+    const prefill = `Use the "${name}" skill: `;
+    setText(prefill);
+    setMenuMode('closed');
+    setHighlight(0);
     requestAnimationFrame(() => {
-      if (taRef.current) taRef.current.style.height = 'auto';
+      const ta = taRef.current;
+      if (ta) {
+        ta.focus();
+        ta.setSelectionRange(prefill.length, prefill.length);
+        grow();
+      }
     });
   };
 
+  const runCommand = (cmd: SlashCommand) => {
+    switch (cmd.name) {
+      case 'clear':
+        post({ type: 'newConversation' });
+        store.setView('chat');
+        clearAndClose();
+        break;
+      case 'solo':
+        post({ type: 'setHarnessMode', mode: 'solo' });
+        clearAndClose();
+        break;
+      case 'coop':
+        post({ type: 'setHarnessMode', mode: 'coop' });
+        clearAndClose();
+        break;
+      case 'diff':
+        store.openReview();
+        clearAndClose();
+        break;
+      case 'fork':
+        post({ type: 'forkConversation' });
+        clearAndClose();
+        break;
+      case 'settings':
+        store.setView('settings');
+        post({ type: 'getSettings' });
+        clearAndClose();
+        break;
+      case 'history':
+        store.setView('history');
+        post({ type: 'listConversations' });
+        clearAndClose();
+        break;
+      case 'status':
+        setShowStatus(true);
+        clearAndClose();
+        break;
+      case 'model':
+        openSubmenu('model');
+        break;
+      case 'export':
+        openSubmenu('export');
+        break;
+      case 'skills':
+        openSubmenu('skills');
+        break;
+    }
+  };
+
+  // Build the current menu rows + their actions from state.
+  const buildMenu = (): MenuEntry[] => {
+    if (menuMode === 'commands') {
+      return filterCommands(text).map((cmd) => ({
+        row: { key: cmd.name, title: `/${cmd.name}`, description: cmd.description },
+        run: () => runCommand(cmd),
+      }));
+    }
+    const q = text.trim().toLowerCase();
+    if (menuMode === 'model') {
+      const providers = settings?.providers ?? [];
+      const out: MenuEntry[] = [];
+      for (const p of providers) {
+        let firstInGroup = true;
+        for (const m of p.models) {
+          const label = m.displayName || m.id;
+          if (q && !`${label} ${p.name}`.toLowerCase().includes(q)) continue;
+          const active = conv?.model?.providerId === p.id && conv?.model?.modelId === m.id;
+          out.push({
+            row: { key: `${p.id}::${m.id}`, title: label, active, groupLabel: firstInGroup ? p.name : undefined },
+            run: () => {
+              post({ type: 'setModel', model: { providerId: p.id, modelId: m.id } });
+              clearAndClose();
+            },
+          });
+          firstInGroup = false;
+        }
+      }
+      if (out.length === 0) {
+        out.push({
+          row: { key: 'none', title: providers.length ? 'No matching models' : 'No providers configured' },
+          disabled: true,
+          run: () => {},
+        });
+      }
+      return out;
+    }
+    if (menuMode === 'export') {
+      const opts = [
+        { key: 'markdown', title: 'Markdown', description: 'Copy the conversation as Markdown', format: 'markdown' as const },
+        { key: 'json', title: 'JSON', description: 'Copy the conversation as JSON', format: 'json' as const },
+      ].filter((o) => !q || `${o.title} ${o.description}`.toLowerCase().includes(q));
+      if (opts.length === 0) {
+        return [{ row: { key: 'none', title: 'No matching formats' }, disabled: true, run: () => {} }];
+      }
+      return opts.map((o) => ({
+        row: { key: o.key, title: o.title, description: o.description },
+        run: () => {
+          post({ type: 'exportConversation', format: o.format });
+          clearAndClose();
+        },
+      }));
+    }
+    if (menuMode === 'skills') {
+      const skills = settings?.skills ?? [];
+      if (skills.length === 0) {
+        return [{ row: { key: 'none', title: 'No skills discovered' }, disabled: true, run: () => {} }];
+      }
+      const filtered = skills.filter((s) => !q || `${s.name} ${s.description}`.toLowerCase().includes(q));
+      if (filtered.length === 0) {
+        return [{ row: { key: 'none', title: 'No matching skills' }, disabled: true, run: () => {} }];
+      }
+      return filtered.map((s) => ({
+        row: { key: s.name, title: s.name, description: s.description },
+        run: () => prefillSkill(s.name),
+      }));
+    }
+    return [];
+  };
+
+  const menu = buildMenu();
+  const menuActive = menuMode !== 'closed';
+  const menuVisible = menuActive && menu.length > 0;
+
+  const menuHeader =
+    menuMode === 'model'
+      ? 'Switch model — Esc to go back'
+      : menuMode === 'export'
+        ? 'Export as — Esc to go back'
+        : menuMode === 'skills'
+          ? 'Use a skill — Esc to go back'
+          : undefined;
+
+  const runHighlighted = () => {
+    const it = menu[Math.min(highlight, menu.length - 1)];
+    if (it && !it.disabled) it.run();
+  };
+
   const onKeyDown = (e: KeyboardEvent) => {
+    if (menuActive) {
+      if (e.key === 'ArrowDown' && menu.length) {
+        e.preventDefault();
+        setHighlight((h) => (h + 1) % menu.length);
+        return;
+      }
+      if (e.key === 'ArrowUp' && menu.length) {
+        e.preventDefault();
+        setHighlight((h) => (h - 1 + menu.length) % menu.length);
+        return;
+      }
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        // Leading '/' but no command matched → close menu, treat as a prompt.
+        if (menuMode === 'commands' && menu.length === 0) {
+          setMenuMode('closed');
+          if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            if (!streaming) send();
+          }
+          return;
+        }
+        e.preventDefault();
+        runHighlighted();
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        if (menuMode === 'commands') {
+          setMenuMode('closed');
+        } else {
+          // Second-level → back to the command list.
+          setMenuMode('commands');
+          setText('/');
+          setHighlight(0);
+          resetHeight();
+        }
+        return;
+      }
+      // Any other key falls through so typing continues to filter.
+    }
+
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       if (!streaming) send();
@@ -37,6 +284,15 @@ export function Composer({ streaming }: { streaming: boolean }) {
       e.preventDefault();
       post({ type: 'cancelResponse' });
     }
+  };
+
+  const onInput = (e: Event) => {
+    const value = (e.target as HTMLTextAreaElement).value;
+    setText(value);
+    grow();
+    setHighlight(0);
+    if (menuMode === 'model' || menuMode === 'export' || menuMode === 'skills') return; // keep filtering the submenu
+    setMenuMode(value.startsWith('/') ? 'commands' : 'closed');
   };
 
   const onFiles = (e: Event) => {
@@ -61,6 +317,7 @@ export function Composer({ streaming }: { streaming: boolean }) {
 
   return (
     <div class="fp-composer-wrap">
+      {showStatus && <StatusCard conv={conv} settings={settings} onClose={() => setShowStatus(false)} />}
       {selection && (
         <div class="fp-attachments">
           <span class="fp-attach-chip fp-selection-chip" title={`${selection.path}:${selection.startLine}-${selection.endLine}`}>
@@ -83,6 +340,18 @@ export function Composer({ streaming }: { streaming: boolean }) {
           ))}
         </div>
       )}
+      {menuVisible && (
+        <SlashMenu
+          items={menu}
+          highlight={highlight}
+          header={menuHeader}
+          onHover={setHighlight}
+          onSelect={(i) => {
+            const it = menu[i];
+            if (it && !it.disabled) it.run();
+          }}
+        />
+      )}
       <div class="fp-composer">
         <div class="fp-composer-box">
           <button type="button" class="fp-icon-btn" onClick={() => fileRef.current?.click()} aria-label="Attach file">
@@ -92,13 +361,10 @@ export function Composer({ streaming }: { streaming: boolean }) {
           <textarea
             ref={taRef}
             class="fp-composer-textarea"
-            placeholder="Ask FowlPlay to make a change…"
+            placeholder="Ask FowlPlay to make a change…  (/ for commands)"
             rows={1}
             value={text}
-            onInput={(e) => {
-              setText((e.target as HTMLTextAreaElement).value);
-              grow();
-            }}
+            onInput={onInput}
             onKeyDown={onKeyDown}
           />
           {streaming ? (
@@ -110,6 +376,59 @@ export function Composer({ streaming }: { streaming: boolean }) {
               <IconArrowUp size={18} />
             </button>
           )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const EMPTY_USAGE: TokenUsage = { inputTokens: 0, outputTokens: 0, cachedTokens: 0 };
+
+/**
+ * Ephemeral /status card — local UI only, never persisted or sent to the model.
+ * Mirrors StatusLine's context computation (approx live context = the most
+ * recent assistant node's input tokens, falling back to cumulative input).
+ */
+function StatusCard({
+  conv,
+  settings,
+  onClose,
+}: {
+  conv: Conversation | null;
+  settings: FowlPlaySettings | null;
+  onClose: () => void;
+}) {
+  const model = conv?.model ?? settings?.defaultModel ?? null;
+  const totals = conv?.usageTotals ?? EMPTY_USAGE;
+  const ctx = contextWindowFor(settings, model);
+  const nodes = conv ? Object.values(conv.nodes) : [];
+  const lastInput =
+    nodes.filter((n) => n.usage).sort((a, b) => b.createdAt - a.createdAt)[0]?.usage?.inputTokens ?? totals.inputTokens;
+  const pct = ctx ? Math.min(100, Math.round((lastInput / ctx) * 100)) : 0;
+  const mode = conv?.harnessMode ?? settings?.harness.defaultMode ?? 'coop';
+
+  return (
+    <div class="fp-status-card">
+      <div class="fp-status-card-head">
+        <span>Session status</span>
+        <button type="button" class="fp-btn-ghost" style={{ padding: 0 }} onClick={onClose} aria-label="Dismiss status">
+          <IconX size={14} />
+        </button>
+      </div>
+      <div class="fp-status-card-rows">
+        <div class="fp-status-row"><span class="fp-status-key">Model</span><span>{modelLabel(settings, model)}</span></div>
+        <div class="fp-status-row"><span class="fp-status-key">Mode</span><span>{mode === 'coop' ? 'Coop (pipeline)' : 'Solo (direct)'}</span></div>
+        <div class="fp-status-row">
+          <span class="fp-status-key">Context</span>
+          <span>
+            {ctx
+              ? `~${fmt(lastInput)} / ${fmt(ctx)} tokens (${pct}%)`
+              : 'context window unknown — set it in Settings → provider'}
+          </span>
+        </div>
+        <div class="fp-status-row">
+          <span class="fp-status-key">Tokens</span>
+          <span class="fp-tokens">↑{fmt(totals.inputTokens)} in · ↓{fmt(totals.outputTokens)} out · ⚡{fmt(totals.cachedTokens)} cached</span>
         </div>
       </div>
     </div>

--- a/src/webview/components/ProviderForm.tsx
+++ b/src/webview/components/ProviderForm.tsx
@@ -145,11 +145,21 @@ export function ModelManagement({ provider }: { provider: ProviderConfig }) {
     post({ type: 'updateProvider', provider: { ...provider, models: next } });
   };
 
-  const toggle = (id: string, on: boolean) => {
-    persist(on ? [...models, { id }] : models.filter((m) => m.id !== id));
+  const add = (f: { id: string; contextWindow?: number }) => {
+    if (models.some((m) => m.id === f.id)) return;
+    // Carry the fetched context window into the saved config (manual override, below, wins later).
+    persist([...models, f.contextWindow ? { id: f.id, contextWindow: f.contextWindow } : { id: f.id }]);
+  };
+  const remove = (id: string) => {
+    persist(models.filter((m) => m.id !== id));
   };
   const rename = (id: string, displayName: string) => {
     persist(models.map((m) => (m.id === id ? { ...m, displayName: displayName || undefined } : m)));
+  };
+  const setContext = (id: string, raw: string) => {
+    const n = parseInt(raw, 10);
+    const contextWindow = Number.isFinite(n) && n > 0 ? n : undefined;
+    persist(models.map((m) => (m.id === id ? { ...m, contextWindow } : m)));
   };
   const addManual = () => {
     const id = manual.trim();
@@ -180,7 +190,17 @@ export function ModelManagement({ provider }: { provider: ProviderConfig }) {
                 value={m.displayName ?? ''}
                 onInput={(e) => rename(m.id, (e.target as HTMLInputElement).value)}
               />
-              <button type="button" class="fp-icon-btn" onClick={() => toggle(m.id, false)} aria-label="Remove model"><IconTrash size={14} /></button>
+              <input
+                class="fp-input"
+                type="number"
+                min={0}
+                style={{ width: 96, padding: '3px 8px' }}
+                placeholder="ctx tokens"
+                title="Context window (tokens) — overrides the fetched value"
+                value={m.contextWindow ?? ''}
+                onInput={(e) => setContext(m.id, (e.target as HTMLInputElement).value)}
+              />
+              <button type="button" class="fp-icon-btn" onClick={() => remove(m.id)} aria-label="Remove model"><IconTrash size={14} /></button>
             </div>
           ))}
         </div>
@@ -192,8 +212,9 @@ export function ModelManagement({ provider }: { provider: ProviderConfig }) {
           <div class="fp-model-list">
             {available.map((f) => (
               <label class="fp-model-item fp-checkbox" key={f.id}>
-                <input type="checkbox" onChange={(e) => toggle(f.id, (e.target as HTMLInputElement).checked)} />
+                <input type="checkbox" onChange={(e) => (e.target as HTMLInputElement).checked && add(f)} />
                 <span style={{ fontFamily: 'var(--fp-font)', fontSize: 12 }}>{f.id}</span>
+                {f.contextWindow && <span style={{ color: 'var(--fp-fg-muted)', fontSize: 11 }}>{Math.round(f.contextWindow / 1000)}k ctx</span>}
               </label>
             ))}
           </div>

--- a/src/webview/components/SlashMenu.tsx
+++ b/src/webview/components/SlashMenu.tsx
@@ -1,0 +1,69 @@
+/**
+ * Codex-style slash-command popup, anchored above the composer.
+ *
+ * Presentational only: the Composer computes the rows (command list or a
+ * second-level picker), owns the highlight + keyboard handling, and passes an
+ * onSelect/onHover pair. Rows carry an optional group label (provider name),
+ * an active checkmark (current model) and a disabled flag (placeholder rows).
+ */
+import { Fragment } from 'preact';
+import type { ComponentChildren } from 'preact';
+import { IconCheck } from './icons';
+
+export interface SlashRow {
+  key: string;
+  title: string;
+  description?: string;
+  /** Renders a group label above this row (e.g. provider name in /model). */
+  groupLabel?: string;
+  /** Renders a checkmark (e.g. the currently-selected model). */
+  active?: boolean;
+}
+
+export interface SlashItem {
+  row: SlashRow;
+  disabled?: boolean;
+}
+
+export function SlashMenu({
+  items,
+  highlight,
+  header,
+  onHover,
+  onSelect,
+}: {
+  items: SlashItem[];
+  highlight: number;
+  header?: ComponentChildren;
+  onHover: (index: number) => void;
+  onSelect: (index: number) => void;
+}) {
+  return (
+    <div class="fp-slash-anchor">
+      {/* preventDefault on mousedown keeps focus in the textarea through a click */}
+      <div class="fp-slash-menu" role="listbox" onMouseDown={(e) => e.preventDefault()}>
+        {header && <div class="fp-slash-header">{header}</div>}
+        {items.map((it, i) => (
+          <Fragment key={it.row.key}>
+            {it.row.groupLabel && <div class="fp-menu-group-label">{it.row.groupLabel}</div>}
+            <button
+              type="button"
+              role="option"
+              aria-selected={i === highlight}
+              disabled={it.disabled}
+              class={`fp-slash-item ${i === highlight ? 'active' : ''} ${it.disabled ? 'disabled' : ''}`}
+              onMouseEnter={() => onHover(i)}
+              onClick={() => {
+                if (!it.disabled) onSelect(i);
+              }}
+            >
+              {it.row.active ? <IconCheck size={15} /> : null}
+              <span class="fp-slash-name">{it.row.title}</span>
+              {it.row.description && <span class="fp-slash-desc">{it.row.description}</span>}
+            </button>
+          </Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/webview/components/StatusLine.tsx
+++ b/src/webview/components/StatusLine.tsx
@@ -70,12 +70,12 @@ export function StatusLine({
       <div class="fp-spacer" />
 
       {ctx && (
-        <div class="fp-context" title={`${lastInput} / ${ctx} context tokens`}>
+        <div class="fp-context" title={`~${lastInput} tokens in context now / ${ctx} window`}>
           <div class="fp-context-bar"><div class="fp-context-fill" style={{ width: `${pct}%` }} /></div>
           <span>{pct}%</span>
         </div>
       )}
-      <span class="fp-tokens" title="input / output / cached tokens">
+      <span class="fp-tokens" title="cumulative this conversation: input / output / cached">
         ↑{fmt(totals.inputTokens)} ↓{fmt(totals.outputTokens)} ⚡{fmt(totals.cachedTokens)}
       </span>
     </div>

--- a/src/webview/components/store.tsx
+++ b/src/webview/components/store.tsx
@@ -39,7 +39,7 @@ export interface AppState {
   rebase: RebaseState;
   commitMessage: string;
   historyItems: ConversationSummary[];
-  modelsFetched: Record<string, { id: string }[]>;
+  modelsFetched: Record<string, { id: string; contextWindow?: number }[]>;
   modelsError: Record<string, string | undefined>;
   toasts: Toast[];
   bootstrapped: boolean;

--- a/src/webview/markdown.ts
+++ b/src/webview/markdown.ts
@@ -176,19 +176,31 @@ export function highlightCode(code: string, lang: string): string {
 // Inline markdown (bold, italic, code, links)
 // ---------------------------------------------------------------------------
 
+// Private-use sentinel char used to placeholder inline-code spans. It passes
+// through escapeHtml unchanged, so it survives the single formatInline pass.
+const CODE_SENTINEL = '\uE000';
+
 function renderInline(src: string): string {
-  // Tokenize inline code first so its contents are not further processed.
-  const parts: string[] = [];
-  let rest = src;
-  const codeRe = /`([^`]+)`/;
-  let m: RegExpExecArray | null;
-  while ((m = codeRe.exec(rest))) {
-    parts.push(formatInline(rest.slice(0, m.index)));
-    parts.push(`<code class="fp-inline-code">${escapeHtml(m[1])}</code>`);
-    rest = rest.slice(m.index + m[0].length);
-  }
-  parts.push(formatInline(rest));
-  return parts.join('');
+  // Strip any sentinel chars from the raw input so user text can never forge a
+  // placeholder (they are not derivable from escaped input either).
+  const clean = src.split(CODE_SENTINEL).join('');
+  // Extract inline-code spans and replace them with index-based placeholders,
+  // so emphasis that spans a code span (e.g. **bold `code` inside**) is matched
+  // as a single run by formatInline instead of being split across fragments.
+  const codes: string[] = [];
+  const withPlaceholders = clean.replace(/`([^`]+)`/g, (_all, code) => {
+    const idx = codes.length;
+    codes.push(code);
+    return `${CODE_SENTINEL}${idx}${CODE_SENTINEL}`;
+  });
+  // Run inline formatting (which HTML-escapes everything) over the whole string
+  // once, then substitute the rendered <code> elements back in.
+  let html = formatInline(withPlaceholders);
+  html = html.replace(
+    new RegExp(`${CODE_SENTINEL}(\\d+)${CODE_SENTINEL}`, 'g'),
+    (_all, n) => `<code class="fp-inline-code">${escapeHtml(codes[Number(n)])}</code>`,
+  );
+  return html;
 }
 
 function formatInline(src: string): string {
@@ -210,6 +222,64 @@ function formatInline(src: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Lists (indentation-aware, nested, mixed ul/ol)
+// ---------------------------------------------------------------------------
+
+interface ListItem {
+  indent: number;
+  ordered: boolean;
+  start: number;
+  text: string;
+}
+
+// Matches a single list-marker line, capturing leading whitespace, the marker
+// (bullet or "N."), and the item text.
+const LIST_ITEM_RE = /^(\s*)([-*+]|\d+\.)\s+(.*)$/;
+
+// Visual indent width; a tab counts as 4 columns so a single tab always reads
+// as a nested level (>= 2 columns deeper).
+function leadingIndent(ws: string): number {
+  let n = 0;
+  for (const ch of ws) n += ch === '\t' ? 4 : 1;
+  return n;
+}
+
+/**
+ * Build nested <ul>/<ol> HTML from a flat list of items, starting at `start`.
+ * Items whose indent is >= 2 columns deeper than the current level become a
+ * nested list attached to the preceding item; a change of marker type at the
+ * same level opens a fresh sibling list. Returns the HTML and the index of the
+ * first item not consumed at this level.
+ */
+function buildListLevel(items: ListItem[], start: number): [string, number] {
+  const levelIndent = items[start].indent;
+  // Same level = within one column of tolerance (models emit 2/3/4-space
+  // indents); deeper by >= 2 columns is a child.
+  const sameLevel = (indent: number) => Math.abs(indent - levelIndent) < 2;
+  let html = '';
+  let i = start;
+  while (i < items.length && sameLevel(items[i].indent)) {
+    const ordered = items[i].ordered;
+    const startNum = items[i].start;
+    let list = ordered ? (startNum !== 1 ? `<ol start="${startNum}">` : '<ol>') : '<ul>';
+    while (i < items.length && sameLevel(items[i].indent) && items[i].ordered === ordered) {
+      let li = `<li>${renderInline(items[i].text)}`;
+      i++;
+      if (i < items.length && items[i].indent - levelIndent >= 2) {
+        const [childHtml, next] = buildListLevel(items, i);
+        li += childHtml;
+        i = next;
+      }
+      li += '</li>';
+      list += li;
+    }
+    list += ordered ? '</ol>' : '</ul>';
+    html += list;
+  }
+  return [html, i];
+}
+
+// ---------------------------------------------------------------------------
 // Block markdown
 // ---------------------------------------------------------------------------
 
@@ -217,13 +287,6 @@ export function renderMarkdown(src: string): string {
   const lines = (src || '').replace(/\r\n/g, '\n').split('\n');
   const out: string[] = [];
   let i = 0;
-
-  const flushList = (buf: string[], ordered: boolean) => {
-    if (!buf.length) return;
-    const tag = ordered ? 'ol' : 'ul';
-    out.push(`<${tag}>${buf.map((li) => `<li>${renderInline(li)}</li>`).join('')}</${tag}>`);
-    buf.length = 0;
-  };
 
   while (i < lines.length) {
     const line = lines[i];
@@ -299,25 +362,23 @@ export function renderMarkdown(src: string): string {
       continue;
     }
 
-    // Unordered list
-    if (/^\s*[-*+]\s+/.test(line)) {
-      const buf: string[] = [];
-      while (i < lines.length && /^\s*[-*+]\s+/.test(lines[i])) {
-        buf.push(lines[i].replace(/^\s*[-*+]\s+/, ''));
+    // List (ordered or unordered, indentation-aware nesting, mixed types)
+    if (LIST_ITEM_RE.test(line)) {
+      const items: ListItem[] = [];
+      while (i < lines.length && LIST_ITEM_RE.test(lines[i])) {
+        const mm = lines[i].match(LIST_ITEM_RE)!;
+        const marker = mm[2];
+        const ordered = /^\d+\.$/.test(marker);
+        items.push({
+          indent: leadingIndent(mm[1]),
+          ordered,
+          start: ordered ? parseInt(marker, 10) : 1,
+          text: mm[3],
+        });
         i++;
       }
-      flushList(buf, false);
-      continue;
-    }
-
-    // Ordered list
-    if (/^\s*\d+\.\s+/.test(line)) {
-      const buf: string[] = [];
-      while (i < lines.length && /^\s*\d+\.\s+/.test(lines[i])) {
-        buf.push(lines[i].replace(/^\s*\d+\.\s+/, ''));
-        i++;
-      }
-      flushList(buf, true);
+      const [html] = buildListLevel(items, 0);
+      out.push(html);
       continue;
     }
 

--- a/src/webview/slashCommands.ts
+++ b/src/webview/slashCommands.ts
@@ -1,0 +1,82 @@
+/**
+ * Slash-command catalog + pure filtering/matching logic for the chat composer.
+ *
+ * Dependency-free (no Preact, no store) so it stays unit-testable. The Preact
+ * <SlashMenu> / Composer consume this module to render the popup and dispatch
+ * the actual actions; nothing here touches the DOM or the protocol.
+ */
+
+/**
+ * How a command behaves once chosen:
+ *  - 'action'  → run an action immediately, then clear + close the composer.
+ *  - 'submenu' → open a second-level picker in the same popup (model/export/skills).
+ *  - 'status'  → render an ephemeral local status card; no host round-trip.
+ */
+export type SlashCommandKind = 'action' | 'submenu' | 'status';
+
+export interface SlashCommand {
+  /** Canonical name, without the leading slash (e.g. "clear"). */
+  name: string;
+  /** Alternate names, without the leading slash (e.g. ["new"]). */
+  aliases: string[];
+  /** One-line description shown dimmed on the right of the row. */
+  description: string;
+  kind: SlashCommandKind;
+}
+
+/** The full command catalog, in display order. */
+export const SLASH_COMMANDS: SlashCommand[] = [
+  { name: 'clear', aliases: ['new'], description: 'Start a new conversation', kind: 'action' },
+  { name: 'model', aliases: [], description: 'Switch the active model', kind: 'submenu' },
+  { name: 'solo', aliases: [], description: 'Direct single-agent mode', kind: 'action' },
+  { name: 'coop', aliases: [], description: 'Cooperative pipeline mode', kind: 'action' },
+  { name: 'diff', aliases: ['review'], description: 'Review staged changes', kind: 'action' },
+  { name: 'fork', aliases: [], description: 'Fork this conversation into a new tab', kind: 'action' },
+  { name: 'export', aliases: [], description: 'Copy conversation as Markdown or JSON', kind: 'submenu' },
+  { name: 'settings', aliases: [], description: 'Open settings', kind: 'action' },
+  { name: 'history', aliases: [], description: 'Browse past conversations', kind: 'action' },
+  {
+    name: 'status',
+    aliases: [],
+    description: 'Show session status: model, mode, context usage, tokens',
+    kind: 'status',
+  },
+  { name: 'skills', aliases: [], description: 'Use a skill', kind: 'submenu' },
+];
+
+/**
+ * Rank of a command against a lowercased query. Lower is better; `null` = no match.
+ *   0 = name/alias starts with the query (prefix)
+ *   1 = name/alias contains the query (substring)
+ *   2 = description contains the query (substring)
+ */
+function matchRank(cmd: SlashCommand, query: string): number | null {
+  const names = [cmd.name, ...cmd.aliases].map((n) => n.toLowerCase());
+  if (names.some((n) => n.startsWith(query))) return 0;
+  if (names.some((n) => n.includes(query))) return 1;
+  if (cmd.description.toLowerCase().includes(query)) return 2;
+  return null;
+}
+
+/**
+ * Filter the command catalog for the current composer input.
+ *
+ * - Input must begin with '/' (the composer only opens the menu on a leading
+ *   slash); anything else returns [].
+ * - An empty query (just '/') lists every command in catalog order.
+ * - Matching is case-insensitive against name, aliases, and description.
+ * - Results are ranked: prefix matches first, then name/alias substrings, then
+ *   description substrings; ties keep catalog order (stable).
+ * - Input that starts with '/' but matches nothing returns [] (the composer
+ *   then sends it as an ordinary prompt).
+ */
+export function filterCommands(input: string): SlashCommand[] {
+  if (!input.startsWith('/')) return [];
+  const query = input.slice(1).trim().toLowerCase();
+  if (query === '') return [...SLASH_COMMANDS];
+  return SLASH_COMMANDS
+    .map((cmd, index) => ({ cmd, index, rank: matchRank(cmd, query) }))
+    .filter((e): e is { cmd: SlashCommand; index: number; rank: number } => e.rank !== null)
+    .sort((a, b) => a.rank - b.rank || a.index - b.index)
+    .map((e) => e.cmd);
+}

--- a/src/webview/theme.css
+++ b/src/webview/theme.css
@@ -399,7 +399,7 @@ a:hover { text-decoration: underline; }
 /* =====================================================================
    Composer + status line
    ===================================================================== */
-.fp-composer-wrap { border-top: 1px solid var(--fp-border); background: var(--fp-bg); flex-shrink: 0; }
+.fp-composer-wrap { position: relative; border-top: 1px solid var(--fp-border); background: var(--fp-bg); flex-shrink: 0; }
 .fp-composer { max-width: 820px; margin: 0 auto; padding: 12px 24px; }
 .fp-composer-box {
   border: 1px solid var(--fp-border-strong); border-radius: var(--fp-radius-lg);
@@ -441,6 +441,56 @@ a:hover { text-decoration: underline; }
 .fp-context-bar { width: 90px; height: 6px; border-radius: 999px; background: var(--fp-bg-sunken); overflow: hidden; border: 1px solid var(--fp-border); }
 .fp-context-fill { height: 100%; background: var(--fp-gradient); transition: width var(--fp-t); }
 .fp-tokens { font-family: var(--fp-font); }
+
+/* Slash-command popup (anchored above the composer) */
+.fp-slash-anchor {
+  position: absolute; bottom: 100%; left: 0; right: 0;
+  max-width: 820px; margin: 0 auto; padding: 0 24px;
+  pointer-events: none;
+}
+.fp-slash-menu {
+  pointer-events: auto;
+  background: var(--fp-surface); border: 1px solid var(--fp-border-strong);
+  border-radius: var(--fp-radius); box-shadow: var(--fp-shadow);
+  padding: 6px; margin-bottom: 8px;
+  max-height: 320px; overflow-y: auto;
+}
+.fp-slash-header {
+  padding: 5px 10px 7px; margin-bottom: 4px;
+  border-bottom: 1px solid var(--fp-border);
+  font-size: calc(11px * var(--fp-scale)); font-weight: 600;
+  color: var(--fp-fg-subtle); text-transform: uppercase; letter-spacing: 0.04em;
+}
+.fp-slash-item {
+  display: flex; align-items: baseline; gap: 10px; width: 100%;
+  padding: 7px 10px; border-radius: var(--fp-radius-sm);
+  text-align: left; color: var(--fp-fg);
+}
+.fp-slash-item.active { background: var(--fp-accent-soft); }
+.fp-slash-item.disabled { color: var(--fp-fg-subtle); cursor: default; }
+.fp-slash-item svg { color: var(--fp-accent); flex-shrink: 0; align-self: center; }
+.fp-slash-name { font-family: var(--fp-font); font-weight: 600; white-space: nowrap; }
+.fp-slash-item.active .fp-slash-name { color: var(--fp-accent); }
+.fp-slash-desc { color: var(--fp-fg-muted); font-size: calc(12px * var(--fp-scale)); margin-left: auto; text-align: right; }
+
+/* /status card (ephemeral, above the composer like the attachments strip) */
+.fp-status-card {
+  max-width: 820px; margin: 8px auto 0; padding: 10px 14px;
+  border: 1px solid var(--fp-border-strong); border-radius: var(--fp-radius);
+  background: var(--fp-bg-sunken);
+  width: calc(100% - 48px);
+}
+.fp-status-card-head {
+  display: flex; align-items: center; justify-content: space-between;
+  font-weight: 700; font-size: calc(12px * var(--fp-scale));
+  text-transform: uppercase; letter-spacing: 0.04em; color: var(--fp-fg-subtle);
+  margin-bottom: 8px;
+}
+.fp-status-card-rows { display: flex; flex-direction: column; gap: 5px; }
+.fp-status-row { display: flex; gap: 12px; font-size: calc(13px * var(--fp-scale)); }
+.fp-status-row .fp-status-key {
+  flex-shrink: 0; width: 72px; font-weight: 600; color: var(--fp-fg-muted);
+}
 
 /* =====================================================================
    Dropdowns / menus / modals

--- a/test/extension-session.test.ts
+++ b/test/extension-session.test.ts
@@ -268,6 +268,42 @@ describe('setModel', () => {
   });
 });
 
+describe('fetchModels wiring', () => {
+  it('passes the provider kind through and forwards fetched contextWindow to the webview', async () => {
+    const posted: HostToWebview[] = [];
+    let receivedKind: string | undefined;
+    let receivedBaseUrl: string | undefined;
+    const deps: SessionDeps = {
+      io: new FakeIo(),
+      secrets: new FakeSecrets(),
+      settings: new FakeSettings('solo'),
+      history: new FakeHistory(),
+      git: fakeGit,
+      post: (m) => posted.push(m),
+      createAdapter: () => scriptedAdapter().adapter,
+      fetchModels: async (cfg) => {
+        receivedKind = cfg.kind;
+        receivedBaseUrl = cfg.baseUrl;
+        return [{ id: 'm1', contextWindow: 32768 }, { id: 'm2' }];
+      },
+      clock: () => Date.now(),
+    };
+    const session = createSessionCore(deps);
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'fetchModels', providerId: 'p1' });
+
+    // The provider's kind (and baseUrl) reach the registry so it can decide to enrich.
+    expect(receivedKind).toBe('local');
+    expect(receivedBaseUrl).toBe('http://localhost:11434/v1');
+
+    const msg = posted.find(
+      (m): m is Extract<HostToWebview, { type: 'modelsFetched' }> => m.type === 'modelsFetched',
+    );
+    expect(msg?.providerId).toBe('p1');
+    expect(msg?.models).toEqual([{ id: 'm1', contextWindow: 32768 }, { id: 'm2' }]);
+  });
+});
+
 describe('solo prompt turn', () => {
   it('streams a turn, stages an edit, and appends a changes block', async () => {
     const { session, posted } = makeSession({ path: 'foo.txt', content: 'hello\nworld\n' });

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { escapeHtml, highlightCode, renderMarkdown } from '../src/webview/markdown';
+
+describe('renderMarkdown lists', () => {
+  it('keeps consecutive numbered items with nested bullets in one <ol>', () => {
+    const src = [
+      '1. **Scout**',
+      '   - **Role:** reads request',
+      '2. **Builder**',
+      '   - **Role:** writes code',
+    ].join('\n');
+    const html = renderMarkdown(src);
+
+    // Exactly one <ol> wrapping the whole thing.
+    expect(html.match(/<ol\b/g)?.length ?? 0).toBe(1);
+    expect(html.match(/<\/ol>/g)?.length ?? 0).toBe(1);
+    // Each numbered item carries a nested <ul>.
+    expect(html.match(/<ul>/g)?.length ?? 0).toBe(2);
+    expect(html).toContain('<strong>Scout</strong>');
+    expect(html).toContain('<strong>Builder</strong>');
+    expect(html).toContain('<strong>Role:</strong> reads request');
+    expect(html).toContain('<strong>Role:</strong> writes code');
+    // Structure: <ol><li>...<ul>...</ul></li><li>...<ul>...</ul></li></ol>
+    expect(html).toMatch(
+      /<ol><li><strong>Scout<\/strong><ul><li><strong>Role:<\/strong> reads request<\/li><\/ul><\/li><li><strong>Builder<\/strong><ul><li><strong>Role:<\/strong> writes code<\/li><\/ul><\/li><\/ol>/,
+    );
+  });
+
+  it('honors a non-1 starting number with the start attribute', () => {
+    const html = renderMarkdown(['3. three', '4. four', '5. five'].join('\n'));
+    expect(html).toContain('<ol start="3">');
+    expect(html.match(/<ol\b/g)?.length ?? 0).toBe(1);
+    expect(html.match(/<li>/g)?.length ?? 0).toBe(3);
+  });
+
+  it('uses a plain <ol> when the list starts at 1', () => {
+    const html = renderMarkdown(['1. one', '2. two'].join('\n'));
+    expect(html).toContain('<ol>');
+    expect(html).not.toContain('start=');
+  });
+
+  it('renders three levels of nesting', () => {
+    const src = ['- a', '  - b', '    - c'].join('\n');
+    const html = renderMarkdown(src);
+    expect(html).toBe('<ul><li>a<ul><li>b<ul><li>c</li></ul></li></ul></li></ul>');
+  });
+
+  it('supports ul nested inside ol', () => {
+    const src = ['1. outer', '   - inner'].join('\n');
+    const html = renderMarkdown(src);
+    expect(html).toBe('<ol><li>outer<ul><li>inner</li></ul></li></ol>');
+  });
+
+  it('supports ol nested inside ul', () => {
+    const src = ['- outer', '   1. inner', '   2. inner two'].join('\n');
+    const html = renderMarkdown(src);
+    expect(html).toBe('<ul><li>outer<ol><li>inner</li><li>inner two</li></ol></li></ul>');
+  });
+
+  it('tolerates 2-, 3-, and 4-space nested indents', () => {
+    for (const pad of ['  ', '   ', '    ']) {
+      const html = renderMarkdown(['- top', `${pad}- child`].join('\n'));
+      expect(html).toBe('<ul><li>top<ul><li>child</li></ul></li></ul>');
+    }
+  });
+
+  it('escapes <script> inside list items', () => {
+    const html = renderMarkdown('- <script>alert(1)</script>');
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});
+
+describe('renderInline emphasis and inline code', () => {
+  it('renders bold spanning an inline-code span', () => {
+    const html = renderMarkdown('**bold with `code` inside**');
+    expect(html).not.toContain('**');
+    expect(html).toContain('<strong>');
+    expect(html).toContain('<code class="fp-inline-code">code</code>');
+    expect(html).toMatch(
+      /<strong>bold with <code class="fp-inline-code">code<\/code> inside<\/strong>/,
+    );
+  });
+
+  it('renders plain italic and strikethrough', () => {
+    expect(renderMarkdown('*italic*')).toContain('<em>italic</em>');
+    expect(renderMarkdown('~~gone~~')).toContain('<del>gone</del>');
+  });
+
+  it('does not further process inline-code contents', () => {
+    const html = renderMarkdown('use `**not bold** and _not italic_`');
+    expect(html).toContain(
+      '<code class="fp-inline-code">**not bold** and _not italic_</code>',
+    );
+    expect(html).not.toContain('<strong>');
+    expect(html).not.toContain('<em>');
+  });
+
+  it('escapes html inside inline code', () => {
+    const html = renderMarkdown('`<script>`');
+    expect(html).toContain('<code class="fp-inline-code">&lt;script&gt;</code>');
+    expect(html).not.toContain('<script>');
+  });
+
+  it('escapes <script> in inline text', () => {
+    const html = renderMarkdown('hello <script>alert(1)</script> world');
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('cannot be tricked by sentinel chars in input', () => {
+    // A raw private-use sentinel plus digits must not forge a <code> element.
+    const html = renderMarkdown('0 `real`');
+    expect(html).toContain('<code class="fp-inline-code">real</code>');
+    // Only the genuine code span becomes a <code> element.
+    expect(html.match(/<code /g)?.length ?? 0).toBe(1);
+  });
+});
+
+describe('renderMarkdown unchanged block behavior', () => {
+  it('renders a fenced code block', () => {
+    const src = ['```ts', 'const x = 1;', '```'].join('\n');
+    const html = renderMarkdown(src);
+    expect(html).toContain('fp-codeblock');
+    expect(html).toContain('<pre class="fp-pre"><code>');
+    expect(html).toContain('fp-copy-btn');
+    expect(html).toContain('<span class="tok-keyword">const</span>');
+  });
+
+  it('renders a table', () => {
+    const src = ['| a | b |', '| - | - |', '| 1 | 2 |'].join('\n');
+    const html = renderMarkdown(src);
+    expect(html).toContain('<table><thead><tr><th>a</th><th>b</th></tr></thead>');
+    expect(html).toContain('<tbody><tr><td>1</td><td>2</td></tr></tbody></table>');
+  });
+
+  it('renders a blockquote', () => {
+    const html = renderMarkdown('> quoted text');
+    expect(html).toContain('<blockquote>');
+    expect(html).toContain('quoted text');
+    expect(html).toContain('</blockquote>');
+  });
+
+  it('renders headings and paragraphs', () => {
+    expect(renderMarkdown('# Title')).toBe('<h1>Title</h1>');
+    expect(renderMarkdown('plain line')).toBe('<p>plain line</p>');
+  });
+});
+
+describe('escapeHtml and highlightCode exports', () => {
+  it('escapes the five entities', () => {
+    expect(escapeHtml(`<>&"'`)).toBe('&lt;&gt;&amp;&quot;&#39;');
+  });
+
+  it('highlights a keyword and escapes unknown languages', () => {
+    expect(highlightCode('const', 'ts')).toContain('tok-keyword');
+    expect(highlightCode('<x>', 'unknownlang')).toBe('&lt;x&gt;');
+  });
+});

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -320,15 +320,118 @@ describe('registry', () => {
   });
 
   it('fetchModels returns sorted ids for openai-completions', async () => {
+    // A remote (non-local) provider: no enrichment, plain id list.
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({ data: [{ id: 'zeta' }, { id: 'alpha' }] }), { status: 200 }));
     vi.stubGlobal('fetch', fetchMock);
     const models = await fetchModels(
-      { sdkType: 'openai-completions', baseUrl: 'http://localhost:11434/v1' },
+      { sdkType: 'openai-completions', baseUrl: 'https://api.example.com/v1' },
       undefined,
     );
     expect(models).toEqual([{ id: 'alpha' }, { id: 'zeta' }]);
     const [url] = fetchMock.mock.calls[0] as unknown as [string];
-    expect(url).toBe('http://localhost:11434/v1/models');
+    expect(url).toBe('https://api.example.com/v1/models');
+  });
+
+  it('fetchModels picks up context_length from the /models payload', async () => {
+    // OpenRouter-style payload with per-model context_length (and vLLM max_model_len).
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          data: [
+            { id: 'big', context_length: 200000 },
+            { id: 'vllm', max_model_len: 32768 },
+            { id: 'plain' },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const models = await fetchModels(
+      { sdkType: 'openai-completions', baseUrl: 'https://openrouter.ai/api/v1' },
+      'sk-or',
+    );
+    expect(models).toEqual([
+      { id: 'big', contextWindow: 200000 },
+      { id: 'plain' },
+      { id: 'vllm', contextWindow: 32768 },
+    ]);
+  });
+
+  it('fetchModels enriches local models from LM Studio /api/v0/models', async () => {
+    const fetchMock = vi.fn(async (input: unknown) => {
+      const url = String(input);
+      if (url.endsWith('/v1/models')) {
+        return new Response(JSON.stringify({ data: [{ id: 'qwen' }, { id: 'gemma' }] }), { status: 200 });
+      }
+      if (url.endsWith('/api/v0/models')) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              { id: 'qwen', max_context_length: 32768, loaded_context_length: 8192 },
+              { id: 'gemma', max_context_length: 8192 },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      // llama.cpp /props and Ollama /api/show are not this server → 404.
+      return new Response('not found', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const models = await fetchModels(
+      { sdkType: 'openai-completions', baseUrl: 'http://localhost:1234/v1', kind: 'local' },
+      undefined,
+    );
+    // gemma → max_context_length; qwen → loaded_context_length preferred over max.
+    expect(models).toEqual([
+      { id: 'gemma', contextWindow: 8192 },
+      { id: 'qwen', contextWindow: 8192 },
+    ]);
+  });
+
+  it('fetchModels: a failing local probe does not break the primary list', async () => {
+    const fetchMock = vi.fn(async (input: unknown) => {
+      const url = String(input);
+      if (url.endsWith('/v1/models')) {
+        return new Response(JSON.stringify({ data: [{ id: 'solo' }] }), { status: 200 });
+      }
+      // Every enrichment probe blows up.
+      throw new Error('connection refused');
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const models = await fetchModels(
+      { sdkType: 'openai-completions', baseUrl: 'http://localhost:11434/v1', kind: 'local' },
+      undefined,
+    );
+    expect(models).toEqual([{ id: 'solo' }]);
+  });
+
+  it('fetchModels arms a ~1.5s AbortSignal timeout on local probes (without sleeping)', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    const fetchMock = vi.fn(async (input: unknown, _init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith('/v1/models')) {
+        return new Response(JSON.stringify({ data: [{ id: 'solo' }] }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchModels(
+      { sdkType: 'openai-completions', baseUrl: 'http://localhost:11434/v1', kind: 'local' },
+      undefined,
+    );
+    // Probes are armed with the bounded deadline; the primary /models call is not.
+    expect(timeoutSpy).toHaveBeenCalledWith(1500);
+    // Every enrichment fetch carried an AbortSignal.
+    const probeCalls = fetchMock.mock.calls.filter(([u]) => !String(u).endsWith('/v1/models'));
+    expect(probeCalls.length).toBeGreaterThan(0);
+    for (const [, init] of probeCalls) {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+    }
   });
 
   it('fetchModels uses /v1/models + x-api-key for anthropic (no doubled /v1)', async () => {

--- a/test/slashCommands.test.ts
+++ b/test/slashCommands.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Slash-command catalog + filtering tests — leading-slash handling, empty-input
+ * listing, name/alias/description matching, prefix-before-substring ranking,
+ * and unrecognized input.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { SLASH_COMMANDS, filterCommands } from '../src/webview/slashCommands';
+
+const names = (cmds: { name: string }[]) => cmds.map((c) => c.name);
+
+describe('SLASH_COMMANDS catalog', () => {
+  it('ships the documented commands, each with a description', () => {
+    for (const n of ['clear', 'model', 'solo', 'coop', 'diff', 'fork', 'export', 'settings', 'history', 'status', 'skills']) {
+      expect(names(SLASH_COMMANDS)).toContain(n);
+    }
+    for (const c of SLASH_COMMANDS) {
+      expect(c.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('marks the second-level pickers as submenus and /status as status', () => {
+    const byName = Object.fromEntries(SLASH_COMMANDS.map((c) => [c.name, c]));
+    expect(byName.model.kind).toBe('submenu');
+    expect(byName.export.kind).toBe('submenu');
+    expect(byName.skills.kind).toBe('submenu');
+    expect(byName.status.kind).toBe('status');
+    expect(byName.clear.kind).toBe('action');
+  });
+});
+
+describe('filterCommands', () => {
+  it('returns nothing when the input does not start with a slash', () => {
+    expect(filterCommands('')).toEqual([]);
+    expect(filterCommands('model')).toEqual([]);
+    expect(filterCommands('hello /model')).toEqual([]);
+  });
+
+  it('lists every command, in catalog order, for a bare slash', () => {
+    expect(names(filterCommands('/'))).toEqual(names(SLASH_COMMANDS));
+  });
+
+  it('filters by name prefix, ranking the prefix match first', () => {
+    // 'mod' is also a substring of "...mode" in several descriptions, but the
+    // /model name-prefix hit must rank first.
+    expect(names(filterCommands('/mod'))[0]).toBe('model');
+    // 'sk' is unique to /skills.
+    expect(names(filterCommands('/sk'))).toEqual(['skills']);
+  });
+
+  it('is case-insensitive', () => {
+    expect(names(filterCommands('/MODEL'))[0]).toBe('model');
+  });
+
+  it('matches aliases, ranking the alias match first', () => {
+    // /new is an alias of /clear; /review is an alias of /diff.
+    expect(names(filterCommands('/new'))[0]).toBe('clear');
+    expect(names(filterCommands('/review'))[0]).toBe('diff');
+  });
+
+  it('matches on the description as a substring', () => {
+    // "pipeline" only appears in the /coop description.
+    expect(names(filterCommands('/pipeline'))).toContain('coop');
+    // "past conversations" is only in /history's description.
+    expect(names(filterCommands('/past'))).toContain('history');
+  });
+
+  it('ranks prefix matches before substring/description matches', () => {
+    // "s" is a prefix of solo/settings/status/skills, but also appears inside
+    // other names/descriptions — the prefix matches must come first.
+    const result = names(filterCommands('/s'));
+    const prefixed = ['solo', 'settings', 'status', 'skills'];
+    const firstFour = result.slice(0, prefixed.length);
+    expect(new Set(firstFour)).toEqual(new Set(prefixed));
+    // and prefix hits precede any pure description hit.
+    for (const p of prefixed) {
+      expect(result.indexOf(p)).toBeLessThan(prefixed.length);
+    }
+  });
+
+  it('keeps catalog order among equally-ranked matches', () => {
+    // All four are name-prefix matches on "s"; catalog order is
+    // solo, settings, status, skills.
+    expect(names(filterCommands('/s')).slice(0, 4)).toEqual(['solo', 'settings', 'status', 'skills']);
+  });
+
+  it('returns empty for an unrecognized command', () => {
+    expect(filterCommands('/zzzznope')).toEqual([]);
+  });
+
+  it('tolerates surrounding whitespace in the query', () => {
+    expect(names(filterCommands('/  model '))[0]).toBe('model');
+  });
+});


### PR DESCRIPTION
Three changes, each in its own commit:

**Markdown rendering fixes** — nested bullets render as real nested `<ul>`/`<ol>` instead of flattening; numbered lists keep counting past nested sublists instead of restarting at "1."; non-1 starts emit the `start` attribute; bold/italic spanning inline code no longer leaks literal `**`. 20 new tests incl. XSS guards.

**Context-window surfacing** — `fetchModels` returns `{ id, contextWindow? }`: parsed from `/models` payloads (`context_length`, `max_model_len`, …) and enriched for local providers via best-effort 1.5s-timeout probes (LM Studio `/api/v0/models` preferring `loaded_context_length`, llama.cpp `/props` `n_ctx`, Ollama `/api/show` `*.context_length`). Provider form saves fetched values and adds a per-model manual override. The status-line context bar now populates for local models; tooltips separate "in context now" from cumulative totals.

**Codex-style slash commands** — `/` as the first composer character opens a filtered popup: `/clear` (`/new`), `/model`, `/solo`, `/coop`, `/diff` (`/review`), `/fork`, `/export`, `/settings`, `/history`, `/status`, `/skills`. Arrow-key navigation, Enter/Tab to run, Escape closes/steps back; `/model`, `/export`, `/skills` open second-level pickers; `/skills` prefills a skill-invoking prompt; `/status` shows an ephemeral session card; unrecognized `/text` sends as a normal prompt. Catalog + filtering in a pure module (`src/webview/slashCommands.ts`) with vitest coverage; user manual updated.

Verification: `tsc --noEmit` clean, 168/168 unit tests, 54/54 e2e tests, `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG)_