### PR TITLE
Side-by-side Edit Selection + history navigation fix

### DIFF
--- a/src/extension/tabManager.ts
+++ b/src/extension/tabManager.ts
@@ -27,6 +27,9 @@ interface Seed {
 export class TabManager {
   private readonly panels = new Set<vscode.WebviewPanel>();
   private readonly sessions = new WeakMap<vscode.WebviewPanel, SessionCore>();
+  /** The activity-bar view (fowlplay.home) and its session, once resolved. */
+  private homeView: vscode.WebviewView | null = null;
+  private homeSession: SessionCore | null = null;
   private readonly secrets: SecretsStore;
   private readonly settings: SettingsStore;
   private readonly history: HistoryStore;
@@ -38,11 +41,11 @@ export class TabManager {
   }
 
   /** Open (or focus) a webview panel tab. An optional seed forks an existing conversation. */
-  openTab(seed?: Seed): vscode.WebviewPanel {
+  openTab(seed?: Seed, viewColumn: vscode.ViewColumn = vscode.ViewColumn.Active): vscode.WebviewPanel {
     const panel = vscode.window.createWebviewPanel(
       'fowlplay.tab',
       'FowlPlay',
-      vscode.ViewColumn.Active,
+      viewColumn,
       {
         enableScripts: true,
         retainContextWhenHidden: true,
@@ -66,7 +69,15 @@ export class TabManager {
       localResourceRoots: [vscode.Uri.joinPath(this.context.extensionUri, 'dist')],
     };
     view.webview.html = this.html(view.webview);
-    this.attachSession(view.webview);
+    // Track the view + session so editSelection can target the sidebar chat.
+    this.homeView = view;
+    this.homeSession = this.attachSession(view.webview);
+    view.onDidDispose(() => {
+      if (this.homeView === view) {
+        this.homeView = null;
+        this.homeSession = null;
+      }
+    });
   }
 
   /** Open (or focus) a tab and switch its UI to the settings view. */
@@ -95,16 +106,35 @@ export class TabManager {
 
   /**
    * Deliver a highlighted editor region to a session as scoped context for its
-   * next change, targeting the active/most-recent panel (opening one if none).
+   * next change. Targets a FowlPlay surface the user can already see, so the
+   * code being discussed is never covered:
+   *   1. a visible editor-area panel (focused one first),
+   *   2. the sidebar view when it is visible (true side-by-side),
+   *   3. an existing hidden panel, revealed in a split beside the editor,
+   *   4. a fresh panel opened beside the editor.
+   * Focus moves to the chat so the user can type about the selection right away.
    */
   editSelection(ctx: SelectionContext): void {
-    const active = [...this.panels].find((p) => p.active) ?? [...this.panels].pop();
-    if (active) {
-      active.reveal();
-      this.sessions.get(active)?.receiveSelection(ctx);
+    const visible = [...this.panels].find((p) => p.active) ?? [...this.panels].find((p) => p.visible);
+    if (visible) {
+      visible.reveal();
+      this.sessions.get(visible)?.receiveSelection(ctx);
       return;
     }
-    const panel = this.openTab();
+    if (this.homeView?.visible && this.homeSession) {
+      this.homeView.show(false);
+      this.homeSession.receiveSelection(ctx);
+      return;
+    }
+    const recent = [...this.panels].pop();
+    if (recent) {
+      // Reveal beside the editor rather than in place — its remembered column
+      // may be the one holding the file the user just selected in.
+      recent.reveal(vscode.ViewColumn.Beside);
+      this.sessions.get(recent)?.receiveSelection(ctx);
+      return;
+    }
+    const panel = this.openTab(undefined, vscode.ViewColumn.Beside);
     panel.reveal();
     // The session stores the selection immediately; the chip message it posts is
     // dropped because the new webview hasn't subscribed yet, but the session

--- a/src/webview/components/Composer.tsx
+++ b/src/webview/components/Composer.tsx
@@ -1,5 +1,5 @@
 /** Auto-growing composer with attachments, slash commands, send / stop. */
-import { useRef, useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import type { Attachment } from '../../shared/protocol';
 import type { Conversation, FowlPlaySettings, ModelRef, TokenUsage } from '../../shared/types';
 import { post, store, useStore } from './store';
@@ -43,6 +43,12 @@ export function Composer({ streaming }: { streaming: boolean }) {
   const conv = useStore((s) => s.conversation);
   const taRef = useRef<HTMLTextAreaElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+
+  // A freshly pinned "Edit Selection" region means the user wants to talk about
+  // it — put the caret in the composer so they can type immediately.
+  useEffect(() => {
+    if (selection) taRef.current?.focus();
+  }, [selection]);
 
   const grow = () => {
     const ta = taRef.current;

--- a/src/webview/components/HistoryPanel.tsx
+++ b/src/webview/components/HistoryPanel.tsx
@@ -43,7 +43,17 @@ export function HistoryPanel({ items }: { items: ConversationSummary[] }) {
         <div class="fp-history-list">
           {items.length === 0 && <div class="fp-empty">No conversations yet.</div>}
           {items.map((c) => (
-            <div class="fp-history-item" key={c.id} onClick={() => renameId !== c.id && post({ type: 'openConversation', id: c.id })}>
+            <div
+              class="fp-history-item"
+              key={c.id}
+              onClick={() => {
+                if (renameId === c.id) return;
+                post({ type: 'openConversation', id: c.id });
+                // Navigate to the chat immediately — the conversation loads into a
+                // view the user can actually see, instead of silently behind history.
+                store.setView('chat');
+              }}
+            >
               {renameId === c.id ? (
                 <input
                   class="fp-input"


### PR DESCRIPTION
Two ease-of-life fixes:

**Edit Selection is now truly side-by-side.** The activity-bar sidebar view (`fowlplay.home`) is tracked as a selection target, so a visible sidebar chat receives the pinned selection next to the code. Routing order: focused/visible FowlPlay tab → visible sidebar view → existing hidden tab revealed `ViewColumn.Beside` → fresh tab opened `ViewColumn.Beside`. A panel never opens in the active column on top of the file the selection came from, and the composer grabs focus when the chip arrives.

**History clicks navigate.** Selecting a conversation in History now switches to the chat view in the same action instead of loading the conversation invisibly behind the history list (repeated clicks previously appeared to do nothing). The copy/export row actions intentionally stay on the history view.

Verification: `tsc --noEmit` clean, 168/168 unit tests, 54/54 e2e tests, `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG)_