### PR TITLE
Sync settings across all live FowlPlay surfaces

### DIFF
--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -116,6 +116,14 @@ export interface SessionDeps {
   git?: GitPort;
   /** Emit a message to the webview. */
   post(msg: HostToWebview): void;
+  /**
+   * Called after this session commits a settings mutation (provider add/update/
+   * delete, default-model change, appearance, harness). Lets the host broadcast a
+   * reload to sibling sessions so they refresh their own settings caches. Fired
+   * after the save + local re-send, so the shared store on disk is current when
+   * siblings reload. Never invoked by `reloadSettings` (that would loop).
+   */
+  onSettingsChanged?: () => void;
   /** Open a new tab seeded with a forked conversation + copied staging. */
   openTab?: (conv: Conversation, overlay: SerializedOverlay) => void;
   /** Injectable for tests; defaults to the real core factory. */
@@ -244,6 +252,7 @@ export class SessionCore {
         // model pick) inherit it instead of reopening on "Select model".
         void this.deps.settings.saveDefaultModel(msg.model);
         if (this.settingsCache) this.settingsCache = { ...this.settingsCache, defaultModel: msg.model };
+        this.deps.onSettingsChanged?.();
         return;
       case 'setHarnessMode':
         this.conv = { ...this.conv, harnessMode: msg.mode, updatedAt: this.clock() };
@@ -303,15 +312,19 @@ export class SessionCore {
         await this.onNewConversation();
         return;
       case 'getSettings':
-        await this.sendSettings();
+        // Force a disk read: cheap, and it guards against any missed broadcast
+        // (e.g. a settings mutation in a sibling surface that never reached here).
+        await this.sendSettings(true);
         return;
       case 'saveAppearance':
         await this.deps.settings.saveAppearance(msg.appearance);
         await this.sendSettings(true);
+        this.deps.onSettingsChanged?.();
         return;
       case 'saveHarnessSettings':
         await this.deps.settings.saveHarness(msg.harness);
         await this.sendSettings(true);
+        this.deps.onSettingsChanged?.();
         return;
       case 'addProvider':
       case 'updateProvider':
@@ -347,6 +360,26 @@ export class SessionCore {
     // A selection delivered before the webview mounted (freshly opened tab) had
     // its chip message dropped; re-surface it now that the webview is listening.
     if (this.pendingSelection) this.deps.post({ type: 'selectionContext', context: this.pendingSelection });
+  }
+
+  /**
+   * Force-reload settings from the shared store and re-send them, then — if this
+   * session's conversation is still brand-new and modelless — adopt the freshly
+   * loaded default model / harness mode (mirroring `onReady`'s inheritance) and
+   * re-send the conversation. This is how a sibling surface (e.g. the sidebar
+   * stuck on "Select model") flips to ready the moment a provider is added in a
+   * tab. Must NOT invoke `onSettingsChanged` — that would loop the broadcast.
+   */
+  async reloadSettings(): Promise<void> {
+    await this.sendSettings(true);
+    if (this.conv.currentLeafId === null && this.conv.model === null && this.settingsCache) {
+      this.conv = {
+        ...this.conv,
+        model: this.settingsCache.defaultModel,
+        harnessMode: this.settingsCache.harness.defaultMode,
+      };
+      this.sendConversation();
+    }
   }
 
   private async ensureSettings(): Promise<FowlPlaySettings> {
@@ -962,6 +995,7 @@ export class SessionCore {
     await this.deps.settings.saveProviders(providers);
     if (apiKey !== undefined && apiKey !== '') await this.deps.secrets.set(provider.id, apiKey);
     await this.sendSettings(true);
+    this.deps.onSettingsChanged?.();
   }
 
   private async onDeleteProvider(providerId: string): Promise<void> {
@@ -974,6 +1008,7 @@ export class SessionCore {
       this.sendConversation();
     }
     await this.sendSettings(true);
+    this.deps.onSettingsChanged?.();
   }
 
   private async onFetchModels(providerId: string): Promise<void> {

--- a/src/extension/tabManager.ts
+++ b/src/extension/tabManager.ts
@@ -27,6 +27,13 @@ interface Seed {
 export class TabManager {
   private readonly panels = new Set<vscode.WebviewPanel>();
   private readonly sessions = new WeakMap<vscode.WebviewPanel, SessionCore>();
+  /**
+   * Every live session across all surfaces (editor-area panels + the sidebar
+   * view). The WeakMap above can't be iterated, so this backs settings
+   * broadcasts and reset re-syncs. Entries are added in `attachSession` and
+   * removed when the owning panel / view is disposed.
+   */
+  private readonly liveSessions = new Set<SessionCore>();
   /** The activity-bar view (fowlplay.home) and its session, once resolved. */
   private homeView: vscode.WebviewView | null = null;
   private homeSession: SessionCore | null = null;
@@ -58,7 +65,10 @@ export class TabManager {
     const session = this.attachSession(panel.webview, seed);
     this.sessions.set(panel, session);
     this.panels.add(panel);
-    panel.onDidDispose(() => this.panels.delete(panel));
+    panel.onDidDispose(() => {
+      this.panels.delete(panel);
+      this.liveSessions.delete(session);
+    });
     return panel;
   }
 
@@ -71,8 +81,10 @@ export class TabManager {
     view.webview.html = this.html(view.webview);
     // Track the view + session so editSelection can target the sidebar chat.
     this.homeView = view;
-    this.homeSession = this.attachSession(view.webview);
+    const session = this.attachSession(view.webview);
+    this.homeSession = session;
     view.onDidDispose(() => {
+      this.liveSessions.delete(session);
       if (this.homeView === view) {
         this.homeView = null;
         this.homeSession = null;
@@ -160,14 +172,37 @@ export class TabManager {
     ]) {
       await cfg.update(key, undefined, t);
     }
-    // Re-sync any open tabs.
-    for (const panel of this.panels) {
-      void this.sessions.get(panel)?.handle({ type: 'getSettings' });
+    // Re-sync every live surface (panels AND the sidebar view). getSettings now
+    // force-reloads from disk, so this reflects the just-cleared providers.
+    for (const session of this.liveSessions) {
+      void session.handle({ type: 'getSettings' });
+    }
+  }
+
+  /**
+   * A session committed a settings mutation: tell every OTHER live session to
+   * reload from the shared store. The originator already re-sent its own
+   * settings, so it is skipped to avoid a redundant double post. Fire-and-forget,
+   * wrapped so one failing session can't break the loop.
+   */
+  private broadcastSettingsChanged(originator: SessionCore): void {
+    for (const session of this.liveSessions) {
+      if (session === originator) continue;
+      try {
+        void session.reloadSettings().catch(() => {
+          /* a stale sibling must not break the broadcast */
+        });
+      } catch {
+        /* ignore synchronous failures too */
+      }
     }
   }
 
   private attachSession(webview: vscode.Webview, seed?: Seed): SessionCore {
     const io = WorkspaceIo.forActiveWorkspace();
+    // `session` is referenced by the onSettingsChanged closure below; it is
+    // assigned before any message (hence any mutation) can arrive.
+    let session: SessionCore;
     const deps: SessionDeps = {
       io: io ?? nullIo(),
       secrets: this.secrets,
@@ -180,8 +215,10 @@ export class TabManager {
       openTab: (conversation, overlay) => {
         this.openTab({ conversation, overlay });
       },
+      onSettingsChanged: () => this.broadcastSettingsChanged(session),
     };
-    const session = createSessionCore(deps, seed ? { conversation: seed.conversation, overlay: seed.overlay } : undefined);
+    session = createSessionCore(deps, seed ? { conversation: seed.conversation, overlay: seed.overlay } : undefined);
+    this.liveSessions.add(session);
     webview.onDidReceiveMessage((msg: WebviewToHost) => {
       void session.handle(msg);
     });

--- a/test/extension-session.test.ts
+++ b/test/extension-session.test.ts
@@ -196,6 +196,8 @@ function makeSession(opts: { mode?: HarnessMode; path?: string; content?: string
   const posted: HostToWebview[] = [];
   const { adapter, requests } = scriptedAdapter(opts.path, opts.content);
   const settings = new FakeSettings(opts.mode ?? 'solo');
+  // Count broadcast triggers so tests can assert which mutations notify siblings.
+  const changed = { count: 0 };
   const deps: SessionDeps = {
     io,
     secrets: new FakeSecrets(),
@@ -206,9 +208,12 @@ function makeSession(opts: { mode?: HarnessMode; path?: string; content?: string
     createAdapter: () => adapter,
     fetchModels: async () => [{ id: 'm1' }],
     clock: () => Date.now(),
+    onSettingsChanged: () => {
+      changed.count += 1;
+    },
   };
   const session = createSessionCore(deps);
-  return { session, posted, io, requests, settings };
+  return { session, posted, io, requests, settings, changed };
 }
 
 function lastConversation(posted: HostToWebview[]): Conversation | undefined {
@@ -654,5 +659,129 @@ describe('coop pipeline', () => {
     // Scout+Inspector+Sentry each spend 5in/3out; the Builder loop makes two
     // model calls (edit round + finish round), so totals must exceed 3 calls.
     expect(conv.usageTotals.inputTokens).toBeGreaterThan(3 * 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-surface settings sync
+// ---------------------------------------------------------------------------
+
+const PROVIDER_2: ProviderConfig = {
+  id: 'p2',
+  name: 'LM Studio',
+  kind: 'local',
+  sdkType: 'openai-completions',
+  baseUrl: 'http://localhost:1234/v1',
+  requiresApiKey: false,
+  models: [{ id: 'lm-1' }],
+};
+
+/** The provider list carried by the last posted `settings` message. */
+function lastSettingsProviders(posted: HostToWebview[]): ProviderConfig[] | undefined {
+  for (let i = posted.length - 1; i >= 0; i--) {
+    const m = posted[i];
+    if (m.type === 'settings') return m.settings.providers;
+  }
+  return undefined;
+}
+
+describe('settings mutations notify siblings (onSettingsChanged)', () => {
+  it('fires when a provider is added', async () => {
+    const { session, changed } = makeSession();
+    await session.handle({ type: 'ready' });
+    const before = changed.count;
+    await session.handle({ type: 'addProvider', provider: PROVIDER_2 });
+    expect(changed.count).toBe(before + 1);
+  });
+
+  it('fires when a provider is deleted', async () => {
+    const { session, changed } = makeSession();
+    await session.handle({ type: 'ready' });
+    const before = changed.count;
+    await session.handle({ type: 'deleteProvider', providerId: 'p1' });
+    expect(changed.count).toBe(before + 1);
+  });
+
+  it('fires when the model (default) changes', async () => {
+    const { session, changed } = makeSession();
+    await session.handle({ type: 'ready' });
+    const before = changed.count;
+    await session.handle({ type: 'setModel', model: { providerId: 'p1', modelId: 'm2' } });
+    expect(changed.count).toBe(before + 1);
+  });
+});
+
+describe('reloadSettings', () => {
+  it('re-sends settings reflecting providers written to the store after the cache was warmed', async () => {
+    const { session, posted, settings } = makeSession();
+    // Warm this session's cache with the original single-provider settings.
+    await session.handle({ type: 'ready' });
+    expect(lastSettingsProviders(posted)!.map((p) => p.id)).toEqual(['p1']);
+
+    // A sibling surface adds a provider directly to the shared store.
+    settings.providers = [PROVIDER, PROVIDER_2];
+
+    const before = posted.length;
+    await session.reloadSettings();
+
+    // reloadSettings force-reloads from disk, so the fresh provider is surfaced
+    // even though this session had already cached the older list.
+    const providers = lastSettingsProviders(posted.slice(before));
+    expect(providers).toBeDefined();
+    expect(providers!.map((p) => p.id)).toEqual(['p1', 'p2']);
+  });
+
+  it('adopts a newly written defaultModel into a brand-new, modelless conversation', async () => {
+    const { session, posted, settings } = makeSession();
+    // Do NOT call ready: the conversation stays brand-new (no leaf, no model).
+    settings.defaultModel = { providerId: 'p2', modelId: 'lm-1' };
+    settings.providers = [PROVIDER, PROVIDER_2];
+
+    await session.reloadSettings();
+
+    const conv = lastConversation(posted);
+    expect(conv).toBeDefined();
+    expect(conv!.model).toEqual({ providerId: 'p2', modelId: 'lm-1' });
+  });
+
+  it('does not overwrite the model of a conversation that already has one', async () => {
+    const { session, posted, settings } = makeSession();
+    // ready seeds the conversation with the current default (m1).
+    await session.handle({ type: 'ready' });
+    expect(lastConversation(posted)!.model).toEqual({ providerId: 'p1', modelId: 'm1' });
+
+    // The store's default changes elsewhere, but this conversation already has a model.
+    settings.defaultModel = { providerId: 'p2', modelId: 'lm-1' };
+    await session.reloadSettings();
+
+    expect(lastConversation(posted)!.model).toEqual({ providerId: 'p1', modelId: 'm1' });
+  });
+
+  it('does not adopt a default model into a conversation that already has messages', async () => {
+    const { session, posted, settings } = makeSession({ path: 'foo.txt', content: 'x\n' });
+    await session.handle({ type: 'ready' });
+    // Send a prompt so the conversation has a leaf, then clear its model to prove
+    // the guard keys off currentLeafId (a touched conversation), not just model.
+    await session.handle({ type: 'sendPrompt', text: 'create foo.txt' });
+    await session.handle({ type: 'deleteProvider', providerId: 'p1' }); // clears conv.model (its provider)
+    expect(lastConversation(posted)!.model).toBeNull();
+
+    settings.defaultModel = { providerId: 'p2', modelId: 'lm-1' };
+    settings.providers = [PROVIDER, PROVIDER_2];
+    await session.reloadSettings();
+
+    // The conversation has messages (a non-null leaf), so the fresh default is
+    // NOT adopted — the model stays null.
+    expect(lastConversation(posted)!.model).toBeNull();
+  });
+
+  it('does not itself trigger a broadcast (no echo loop)', async () => {
+    const { session, settings, changed } = makeSession();
+    await session.handle({ type: 'ready' });
+    settings.providers = [PROVIDER, PROVIDER_2];
+
+    const before = changed.count;
+    await session.reloadSettings();
+    expect(changed.count).toBe(before);
   });
 });


### PR DESCRIPTION
Fixes providers/models added in one FowlPlay surface not appearing in others (e.g. LM Studio configured in an editor tab was invisible to the sidebar chat, which kept showing "No models / Select model" until a full window reload).

- Every settings mutation (add/update/delete provider, model default, appearance, harness) fires `onSettingsChanged`; `TabManager` broadcasts a force-reload to every other live session — the sidebar view included — with guards against echo loops and one failing surface breaking the loop
- Brand-new model-less conversations adopt a freshly-set default model automatically (sidebar becomes ready the moment a provider is added anywhere)
- `getSettings` now always force-reads from disk; Reset Settings re-syncs all surfaces via the live-session set instead of panels only

Verification: `tsc --noEmit` clean, 176/176 unit tests (8 new), 54/54 e2e, `npm run build` succeeds. No protocol changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG)_