### PR TITLE
Per-role models, context budgets, PRD story builds, expanded e2e coverage

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -149,6 +149,7 @@ you typed isn't a command, just press **Enter** to send it as an ordinary prompt
 | `/model` | Switch the active model (opens a provider/model picker) |
 | `/solo` | Switch to Solo (direct single-agent) mode |
 | `/coop` | Switch to Coop (cooperative pipeline) mode |
+| `/prd` | Arm the next message as a **PRD build** — decompose it into stories and build them one at a time (see §7) |
 | `/diff` (`/review`) | Review the staged changes |
 | `/fork` | Fork this conversation into a new tab |
 | `/export` | Copy the conversation as Markdown or JSON |
@@ -197,6 +198,36 @@ Toggle the mode in the status line.
 Each stage emits an **evidence gate card** in the chat so you can see what was checked and
 why it passed. QA and Security gates can't be bypassed. Coop is what makes local models
 reliable: their output is verified before it reaches you.
+
+### PRD builds — long-horizon work
+
+A whole PRD (product requirements doc) is too big to build in one changeset. Run **`/prd`**
+to break it into a sequence of small stories and build them one at a time, with a human
+review between each.
+
+1. Type **`/prd`** — a **PRD build** chip appears above the composer (the `⚑` badge next to
+   your attachments). The `X` on the chip disarms it if you change your mind.
+2. Paste or type the PRD and send. The chip means *this one message* is treated as a PRD;
+   ordinary sends are unaffected.
+3. A **Foreman** gate card decomposes the PRD into 2–12 ordered, independently-buildable
+   **stories**, each with a title, summary, and its own acceptance criteria. Each story is
+   also written to disk as a spec under `.fowlplay/specs/<conversation>/NN-<slug>.md` so you
+   have a durable, editable record outside the chat.
+4. **Story 1 builds immediately** through the normal Coop pipeline (Scout → Builder →
+   Inspector → Sentry → your review), and a **plan block** shows the whole story list with a
+   status glyph each: ○ pending, spinner building, ◉ awaiting review, ✓ done, ✕ failed.
+5. Review story 1's diff as usual (apply, comment, revert, send feedback). When you're
+   satisfied, press **Continue — next story** on the plan block. That marks the story done
+   and builds the next one as a fresh turn. If a story failed, the button reads **Continue
+   anyway** — moving on is your call, and the skip is noted in that story's spec file.
+6. When the last story is done, a short **completion summary** lists every story's final
+   status.
+
+The plan lives on the conversation, so it survives save/reload and shows the live status
+each time you reopen it. If the Foreman can't produce at least two buildable stories, it
+blocks with guidance instead of creating a plan — rephrase or split the PRD, or send it as a
+normal request. Normal prompts between stories run exactly as usual and leave the plan
+untouched; starting a new conversation clears the plan with it.
 
 ---
 

--- a/e2e/mockBridge.js
+++ b/e2e/mockBridge.js
@@ -7,7 +7,11 @@
  *  - window.__fowlplayBridge       : the bridge the webview bundle picks up
  *
  * On the UI's 'ready' message a scripted scenario runs, selected by URL hash:
- *   #chat #diff #settings #onboarding #stream   (default: #chat)
+ *   #chat #diff #settings #onboarding #stream #history #history-diff #selection
+ *   #prd-plan #markdown   (default: #chat)
+ *
+ * window.__fixtures exposes fixture builders (prdConversation, markdownConversation)
+ * so a test can re-inject variants mid-scenario via window.__host.emit().
  */
 (function () {
   const handlers = [];
@@ -368,6 +372,100 @@
     };
   }
 
+  // A PRD-build conversation: a `plan` marker block plus a live `prdPlan` of three
+  // stories. `cursorStatus` sets the status of the cursor story (index 1) so a test
+  // can exercise every "Continue" button label. The other two stories stay fixed
+  // (story 1 done, story 3 pending) so exactly one story reads as done.
+  function prdStory(title, status) {
+    return {
+      title,
+      summary: `${title} — one-line summary`,
+      criteria: [`${title} behaves as specified`],
+      specPath: `.fowlplay/prd/${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}.md`,
+      status,
+    };
+  }
+
+  function prdConversation(cursorStatus) {
+    const stories = [
+      prdStory('Story 1 — schema', 'done'),
+      prdStory('Story 2 — endpoint', cursorStatus || 'awaiting-review'),
+      prdStory('Story 3 — UI', 'pending'),
+    ];
+    const u = {
+      id: 'u1', parentId: null, role: 'user',
+      blocks: [{ type: 'text', text: 'Build this PRD end to end.' }],
+      createdAt: now - 60000,
+    };
+    const a = {
+      id: 'a1', parentId: 'u1', role: 'assistant',
+      blocks: [
+        { type: 'text', text: 'Decomposed the PRD into three stories; building them one by one.' },
+        { type: 'plan' },
+      ],
+      createdAt: now - 30000,
+      model: { providerId: 'prov-ollama', modelId: 'qwen2.5-coder:32b' },
+      usage: { inputTokens: 500, outputTokens: 200, cachedTokens: 0 },
+    };
+    return {
+      type: 'conversation',
+      conversation: {
+        id: 'conv-prd', title: 'PRD build',
+        nodes: { u1: u, a1: a },
+        rootIds: ['u1'], currentLeafId: 'a1',
+        model: { providerId: 'prov-ollama', modelId: 'qwen2.5-coder:32b' },
+        harnessMode: 'coop',
+        prdPlan: { stories, cursor: 1 },
+        createdAt: now - 60000, updatedAt: now,
+        usageTotals: { inputTokens: 500, outputTokens: 200, cachedTokens: 0 },
+      },
+    };
+  }
+
+  // A conversation whose only assistant text exercises the markdown list renderer:
+  // a numbered list with nested bullets between items (the Scout/Builder shape that
+  // used to fragment into multiple <ol>s), plus emphasis wrapping an inline-code span.
+  function markdownConversation() {
+    const md =
+      'Here is the plan:\n\n' +
+      '1. Parse the request into acceptance criteria\n' +
+      '   - restate the ask\n' +
+      '   - list the edge cases\n' +
+      '2. Implement the change\n' +
+      '   - update `login()`\n' +
+      '   - add `AuthError`\n' +
+      '3. Cover it with a test\n\n' +
+      'This is **bold with `code` inside** to prove emphasis wraps a code span.';
+    const u = {
+      id: 'u1', parentId: null, role: 'user',
+      blocks: [{ type: 'text', text: 'Outline the plan.' }],
+      createdAt: now - 60000,
+    };
+    const a = {
+      id: 'a1', parentId: 'u1', role: 'assistant',
+      blocks: [{ type: 'text', text: md }],
+      createdAt: now - 30000,
+      model: { providerId: 'prov-ollama', modelId: 'qwen2.5-coder:32b' },
+      usage: { inputTokens: 200, outputTokens: 80, cachedTokens: 0 },
+    };
+    return {
+      type: 'conversation',
+      conversation: {
+        id: 'conv-md', title: 'Markdown rendering',
+        nodes: { u1: u, a1: a },
+        rootIds: ['u1'], currentLeafId: 'a1',
+        model: { providerId: 'prov-ollama', modelId: 'qwen2.5-coder:32b' },
+        harnessMode: 'coop',
+        createdAt: now - 60000, updatedAt: now,
+        usageTotals: { inputTokens: 200, outputTokens: 80, cachedTokens: 0 },
+      },
+    };
+  }
+
+  // Expose fixture builders so a test can re-inject variants mid-scenario (e.g. the
+  // same PRD plan with a different cursor-story status) via window.__host.emit().
+  window.__fixtures = { prdConversation, markdownConversation };
+
   // --------------------------------------------------------------------------
   // Scenarios
   // --------------------------------------------------------------------------
@@ -403,6 +501,14 @@
         emit(settings(true));
         emit(conversationList());
         setView('history');
+        break;
+      case 'prd-plan':
+        emit(settings(true));
+        emit(prdConversation('awaiting-review'));
+        break;
+      case 'markdown':
+        emit(settings(true));
+        emit(markdownConversation());
         break;
       case 'selection':
         emit(settings(true));

--- a/e2e/mockBridge.js
+++ b/e2e/mockBridge.js
@@ -38,6 +38,11 @@
       if (msg && msg.type === 'clearSelection') {
         emit({ type: 'selectionContext', context: null });
       }
+      // Model-mention disambiguation answered → the real host would apply/dismiss
+      // and release the held prompt. The mock just acks (no scripted flow needs it).
+      if (msg && msg.type === 'resolveModelMention') {
+        /* no-op ack — protocol stays mirrored */
+      }
     },
     onMessage(handler) {
       handlers.push(handler);

--- a/e2e/mockBridge.js
+++ b/e2e/mockBridge.js
@@ -43,6 +43,12 @@
       if (msg && msg.type === 'resolveModelMention') {
         /* no-op ack — protocol stays mirrored */
       }
+      // A PRD send (sendPrompt with prd:true) is treated as a normal send here; the
+      // `prd` flag is accepted so the protocol stays mirrored. continueStoryLoop is
+      // acked as a no-op — no scripted scenario drives the per-story loop.
+      if (msg && msg.type === 'continueStoryLoop') {
+        /* no-op ack — protocol stays mirrored */
+      }
     },
     onMessage(handler) {
       handlers.push(handler);

--- a/e2e/run.mjs
+++ b/e2e/run.mjs
@@ -241,6 +241,190 @@ await waitFor(page, () => document.body.innerText.includes('Sentry — security 
 await waitFor(page, () => /3 files/.test(document.body.innerText), 'final changes block appears', 8000);
 await page.screenshot({ path: join(SHOTS, 'stream.png'), fullPage: false });
 
+// ============================== SLASH MENU ===================================
+console.log('\n# slash menu');
+await open('chat');
+const composer = () => page.locator('.fp-composer-textarea');
+// Typing '/' opens the command popup listing every command with its description.
+await composer().fill('/');
+await waitFor(page, () => !!document.querySelector('.fp-slash-menu'), 'slash popup opens on /');
+await waitFor(page, () => document.body.innerText.includes('Start a new conversation'), 'command descriptions render');
+// Typing 'mo' ranks /model to the top (prefix match) as the highlighted row.
+await composer().fill('/mo');
+await waitFor(
+  page,
+  () => document.querySelector('.fp-slash-item[aria-selected="true"] .fp-slash-name')?.textContent === '/model',
+  '/mo highlights /model',
+);
+// Enter opens the model submenu: providers grouped, models listed.
+await composer().press('Enter');
+await waitFor(page, () => document.querySelector('.fp-slash-header')?.textContent?.includes('Switch model') ?? false, 'model submenu header');
+await waitFor(page, () => {
+  const groups = Array.from(document.querySelectorAll('.fp-menu-group-label')).map((n) => n.textContent);
+  return groups.includes('Ollama (local)') && groups.includes('Anthropic');
+}, 'model submenu groups providers');
+await waitFor(page, () => {
+  const names = Array.from(document.querySelectorAll('.fp-slash-name')).map((n) => n.textContent);
+  return names.includes('Qwen2.5 Coder 32B') && names.includes('Claude Sonnet 4');
+}, 'model submenu lists mock models');
+await page.screenshot({ path: join(SHOTS, 'slash-model.png'), fullPage: false });
+// Escape steps back from the submenu to the command list.
+await composer().press('Escape');
+await waitFor(page, () => !document.querySelector('.fp-slash-header'), 'Escape leaves the model submenu');
+await waitFor(page, () => document.body.innerText.includes('Start a new conversation'), 'Escape returns to command list');
+// Re-open the submenu and pick a model → setModel post with the chosen ref.
+await composer().fill('/mo');
+await composer().press('Enter');
+await page.locator('.fp-slash-item', { hasText: 'Claude Sonnet 4' }).first().click();
+ok(
+  (await sent(page, 'setModel')).some((m) => m.model?.providerId === 'prov-anthropic' && m.model?.modelId === 'claude-sonnet-4'),
+  'picking a model posts setModel',
+);
+// /status renders the ephemeral local status card (model + mode present).
+await composer().fill('/status');
+await composer().press('Enter');
+await waitFor(page, () => !!document.querySelector('.fp-status-card'), '/status renders the status card');
+await waitFor(page, () => {
+  const t = document.querySelector('.fp-status-card')?.textContent ?? '';
+  return t.includes('Qwen2.5 Coder 32B') && t.includes('Coop (pipeline)');
+}, 'status card shows model name and mode');
+await page.screenshot({ path: join(SHOTS, 'slash-status.png'), fullPage: false });
+await page.locator('.fp-status-card button[aria-label="Dismiss status"]').click();
+// /clear starts a new conversation.
+await composer().fill('/clear');
+await composer().press('Enter');
+ok((await sent(page, 'newConversation')).length >= 1, '/clear posts newConversation');
+// A leading-slash string that matches nothing is sent as an ordinary prompt.
+await composer().fill('/notacommand');
+await composer().press('Enter');
+ok((await sent(page, 'sendPrompt')).some((m) => m.text === '/notacommand'), 'unknown /command sends as a prompt');
+
+// ============================== CONTEXT INDICATOR ============================
+console.log('\n# context indicator');
+await open('chat');
+// Model contextWindow 32768, last assistant input 8450 → ~26%; cumulative tokens shown.
+await waitFor(page, () => document.querySelector('.fp-context')?.textContent?.includes('26%') ?? false, 'status line shows context percentage');
+await waitFor(page, () => /↑8\.\dk/.test(document.querySelector('.fp-tokens')?.textContent ?? ''), 'status line shows tokens counter');
+
+// ============================== MENTION PICKER ===============================
+console.log('\n# model-mention picker');
+await open('chat');
+const injectMention = () =>
+  page.evaluate(() =>
+    window.__host.emit({
+      type: 'modelMentionChoice',
+      role: 'conversation',
+      query: 'qwen',
+      candidates: [
+        { providerId: 'prov-ollama', modelId: 'qwen2.5-coder:32b', label: 'Qwen2.5 Coder 32B' },
+        { providerId: 'prov-anthropic', modelId: 'claude-sonnet-4', label: 'Claude Sonnet 4' },
+      ],
+    }),
+  );
+await injectMention();
+await waitFor(page, () => !!document.querySelector('.fp-mention-card'), 'mention picker card renders');
+await waitFor(page, () => document.querySelector('.fp-mention-head')?.textContent?.includes('qwen') ?? false, 'mention card shows the query');
+await waitFor(page, () => {
+  const labels = Array.from(document.querySelectorAll('.fp-mention-label')).map((n) => n.textContent);
+  return labels.includes('Qwen2.5 Coder 32B') && labels.includes('Claude Sonnet 4');
+}, 'mention card lists both candidate labels');
+await page.screenshot({ path: join(SHOTS, 'mention-picker.png'), fullPage: false });
+await page.locator('.fp-mention-option').first().click();
+ok(
+  (await sent(page, 'resolveModelMention')).some((m) => m.model?.modelId === 'qwen2.5-coder:32b' && m.model?.providerId === 'prov-ollama'),
+  'picking a candidate posts resolveModelMention with the ModelRef',
+);
+// Re-inject and dismiss via the X → resolves with model: null.
+await injectMention();
+await waitFor(page, () => !!document.querySelector('.fp-mention-card'), 'mention picker re-renders');
+await page.locator('.fp-mention-card button[aria-label*="Dismiss"]').click();
+ok(
+  (await sent(page, 'resolveModelMention')).some((m) => m.model === null),
+  'dismissing the picker posts resolveModelMention with model: null',
+);
+
+// ============================== PRD PLAN BLOCK ===============================
+console.log('\n# prd plan block');
+await open('prd-plan');
+await waitFor(page, () => !!document.querySelector('.fp-plan'), 'plan block renders');
+await waitFor(page, () => {
+  const titles = Array.from(document.querySelectorAll('.fp-plan-story-title')).map((n) => n.textContent);
+  return ['Story 1 — schema', 'Story 2 — endpoint', 'Story 3 — UI'].every((t) => titles.includes(t));
+}, 'plan checklist lists all story titles');
+await waitFor(page, () => document.querySelector('.fp-plan-count')?.textContent === '1 of 3 done', 'plan shows "1 of 3 done"');
+ok((await page.locator('.fp-plan-story .fp-plan-glyph').count()) === 3, 'each story renders a status glyph');
+ok(await page.getByRole('button', { name: /Continue — next story/ }).isVisible().catch(() => false), 'awaiting-review cursor shows "Continue — next story"');
+await page.screenshot({ path: join(SHOTS, 'prd-plan.png'), fullPage: false });
+await page.getByRole('button', { name: /Continue — next story/ }).click();
+ok((await sent(page, 'continueStoryLoop')).length >= 1, 'Continue button posts continueStoryLoop');
+// Re-inject the same plan with the cursor story pending → "Resume story 2".
+await page.evaluate(() => window.__host.emit(window.__fixtures.prdConversation('pending')));
+await waitFor(page, () => !!document.querySelector('.fp-plan') && !!Array.from(document.querySelectorAll('button')).find((b) => /Resume story 2/.test(b.textContent || '')), 'pending cursor shows "Resume story 2"');
+// …and with the cursor story failed → "Continue anyway".
+await page.evaluate(() => window.__host.emit(window.__fixtures.prdConversation('failed')));
+await waitFor(page, () => !!Array.from(document.querySelectorAll('button')).find((b) => /Continue anyway/.test(b.textContent || '')), 'failed cursor shows "Continue anyway"');
+
+// ============================== PRD CHIP =====================================
+console.log('\n# prd chip');
+await open('chat');
+await composer().fill('/prd');
+await composer().press('Enter');
+await waitFor(page, () => !!document.querySelector('.fp-prd-chip'), '/prd arms the PRD build chip');
+await waitFor(page, () => document.querySelector('.fp-prd-chip')?.textContent?.includes('PRD build') ?? false, 'PRD chip labels itself');
+await page.screenshot({ path: join(SHOTS, 'prd-chip.png'), fullPage: false });
+await composer().fill('Build the whole PRD');
+await composer().press('Enter');
+ok((await sent(page, 'sendPrompt')).some((m) => m.text === 'Build the whole PRD' && m.prd === true), 'armed send posts sendPrompt with prd:true');
+// The chip disarms after one send — the next message carries no prd flag.
+await composer().fill('Just a normal follow-up');
+await composer().press('Enter');
+ok((await sent(page, 'sendPrompt')).some((m) => m.text === 'Just a normal follow-up' && !m.prd), 'subsequent send omits the prd flag');
+
+// ============================== MARKDOWN REGRESSION ==========================
+console.log('\n# markdown regression');
+await open('markdown');
+await waitFor(page, () => document.querySelectorAll('.fp-msg-assistant .fp-md ol').length === 1, 'numbered list renders a single <ol>');
+ok(
+  await page.evaluate(() => document.querySelectorAll('.fp-msg-assistant .fp-md ol > li').length === 3),
+  'the single <ol> has three list items (numbering continuous, not restarting)',
+);
+ok(
+  await page.evaluate(() => document.querySelectorAll('.fp-msg-assistant .fp-md ol > li ul').length >= 1),
+  'nested <ul> bullets render inside the numbered items',
+);
+ok(
+  await page.evaluate(() => {
+    const strong = Array.from(document.querySelectorAll('.fp-msg-assistant .fp-md strong')).find((s) => s.querySelector('code'));
+    return !!strong && !(strong.textContent || '').includes('**');
+  }),
+  'emphasis wraps an inline <code> with no literal ** in the text',
+);
+await page.screenshot({ path: join(SHOTS, 'markdown.png'), fullPage: false });
+
+// ============================== GATE MODEL LABEL =============================
+console.log('\n# gate model label');
+await open('chat');
+await page.evaluate(() =>
+  window.__host.emit({
+    type: 'gateUpdate',
+    card: {
+      id: 'gate-builder-model',
+      role: 'builder',
+      title: 'Builder — implementation',
+      status: 'passed',
+      modelLabel: 'Claude Sonnet 4',
+      evidence: 'Applied the edits and ran the build.',
+      usage: { inputTokens: 4200, outputTokens: 800, cachedTokens: 0 },
+    },
+  }),
+);
+await waitFor(page, () => document.querySelector('.fp-gate-model')?.textContent === 'Claude Sonnet 4', 'gate card shows its model label');
+await waitFor(page, () => {
+  const u = document.querySelector('.fp-gate-usage')?.textContent ?? '';
+  return u.includes('4.2k') && u.includes('800');
+}, 'gate card shows its token usage');
+await page.screenshot({ path: join(SHOTS, 'gate-model.png'), fullPage: false });
+
 // ============================== THEME ========================================
 console.log('\n# theme');
 const accent = await page.evaluate(() =>

--- a/src/core/agent/contextBudget.ts
+++ b/src/core/agent/contextBudget.ts
@@ -1,0 +1,275 @@
+/**
+ * Context-window budgeting.
+ *
+ * FowlPlay knows each model's context window (`ModelConfig.contextWindow`) and
+ * resolves a model per Coop role. This module turns that knowledge into concrete
+ * mechanism, so a big changeset or a long conversation does not overrun a small
+ * local model and surface as a raw provider error:
+ *
+ *  - `estimateTokens` — a cheap chars/4 heuristic (never a real tokenizer).
+ *  - `fitDiffToBudget` — split a unified diff at file boundaries and pack whole
+ *    files into as few chunks as fit, so a review role (Inspector/Sentry) can run
+ *    once per chunk instead of choking on the whole diff.
+ *  - `trimWireToBudget` — drop the oldest whole turns from a wire history so the
+ *    most recent turn always fits, never touching the newest user message.
+ *
+ * Pure TypeScript — no `vscode`, no Node built-ins. The caller always passes a
+ * budget that is ALREADY net of system-prompt / instruction / response overhead.
+ */
+
+import type { WireMessage } from '../providers/adapter';
+
+// ---------------------------------------------------------------------------
+// Estimation
+// ---------------------------------------------------------------------------
+
+/** Cheap token estimate: ~4 characters per token, rounded up. */
+export function estimateTokens(s: string): number {
+  if (!s) return 0;
+  return Math.ceil(s.length / 4);
+}
+
+/** Small fixed cost charged per tool call / tool result (framing, ids, keys). */
+const PART_OVERHEAD = 8;
+/** Nominal cost for an inline image part (they never dominate a trim decision). */
+const IMAGE_TOKENS = 256;
+
+/** Estimate a single wire message's token footprint. */
+function messageTokens(m: WireMessage): number {
+  if (m.role === 'tool') {
+    return m.results.reduce((n, r) => n + estimateTokens(r.content) + PART_OVERHEAD, 0);
+  }
+  let sum = 0;
+  for (const part of m.content) {
+    if (part.type === 'text' || part.type === 'thinking') {
+      sum += estimateTokens(part.text);
+    } else if (part.type === 'tool_call') {
+      sum += estimateTokens(safeJson(part.args)) + PART_OVERHEAD;
+    } else if (part.type === 'image') {
+      sum += IMAGE_TOKENS;
+    }
+  }
+  return sum;
+}
+
+/** Total estimated tokens for a wire history. */
+export function wireTokens(messages: WireMessage[]): number {
+  let sum = 0;
+  for (const m of messages) sum += messageTokens(m);
+  return sum;
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? '';
+  } catch {
+    return String(value);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Diff fitting
+// ---------------------------------------------------------------------------
+
+/** Maximum number of chunks a diff is ever split into for chunked review. */
+const MAX_CHUNKS = 4;
+
+function truncationMarker(hunks: number): string {
+  return `[... diff truncated to fit the model's context window — ${hunks} more hunk(s) not shown]`;
+}
+
+/**
+ * Split a unified diff to fit a per-call token budget.
+ *
+ *  - Fits entirely → a single chunk, byte-for-byte unchanged.
+ *  - Otherwise split at file boundaries (`--- a/` headers) and greedily pack
+ *    whole files into as few chunks as possible, each ≤ budget, capped at
+ *    {@link MAX_CHUNKS}.
+ *  - A single file bigger than the budget keeps its leading hunks up to budget
+ *    and gains a truncation marker; `truncated` becomes true.
+ *  - If even {@link MAX_CHUNKS} chunks cannot hold everything, the overflow is
+ *    folded into the last chunk's truncation marker rather than emitting more.
+ */
+export function fitDiffToBudget(
+  diff: string,
+  budgetTokens: number,
+): { chunks: string[]; truncated: boolean } {
+  if (estimateTokens(diff) <= budgetTokens) {
+    return { chunks: [diff], truncated: false };
+  }
+
+  const files = splitDiffByFile(diff);
+  let truncated = false;
+
+  // Normalize: any file that alone exceeds the budget is truncated to fit.
+  const units: string[] = [];
+  for (const file of files) {
+    if (estimateTokens(file) <= budgetTokens) {
+      units.push(file);
+    } else {
+      const t = truncateFileToBudget(file, budgetTokens);
+      if (t.droppedHunks > 0) truncated = true;
+      units.push(t.text);
+    }
+  }
+
+  // Greedy first-fit packing of whole files into chunks ≤ budget.
+  const chunks: string[] = [];
+  let current = '';
+  for (const unit of units) {
+    if (current === '') {
+      current = unit;
+      continue;
+    }
+    const combined = `${current}\n${unit}`;
+    if (estimateTokens(combined) <= budgetTokens) {
+      current = combined;
+    } else {
+      chunks.push(current);
+      current = unit;
+    }
+  }
+  if (current !== '') chunks.push(current);
+
+  // Cap the chunk count: fold overflow into the last kept chunk's marker.
+  if (chunks.length > MAX_CHUNKS) {
+    const kept = chunks.slice(0, MAX_CHUNKS);
+    const overflow = chunks.slice(MAX_CHUNKS);
+    const droppedHunks = overflow.reduce((n, c) => n + countHunks(c), 0);
+    kept[MAX_CHUNKS - 1] = `${kept[MAX_CHUNKS - 1]}\n${truncationMarker(droppedHunks)}`;
+    return { chunks: kept, truncated: true };
+  }
+
+  return { chunks, truncated };
+}
+
+/** Split a unified diff into per-file blocks, each starting at a `--- a/` header. */
+function splitDiffByFile(diff: string): string[] {
+  const lines = diff.split('\n');
+  const blocks: string[] = [];
+  let current: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith('--- a/') && current.length > 0) {
+      blocks.push(current.join('\n'));
+      current = [line];
+    } else {
+      current.push(line);
+    }
+  }
+  if (current.length > 0) blocks.push(current.join('\n'));
+  return blocks;
+}
+
+/** Separate a file block's header (`---`/`+++` lines) from its `@@` hunks. */
+function splitFileIntoHunks(fileBlock: string): { header: string; hunks: string[] } {
+  const lines = fileBlock.split('\n');
+  const header: string[] = [];
+  const hunks: string[] = [];
+  let current: string[] | null = null;
+  for (const line of lines) {
+    if (line.startsWith('@@')) {
+      if (current) hunks.push(current.join('\n'));
+      current = [line];
+    } else if (current) {
+      current.push(line);
+    } else {
+      header.push(line);
+    }
+  }
+  if (current) hunks.push(current.join('\n'));
+  return { header: header.join('\n'), hunks };
+}
+
+/** Keep a single file's leading hunks up to budget; append a marker for the rest. */
+function truncateFileToBudget(
+  fileBlock: string,
+  budgetTokens: number,
+): { text: string; droppedHunks: number } {
+  const { header, hunks } = splitFileIntoHunks(fileBlock);
+  const kept: string[] = [];
+  for (let i = 0; i < hunks.length; i += 1) {
+    const droppedIfStop = hunks.length - (i + 1);
+    const marker = droppedIfStop > 0 ? `\n${truncationMarker(droppedIfStop)}` : '';
+    const candidate = [header, ...kept, hunks[i]].join('\n');
+    if (estimateTokens(candidate + marker) <= budgetTokens) {
+      kept.push(hunks[i]);
+    } else {
+      break;
+    }
+  }
+  const droppedHunks = hunks.length - kept.length;
+  if (droppedHunks === 0) return { text: fileBlock, droppedHunks: 0 };
+  const text = `${[header, ...kept].join('\n')}\n${truncationMarker(droppedHunks)}`;
+  return { text, droppedHunks };
+}
+
+function countHunks(text: string): number {
+  let n = 0;
+  for (const line of text.split('\n')) if (line.startsWith('@@')) n += 1;
+  return n;
+}
+
+// ---------------------------------------------------------------------------
+// Wire history trimming
+// ---------------------------------------------------------------------------
+
+/** The synthetic note prepended once when earlier turns are dropped. */
+export const WIRE_TRIM_NOTE = '[earlier conversation trimmed to fit the model\'s context window]';
+
+function trimNoteMessage(): WireMessage {
+  return { role: 'user', content: [{ type: 'text', text: WIRE_TRIM_NOTE }] };
+}
+
+/**
+ * Drop the oldest whole turns from a wire history until it fits the budget.
+ *
+ * Invariants:
+ *  - The newest user message and everything after it are NEVER dropped.
+ *  - Turns are dropped oldest-first, in whole units (a user message plus every
+ *    message up to the next user message).
+ *  - When anything is dropped, a single synthetic user note is prepended.
+ *  - If the newest turn alone still exceeds the budget, it is returned anyway
+ *    (with the note if earlier turns were dropped) — the caller decides.
+ */
+export function trimWireToBudget(
+  messages: WireMessage[],
+  budgetTokens: number,
+): { messages: WireMessage[]; dropped: number } {
+  if (messages.length === 0) return { messages, dropped: 0 };
+
+  const userIdx: number[] = [];
+  messages.forEach((m, i) => {
+    if (m.role === 'user') userIdx.push(i);
+  });
+  // No user turns → nothing we can safely drop.
+  if (userIdx.length === 0) return { messages, dropped: 0 };
+
+  // Already fits → untouched.
+  if (wireTokens(messages) <= budgetTokens) return { messages, dropped: 0 };
+
+  // Drop-unit boundaries: unit 0 covers any leading orphan + the first user
+  // turn; each later unit starts at a user message. The final unit (the newest
+  // turn) is protected and never dropped.
+  const boundaries = [0];
+  for (let k = 1; k < userIdx.length; k += 1) boundaries.push(userIdx[k]);
+
+  const noteTokens = messageTokens(trimNoteMessage());
+  const tokensFrom = (idx: number): number => {
+    let sum = noteTokens;
+    for (let i = idx; i < messages.length; i += 1) sum += messageTokens(messages[i]);
+    return sum;
+  };
+
+  // Advance keepFrom one whole turn at a time until it fits or only the newest
+  // turn remains.
+  let keepFrom = 0;
+  for (let unit = 0; unit < boundaries.length - 1; unit += 1) {
+    keepFrom = boundaries[unit + 1];
+    if (tokensFrom(keepFrom) <= budgetTokens) break;
+  }
+
+  // Nothing could be dropped (single turn) → return untouched.
+  if (keepFrom === 0) return { messages, dropped: 0 };
+
+  return { messages: [trimNoteMessage(), ...messages.slice(keepFrom)], dropped: keepFrom };
+}

--- a/src/core/agent/modelMentions.ts
+++ b/src/core/agent/modelMentions.ts
@@ -1,0 +1,310 @@
+/**
+ * Deterministic chat-mention parsing for per-role model directives.
+ *
+ * A user can steer which model runs which Coop role in plain prose — e.g.
+ * "qwen to orchestrate", "build with glm", "use fable for review", or a
+ * role-less "use qwen" / "switch to qwen" that sets the conversation model.
+ *
+ * This module is a PURE, conservative recognizer: no `vscode`, no network, no
+ * fuzzy AI. The grammar is intentionally narrow — it is better to miss a
+ * directive than to false-positive on ordinary prose like
+ * "we should build the parser with care". Recognition and model matching are
+ * split so the host can toast on 0 matches and disambiguate on >1.
+ *
+ * Fully unit-testable (see test/modelMentions.test.ts).
+ */
+
+import type { CoopRole, ModelRef, ProviderConfig } from '../../shared/types';
+
+// ---------------------------------------------------------------------------
+// Public shapes
+// ---------------------------------------------------------------------------
+
+/** The target of a mention: a specific Coop role, or the whole conversation. */
+export type MentionRole = CoopRole | 'conversation';
+
+export interface Mention {
+  role: MentionRole;
+  /** The captured model-name query (1–3 short tokens), verbatim from the text. */
+  query: string;
+}
+
+export interface ModelMatch {
+  providerId: string;
+  modelId: string;
+  /** Human label (displayName or id) for pickers / confirmations. */
+  label: string;
+}
+
+// ---------------------------------------------------------------------------
+// Grammar tables (case-insensitive throughout)
+// ---------------------------------------------------------------------------
+
+/** Verbs that name a role when used as an action ("<name> to <verb>"). */
+const VERB_TO_ROLE: Record<string, CoopRole> = {
+  build: 'builder', builds: 'builder', building: 'builder', implement: 'builder',
+  plan: 'scout', plans: 'scout', planning: 'scout', orchestrate: 'scout', orchestrates: 'scout', scout: 'scout',
+  review: 'inspector', reviews: 'inspector', reviewing: 'inspector', inspect: 'inspector', qa: 'inspector',
+  security: 'sentry', sentry: 'sentry', audit: 'sentry',
+};
+
+/** Role-nouns used in "<name> for <role-noun>". */
+const NOUN_TO_ROLE: Record<string, CoopRole> = {
+  building: 'builder', implementation: 'builder',
+  planning: 'scout', orchestration: 'scout',
+  review: 'inspector', qa: 'inspector', inspection: 'inspector',
+  security: 'sentry', audit: 'sentry',
+};
+
+/**
+ * Structural connectives that must never be captured as part of a model name.
+ * Combined with the verb/noun vocabulary, these bound the `<name>` capture so a
+ * directive cannot swallow the next clause ("qwen to orchestrate and glm to
+ * build" stays two mentions, not one).
+ */
+const CONNECTIVES = ['to', 'with', 'for', 'and', 'or', 'use', 'let', 'switch', 'everything', 'all', 'every', 'please'];
+
+const KEYWORDS = new Set<string>([
+  ...CONNECTIVES,
+  ...Object.keys(VERB_TO_ROLE),
+  ...Object.keys(NOUN_TO_ROLE),
+]);
+
+function isKeyword(token: string): boolean {
+  return KEYWORDS.has(token.toLowerCase());
+}
+
+/** Alternation of tokens, longest-first so e.g. "reviewing" beats "review". */
+function alternation(tokens: string[]): string {
+  return [...tokens]
+    .sort((a, b) => b.length - a.length)
+    .map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|');
+}
+
+const VERB_ALT = alternation(Object.keys(VERB_TO_ROLE));
+const NOUN_ALT = alternation(Object.keys(NOUN_TO_ROLE));
+const KW_ALT = alternation([...KEYWORDS]);
+
+// A single name token: word-ish run that is NOT itself a keyword. The leading
+// `\b` (only on the first token) prevents starting inside another word — e.g.
+// backtracking into "and" to capture "nd".
+const NAME_TOKEN = `(?!(?:${KW_ALT})\\b)[A-Za-z0-9][\\w.:/-]*`;
+// A name: 1–3 such tokens, anchored at a word boundary.
+const NAME = `(\\b${NAME_TOKEN}(?:[ \\t]+${NAME_TOKEN}){0,2})`;
+// Optional trailing "for everything / all / every role" on a role-less directive.
+const FOR_ALL = `(?:[ \\t]+for[ \\t]+(?:everything|all(?:[ \\t]+roles?)?|every[ \\t]+role))?`;
+
+// ---------------------------------------------------------------------------
+// Pattern set (priority order — most specific first)
+// ---------------------------------------------------------------------------
+
+interface Pattern {
+  re: RegExp;
+  /** Produce a mention from a match, or null to reject it. */
+  make(m: RegExpExecArray): Mention | null;
+}
+
+const nameQuery = (raw: string): string => {
+  const out: string[] = [];
+  for (const t of raw.trim().split(/\s+/).filter(Boolean)) {
+    if (isKeyword(t) || out.length === 3) break;
+    out.push(t);
+  }
+  return out.join(' ').trim();
+};
+
+const verbRole = (verb: string): CoopRole | undefined => VERB_TO_ROLE[verb.toLowerCase()];
+const nounRole = (noun: string): CoopRole | undefined => NOUN_TO_ROLE[noun.toLowerCase()];
+
+const roleMention = (query: string, role: CoopRole | undefined): Mention | null =>
+  role && query ? { role, query } : null;
+
+const PATTERNS: Pattern[] = [
+  // use <name> to <verb>
+  {
+    re: new RegExp(`\\buse[ \\t]+${NAME}[ \\t]+to[ \\t]+(${VERB_ALT})\\b`, 'gi'),
+    make: (m) => roleMention(nameQuery(m[1]), verbRole(m[2])),
+  },
+  // <verb> with <name>   ("build with glm")
+  {
+    re: new RegExp(`\\b(${VERB_ALT})[ \\t]+with[ \\t]+${NAME}`, 'gi'),
+    make: (m) => roleMention(nameQuery(m[2]), verbRole(m[1])),
+  },
+  // let <name> <verb>
+  {
+    re: new RegExp(`\\blet[ \\t]+${NAME}[ \\t]+(${VERB_ALT})\\b`, 'gi'),
+    make: (m) => roleMention(nameQuery(m[1]), verbRole(m[2])),
+  },
+  // <name> for <role-noun>   ("qwen for review")
+  {
+    re: new RegExp(`${NAME}[ \\t]+for[ \\t]+(${NOUN_ALT})\\b`, 'gi'),
+    make: (m) => roleMention(nameQuery(m[1]), nounRole(m[2])),
+  },
+  // <name> to <verb>   ("qwen to orchestrate")
+  {
+    re: new RegExp(`${NAME}[ \\t]+to[ \\t]+(${VERB_ALT})\\b`, 'gi'),
+    make: (m) => roleMention(nameQuery(m[1]), verbRole(m[2])),
+  },
+  // switch to <name>   (role-less → conversation)
+  {
+    re: new RegExp(`\\bswitch[ \\t]+to[ \\t]+${NAME}${FOR_ALL}`, 'gi'),
+    make: (m) => {
+      const q = nameQuery(m[1]);
+      return q ? { role: 'conversation', query: q } : null;
+    },
+  },
+  // use <name> [for everything]   (role-less → conversation)
+  {
+    re: new RegExp(`\\buse[ \\t]+${NAME}${FOR_ALL}`, 'gi'),
+    make: (m) => {
+      const q = nameQuery(m[1]);
+      return q ? { role: 'conversation', query: q } : null;
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Scanning
+// ---------------------------------------------------------------------------
+
+interface Span {
+  mention: Mention;
+  start: number;
+  end: number;
+}
+
+/** Recognize every directive span, higher-priority patterns claiming text first. */
+function scan(text: string): Span[] {
+  const src = text ?? '';
+  const spans: Span[] = [];
+  const claimed: boolean[] = new Array(src.length).fill(false);
+  const overlaps = (s: number, e: number): boolean => {
+    for (let i = s; i < e; i += 1) if (claimed[i]) return true;
+    return false;
+  };
+  for (const { re, make } of PATTERNS) {
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(src)) !== null) {
+      const start = m.index;
+      const end = start + m[0].length;
+      if (m[0].length === 0) {
+        re.lastIndex += 1;
+        continue;
+      }
+      if (overlaps(start, end)) continue;
+      const mention = make(m);
+      if (!mention) continue;
+      for (let i = start; i < end; i += 1) claimed[i] = true;
+      spans.push({ mention, start, end });
+    }
+  }
+  return spans.sort((a, b) => a.start - b.start);
+}
+
+/**
+ * Parse model-steering directives from a message, in reading order. Conservative:
+ * returns [] for ordinary prose that merely contains a verb but no model-name
+ * directive shape.
+ */
+export function parseModelMentions(text: string): Mention[] {
+  return scan(text).map((s) => s.mention);
+}
+
+/**
+ * Remove recognized directive spans from the text, leaving the "real" request.
+ * The host uses the residue to decide whether a message is directive-ONLY (only
+ * mentions + whitespace/punctuation remain) and thus should not start a turn.
+ * The `mentions` argument is accepted for symmetry but the spans are recomputed
+ * from `text` (mentions carry no offsets).
+ */
+export function stripDirectives(text: string, _mentions?: Mention[]): string {
+  const src = text ?? '';
+  const spans = scan(src);
+  if (spans.length === 0) return src;
+  let out = '';
+  let cursor = 0;
+  for (const s of spans) {
+    out += src.slice(cursor, s.start);
+    cursor = s.end;
+  }
+  out += src.slice(cursor);
+  return out;
+}
+
+/** Conjunctions/fillers that may glue two directives without making a message "real". */
+const FILLER = new Set(['and', 'then', 'also', 'plus', 'please', 'or', 'so', 'now']);
+
+/**
+ * True when the message is nothing but directives — after stripping the
+ * recognized spans, only whitespace, punctuation, and bare conjunctions
+ * ("qwen to plan and glm to build") remain.
+ */
+export function isDirectiveOnly(text: string): boolean {
+  const src = text ?? '';
+  if (scan(src).length === 0) return false;
+  const words = stripDirectives(src)
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+  return words.every((w) => FILLER.has(w));
+}
+
+// ---------------------------------------------------------------------------
+// Model matching
+// ---------------------------------------------------------------------------
+
+/** Does `q` appear in `s` at the start of a token (start-of-string or after a non-alnum)? */
+function tokenStart(s: string, q: string): boolean {
+  let from = 0;
+  for (;;) {
+    const i = s.indexOf(q, from);
+    if (i < 0) return false;
+    if (i === 0 || !/[a-z0-9]/.test(s[i - 1])) return true;
+    from = i + 1;
+  }
+}
+
+/** Rank a candidate model against a query: 0 exact, 1 token-start, 2 substring, null none. */
+function matchRank(q: string, id: string, displayName: string): number | null {
+  if (id === q || displayName === q) return 0;
+  if (tokenStart(id, q) || tokenStart(displayName, q)) return 1;
+  if (id.includes(q) || displayName.includes(q)) return 2;
+  return null;
+}
+
+/**
+ * Find the models best matching a query across every provider's models. Candidates
+ * are ranked exact > token-start > substring; all matches at the best rank are
+ * returned (so two loaded "qwen" versions both surface), deduped by provider+model.
+ */
+export function matchModels(query: string, providers: ProviderConfig[]): ModelMatch[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+  const ranked: Array<ModelMatch & { rank: number }> = [];
+  for (const p of providers) {
+    for (const m of p.models) {
+      const rank = matchRank(q, m.id.toLowerCase(), (m.displayName ?? '').toLowerCase());
+      if (rank === null) continue;
+      ranked.push({ providerId: p.id, modelId: m.id, label: m.displayName || m.id, rank });
+    }
+  }
+  if (ranked.length === 0) return [];
+  const best = Math.min(...ranked.map((c) => c.rank));
+  const seen = new Set<string>();
+  const out: ModelMatch[] = [];
+  for (const c of ranked) {
+    if (c.rank !== best) continue;
+    const key = `${c.providerId} ${c.modelId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ providerId: c.providerId, modelId: c.modelId, label: c.label });
+  }
+  return out;
+}
+
+/** Convenience: a `ModelMatch` as a `ModelRef`. */
+export function toModelRef(match: ModelMatch): ModelRef {
+  return { providerId: match.providerId, modelId: match.modelId };
+}

--- a/src/core/harness/coop.ts
+++ b/src/core/harness/coop.ts
@@ -22,6 +22,7 @@ import type {
   HarnessSettings,
   TokenUsage,
 } from '../../shared/types';
+import { fitDiffToBudget } from '../agent/contextBudget';
 import {
   createCard,
   joinSections,
@@ -31,6 +32,7 @@ import {
   section,
   transition,
   type ParsedVerdict,
+  type Verdict,
 } from './evidence';
 import {
   INSPECTOR_SYSTEM,
@@ -90,6 +92,14 @@ export interface CoopPipelineOptions {
    * `modelLabel` unset on cards (existing tests stay green).
    */
   modelLabelFor?: (role: CoopRole) => string | undefined;
+  /**
+   * Payload token budget a review role (Inspector/Sentry) may spend on the diff,
+   * already net of system-prompt / instruction / response overhead. When it
+   * returns a number and the diff overflows it, the role runs once per chunk and
+   * the verdicts are aggregated. Returning `undefined` (unknown context window)
+   * preserves the exact single-call path — the extension supplies this.
+   */
+  diffBudgetFor?: (role: CoopRole) => number | undefined;
   signal?: AbortSignal;
 }
 
@@ -98,12 +108,39 @@ export type CoopOutcome =
   | 'blocked'
   | 'qas-failed'
   | 'security-blocked'
+  | 'context-exceeded'
   | 'cancelled';
+
+/** Detail behind a `context-exceeded` outcome, for the caller's user-facing message. */
+export interface ContextExceededInfo {
+  role: CoopRole;
+  modelLabel?: string;
+  /** The model's full context window in tokens, when known. */
+  windowTokens?: number;
+  /** Estimated tokens the (already-trimmed) newest turn needs. */
+  neededTokens: number;
+  /** The payload budget it had to fit into. */
+  budgetTokens: number;
+}
+
+/**
+ * Thrown from `buildStage` when the newest turn alone cannot fit the Builder's
+ * payload budget even after trimming. The pipeline catches it, emits a blocked
+ * "Context limit" gate card, and returns the `context-exceeded` outcome.
+ */
+export class ContextExceededError extends Error {
+  constructor(public readonly info: ContextExceededInfo) {
+    super('Context window exceeded');
+    this.name = 'ContextExceededError';
+  }
+}
 
 export interface CoopResult {
   outcome: CoopOutcome;
   /** Present for `blocked` — the clarifying question to surface to the user. */
   question?: string;
+  /** Present for `context-exceeded` — sizes + model for the user-facing message. */
+  context?: ContextExceededInfo;
   cards: GateCard[];
   usage: TokenUsage;
 }
@@ -113,7 +150,7 @@ export interface CoopResult {
 // ---------------------------------------------------------------------------
 
 export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopResult> {
-  const { userPrompt, runner, inspector, buildStage, settings, onGate, modelLabelFor, signal } = opts;
+  const { userPrompt, runner, inspector, buildStage, settings, onGate, modelLabelFor, diffBudgetFor, signal } = opts;
   const labelFor = (role: CoopRole): string | undefined => modelLabelFor?.(role);
 
   const usage: TokenUsage = { inputTokens: 0, outputTokens: 0, cachedTokens: 0 };
@@ -137,6 +174,87 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
   };
 
   const aborted = () => Boolean(signal?.aborted);
+
+  /**
+   * Run a read-only review role (Inspector/Sentry) over the diff, splitting it
+   * into budget-sized chunks when a budget is supplied and the diff overflows.
+   * Each chunk is reviewed sequentially (abort-aware); the verdicts are then
+   * aggregated — approve only if EVERY chunk approves, findings unioned. Returns
+   * the aggregated verdict, the role's summed usage, and a context note (empty
+   * when a single call sufficed).
+   */
+  const runReview = async (
+    role: CoopRole,
+    system: string,
+    buildPrompt: (chunk: string) => string,
+    diff: string,
+  ): Promise<{ verdict: ParsedVerdict; usage: TokenUsage; note: string; aborted: boolean }> => {
+    const budget = diffBudgetFor?.(role);
+    const fit =
+      budget !== undefined ? fitDiffToBudget(diff, budget) : { chunks: [diff], truncated: false };
+    const roleUsage: TokenUsage = { inputTokens: 0, outputTokens: 0, cachedTokens: 0 };
+    const spend = (u: TokenUsage) => {
+      roleUsage.inputTokens += u.inputTokens;
+      roleUsage.outputTokens += u.outputTokens;
+      roleUsage.cachedTokens += u.cachedTokens;
+    };
+
+    // Single-call path (no budget, or the whole diff fits): identical to before.
+    if (fit.chunks.length <= 1) {
+      const run = await runner.run({
+        role,
+        system,
+        userPrompt: buildPrompt(fit.chunks[0] ?? diff),
+        readOnly: true,
+        signal,
+      });
+      spend(run.usage);
+      const note = fit.truncated
+        ? 'Part of the diff was truncated to fit the model\'s context window.'
+        : '';
+      return { verdict: parseVerdict(run.text), usage: roleUsage, note, aborted: aborted() };
+    }
+
+    // Chunked path: review each part, then aggregate.
+    const n = fit.chunks.length;
+    const verdicts: ParsedVerdict[] = [];
+    for (let i = 0; i < n; i += 1) {
+      if (aborted()) {
+        return {
+          verdict: { verdict: 'reject', findings: [], evidence: '' },
+          usage: roleUsage,
+          note: '',
+          aborted: true,
+        };
+      }
+      const prompt = `(Reviewing part ${i + 1} of ${n} of the changeset — judge only what is present in this part.)\n\n${buildPrompt(fit.chunks[i])}`;
+      const run = await runner.run({ role, system, userPrompt: prompt, readOnly: true, signal });
+      spend(run.usage);
+      verdicts.push(parseVerdict(run.text));
+    }
+    const note = `Diff reviewed in ${n} parts (context budget).${fit.truncated ? ' Part of the diff was truncated to fit.' : ''}`;
+    return { verdict: aggregateVerdicts(verdicts), usage: roleUsage, note, aborted: aborted() };
+  };
+
+  /** Blocked "Context limit" card + `context-exceeded` result. */
+  const contextExceeded = (info: ContextExceededInfo): CoopResult => {
+    emit(
+      createCard(nextId('ctx'), {
+        role: 'stop-the-line',
+        title: 'Context limit',
+        status: 'blocked',
+        modelLabel: info.modelLabel,
+        evidence: joinSections(
+          section(
+            'Context window exceeded',
+            `The ${info.role} step's request needs ~${fmtK(info.neededTokens)} tokens but only ~${fmtK(info.budgetTokens)} fit ${info.modelLabel ?? 'the selected model'}'s payload budget${info.windowTokens ? ` (~${fmtK(info.windowTokens)} token window)` : ''}.`,
+          ),
+          section('What to do', 'Trim the request, start a fresh conversation, or pick a model with a larger context window.'),
+        ),
+      }),
+    );
+    return { outcome: 'context-exceeded', context: info, cards, usage };
+  };
 
   /** Finalize on cancellation: mark the in-flight card and return the cancelled result. */
   const cancel = (running?: GateCard): CoopResult => {
@@ -174,6 +292,7 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
   const scout = parseScout(scoutRun.text);
   emit(
     transition(scoutCard, 'passed', {
+      usage: scoutRun.usage,
       acceptanceCriteria: scout.criteria,
       evidence: scout.ambiguous
         ? joinSections(
@@ -245,7 +364,22 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
         ? composeBuilderInstructions(userPrompt, scout.criteria, scout.plan)
         : composeBuilderFix(userPrompt, scout.criteria, scout.plan, inspectorFindings);
 
-    const builderUsage = await buildStage(instructions, signal);
+    let builderUsage: TokenUsage;
+    try {
+      builderUsage = await buildStage(instructions, signal);
+    } catch (err) {
+      if (err instanceof ContextExceededError) {
+        // Mark the in-flight Builder card, then emit the Context limit gate.
+        emit(
+          transition(builderCard, 'failed', {
+            attempt,
+            evidence: joinSections(builderCard.evidence, '_Halted — request exceeds the context window._'),
+          }),
+        );
+        return contextExceeded(err.info);
+      }
+      throw err;
+    }
     addUsage(builderUsage);
     if (aborted()) return cancel(builderCard);
 
@@ -253,6 +387,7 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
     emit(
       transition(builderCard, 'passed', {
         attempt,
+        usage: builderUsage,
         evidence: joinSections(
           section('Changeset', renderChangeSummary(summary)),
           attempt > 1
@@ -274,23 +409,26 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
       }),
     );
     const diff = inspector.unifiedDiff();
-    const inspectorRun = await runner.run({
-      role: 'inspector',
-      system: INSPECTOR_SYSTEM,
-      userPrompt: composeInspectorPrompt(scout.criteria, diff),
-      readOnly: true,
-      signal,
-    });
-    addUsage(inspectorRun.usage);
-    if (aborted()) return cancel(inspectorCard);
+    const inspectorReview = await runReview(
+      'inspector',
+      INSPECTOR_SYSTEM,
+      (chunk) => composeInspectorPrompt(scout.criteria, chunk),
+      diff,
+    );
+    addUsage(inspectorReview.usage);
+    if (inspectorReview.aborted) return cancel(inspectorCard);
 
-    const verdict = parseVerdict(inspectorRun.text);
+    const verdict = inspectorReview.verdict;
     if (verdict.verdict === 'approve') {
       emit(
         transition(inspectorCard, 'passed', {
           attempt,
+          usage: inspectorReview.usage,
           findings: verdict.findings,
-          evidence: verdictEvidence('All acceptance criteria verified.', verdict),
+          evidence: joinSections(
+            verdictEvidence('All acceptance criteria verified.', verdict),
+            inspectorReview.note ? section('Context', inspectorReview.note) : '',
+          ),
         }),
       );
       break; // proceed to Sentry
@@ -306,12 +444,16 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
     emit(
       transition(inspectorCard, 'failed', {
         attempt,
+        usage: inspectorReview.usage,
         findings: inspectorFindings,
-        evidence: verdictEvidence(
-          budgetRemains
-            ? `Routing back to Builder (attempt ${attempt} of ${maxAttempts}).`
-            : 'Retry budget exhausted.',
-          verdict,
+        evidence: joinSections(
+          verdictEvidence(
+            budgetRemains
+              ? `Routing back to Builder (attempt ${attempt} of ${maxAttempts}).`
+              : 'Retry budget exhausted.',
+            verdict,
+          ),
+          inspectorReview.note ? section('Context', inspectorReview.note) : '',
         ),
       }),
     );
@@ -333,17 +475,16 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
       modelLabel: labelFor('sentry'),
     }),
   );
-  const sentryRun = await runner.run({
-    role: 'sentry',
-    system: SENTRY_SYSTEM,
-    userPrompt: composeSentryPrompt(inspector.unifiedDiff()),
-    readOnly: true,
-    signal,
-  });
-  addUsage(sentryRun.usage);
-  if (aborted()) return cancel(sentryCard);
+  const sentryReview = await runReview(
+    'sentry',
+    SENTRY_SYSTEM,
+    (chunk) => composeSentryPrompt(chunk),
+    inspector.unifiedDiff(),
+  );
+  addUsage(sentryReview.usage);
+  if (sentryReview.aborted) return cancel(sentryCard);
 
-  const sentryVerdict = parseVerdict(sentryRun.text);
+  const sentryVerdict = sentryReview.verdict;
   if (sentryVerdict.verdict !== 'approve') {
     // Security findings are never auto-fixed — the human decides.
     const findings =
@@ -352,16 +493,24 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
         : ['Sentry flagged a security concern but gave no specific finding; treat the changeset as suspect.'];
     emit(
       transition(sentryCard, 'blocked', {
+        usage: sentryReview.usage,
         findings,
-        evidence: verdictEvidence('Security concern — pipeline halted for human decision.', sentryVerdict),
+        evidence: joinSections(
+          verdictEvidence('Security concern — pipeline halted for human decision.', sentryVerdict),
+          sentryReview.note ? section('Context', sentryReview.note) : '',
+        ),
       }),
     );
     return { outcome: 'security-blocked', cards, usage };
   }
   emit(
     transition(sentryCard, 'passed', {
+      usage: sentryReview.usage,
       findings: sentryVerdict.findings,
-      evidence: verdictEvidence('No security concerns found in the diff.', sentryVerdict),
+      evidence: joinSections(
+        verdictEvidence('No security concerns found in the diff.', sentryVerdict),
+        sentryReview.note ? section('Context', sentryReview.note) : '',
+      ),
     }),
   );
 
@@ -384,6 +533,38 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Aggregate per-chunk review verdicts into one: approve ONLY if every chunk
+ * approves; any `block` wins over `reject`; findings are unioned (dedup, order
+ * preserved); evidence lists each part's verdict.
+ */
+function aggregateVerdicts(verdicts: ParsedVerdict[]): ParsedVerdict {
+  const allApprove = verdicts.length > 0 && verdicts.every((v) => v.verdict === 'approve');
+  const anyBlock = verdicts.some((v) => v.verdict === 'block');
+  const verdict: Verdict = allApprove ? 'approve' : anyBlock ? 'block' : 'reject';
+
+  const seen = new Set<string>();
+  const findings: string[] = [];
+  for (const v of verdicts) {
+    for (const f of v.findings) {
+      if (!seen.has(f)) {
+        seen.add(f);
+        findings.push(f);
+      }
+    }
+  }
+  const evidence = verdicts
+    .map((v, i) => `Part ${i + 1}: ${v.verdict.toUpperCase()}${v.evidence ? ` — ${v.evidence}` : ''}`)
+    .join('\n');
+  return { verdict, findings, evidence };
+}
+
+/** Format a token count with a thousands suffix, e.g. 1234 → "1.2k". */
+function fmtK(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k`;
+  return String(n);
+}
 
 /** Assemble a role card's evidence markdown from a headline + parsed verdict. */
 function verdictEvidence(headline: string, verdict: ParsedVerdict): string {

--- a/src/core/harness/coop.ts
+++ b/src/core/harness/coop.ts
@@ -83,6 +83,13 @@ export interface CoopPipelineOptions {
   settings: HarnessSettings;
   /** Called on every card transition (create + each status change). */
   onGate: (card: GateCard) => void;
+  /**
+   * Resolves the display label of the model a given role will run on, so each
+   * role's gate card can show which model ran it. Optional — the pipeline itself
+   * knows nothing about models; the extension supplies this. Omitting it leaves
+   * `modelLabel` unset on cards (existing tests stay green).
+   */
+  modelLabelFor?: (role: CoopRole) => string | undefined;
   signal?: AbortSignal;
 }
 
@@ -106,7 +113,8 @@ export interface CoopResult {
 // ---------------------------------------------------------------------------
 
 export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopResult> {
-  const { userPrompt, runner, inspector, buildStage, settings, onGate, signal } = opts;
+  const { userPrompt, runner, inspector, buildStage, settings, onGate, modelLabelFor, signal } = opts;
+  const labelFor = (role: CoopRole): string | undefined => modelLabelFor?.(role);
 
   const usage: TokenUsage = { inputTokens: 0, outputTokens: 0, cachedTokens: 0 };
   const cards: GateCard[] = [];
@@ -148,6 +156,7 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
       role: 'scout',
       title: 'Scout — acceptance criteria',
       evidence: 'Restating the request as testable acceptance criteria…',
+      modelLabel: labelFor('scout'),
     }),
   );
   if (aborted()) return cancel(scoutCard);
@@ -228,6 +237,7 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
           attempt === 1
             ? 'Implementing against the acceptance criteria…'
             : 'Revising to address Inspector findings…',
+        modelLabel: labelFor('builder'),
       }),
     );
     const instructions =
@@ -260,6 +270,7 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
         title: 'Inspector — QA validation',
         attempt,
         evidence: 'Validating the changeset against the acceptance criteria (fresh eyes)…',
+        modelLabel: labelFor('inspector'),
       }),
     );
     const diff = inspector.unifiedDiff();
@@ -319,6 +330,7 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
       role: 'sentry',
       title: 'Sentry — security review',
       evidence: 'Reviewing the diff for secrets, injection, and unsafe patterns…',
+      modelLabel: labelFor('sentry'),
     }),
   );
   const sentryRun = await runner.run({

--- a/src/core/harness/evidence.ts
+++ b/src/core/harness/evidence.ts
@@ -30,6 +30,8 @@ export interface GateCardInit {
   acceptanceCriteria?: string[];
   findings?: string[];
   attempt?: number;
+  /** Display label of the model that ran this role. */
+  modelLabel?: string;
 }
 
 /**
@@ -48,6 +50,7 @@ export function createCard(id: string, init: GateCardInit): GateCard {
   if (init.acceptanceCriteria) card.acceptanceCriteria = init.acceptanceCriteria;
   if (init.findings) card.findings = init.findings;
   if (init.attempt !== undefined) card.attempt = init.attempt;
+  if (init.modelLabel) card.modelLabel = init.modelLabel;
   return card;
 }
 

--- a/src/core/harness/prd.ts
+++ b/src/core/harness/prd.ts
@@ -1,0 +1,213 @@
+/**
+ * PRD decomposition — the long-horizon planning front-end to the Coop pipeline.
+ *
+ * A pasted PRD (product requirements doc) is too large to build in one changeset. The
+ * FOREMAN role decomposes it into a short list of ordered, independently-buildable stories.
+ * Each story is written to disk as a spec file, then the EXISTING Scout→Builder⇄Inspector→
+ * Sentry pipeline runs once per story with a fresh, spec-sized prompt — pausing for a human
+ * review between stories.
+ *
+ * This module is pure: prompt text, lenient parsing, on-disk spec rendering, path derivation
+ * and prompt composition. No `vscode`, no Node built-ins. The state types (`PrdStory`,
+ * `PrdPlan`) live in `shared/types` so they can ride on the `Conversation` object (which
+ * `shared` owns and must not import `core`); they are re-exported here for convenience.
+ */
+
+import { extractJsonObject, toStringList } from './evidence';
+import type { PrdPlan, PrdStory, PrdStoryStatus } from '../../shared/types';
+
+export type { PrdPlan, PrdStory, PrdStoryStatus } from '../../shared/types';
+
+// ===========================================================================
+// Foreman role system prompt
+// ===========================================================================
+
+/**
+ * FOREMAN — decomposes a PRD into ordered, independently-buildable stories. Read-only:
+ * it may explore the workspace to ground its decomposition but writes nothing. Planning
+ * roles (Scout, Foreman) share a model by design — the extension resolves the Foreman
+ * with the Scout role's model.
+ */
+export const FOREMAN_SYSTEM = `You are FOREMAN, the delivery lead in a role-gated coding pipeline.
+You do NOT write code. You are given a PRD (product requirements document) and your only
+job is to decompose it into an ordered sequence of small, independently-buildable STORIES
+that a downstream pipeline (Scout, Builder, Inspector, Sentry) will implement ONE AT A TIME.
+
+You are READ-ONLY. You may use the available tools to explore the workspace (glob/grep/
+read) so your decomposition fits the actual codebase, but you must NEVER edit anything.
+
+HOW TO DECOMPOSE
+- Produce between 2 and 12 stories. If the PRD is genuinely one small change, it does not
+  need a PRD build — still return at least 2 stories only when the work truly separates.
+- Order them so each story builds on the ones before it (earlier stories are applied first).
+- Each story must be independently buildable and reviewable: a coherent slice of value, not
+  a random fragment. Prefer vertical slices over horizontal layers.
+- For each story provide:
+  - "title": a short imperative name (e.g. "Add the /users pagination endpoint").
+  - "summary": 1–3 sentences describing the slice and why it comes where it does.
+  - "criteria": 2–6 testable acceptance criteria, each an observable outcome ("X does Y"),
+    scoped to THIS story only — do not restate the whole PRD.
+
+OUTPUT
+Reply with ONE fenced JSON block and nothing that could be mistaken for a second one:
+
+\`\`\`json
+{
+  "stories": [
+    { "title": "...", "summary": "...", "criteria": ["...", "..."] }
+  ]
+}
+\`\`\`
+
+Do not wrap the stories in extra prose. Keep titles and criteria concrete and buildable.`;
+
+// ===========================================================================
+// Parsing
+// ===========================================================================
+
+/** A story as parsed from the Foreman's output — before it is assigned a spec path/status. */
+export interface ForemanStory {
+  title: string;
+  summary: string;
+  criteria: string[];
+}
+
+/** Hard cap on stories — a PRD build past a dozen slices should be split into more PRDs. */
+export const MAX_STORIES = 12;
+
+/**
+ * Lenient parse of the Foreman's output, mirroring {@link parseScout}: extract a JSON object
+ * from fenced or bare text, read a `stories` array, and coerce each entry. Empty stories (no
+ * title and no criteria) are dropped; the list is capped at {@link MAX_STORIES}. Returns an
+ * empty array when nothing usable can be recovered — the caller treats <2 stories as a
+ * decomposition failure and never creates a plan.
+ */
+export function parseForeman(text: string): ForemanStory[] {
+  const obj = extractJsonObject((text ?? '').toString());
+  if (!obj) return [];
+  const raw = obj.stories ?? obj.plan ?? obj.items ?? obj.tasks;
+  if (!Array.isArray(raw)) return [];
+
+  const stories: ForemanStory[] = [];
+  for (const entry of raw) {
+    if (stories.length >= MAX_STORIES) break;
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const r = entry as Record<string, unknown>;
+    const title = firstString(r.title, r.name, r.story);
+    const summary = firstString(r.summary, r.description, r.detail, r.rationale);
+    const criteria = toStringList(r.criteria ?? r.acceptanceCriteria ?? r.acceptance_criteria);
+    // Drop empties: a story with neither a title nor any criterion carries no signal.
+    if (!title && criteria.length === 0) continue;
+    stories.push({
+      title: title || summary || `Story ${stories.length + 1}`,
+      summary,
+      criteria,
+    });
+  }
+  return stories;
+}
+
+// ===========================================================================
+// On-disk spec rendering
+// ===========================================================================
+
+const STATUS_LABEL: Record<PrdStoryStatus, string> = {
+  pending: 'Pending',
+  building: 'Building',
+  'awaiting-review': 'Awaiting review',
+  done: 'Done',
+  failed: 'Failed',
+};
+
+/**
+ * Render a story as its on-disk spec markdown: title, status line, summary, an acceptance-
+ * criteria checklist, and a "story N of M" footer. `index`/`total` are 1-based for display.
+ * `note` (e.g. "skipped review") is appended to the status line when the human moved past a
+ * story without a clean pass — the spec file records that nuance the state machine omits.
+ */
+export function renderSpecMarkdown(
+  story: PrdStory,
+  index: number,
+  total: number,
+  prdTitle?: string,
+  note?: string,
+): string {
+  const statusLine = note
+    ? `**Status:** ${STATUS_LABEL[story.status]} (${note})`
+    : `**Status:** ${STATUS_LABEL[story.status]}`;
+  const lines: string[] = [];
+  lines.push(`# ${story.title}`);
+  lines.push('');
+  if (prdTitle) {
+    lines.push(`> Decomposed from PRD: ${prdTitle}`);
+    lines.push('');
+  }
+  lines.push(statusLine);
+  lines.push('');
+  if (story.summary.trim()) {
+    lines.push(story.summary.trim());
+    lines.push('');
+  }
+  lines.push('## Acceptance criteria');
+  lines.push('');
+  if (story.criteria.length === 0) {
+    lines.push('- _none specified_');
+  } else {
+    for (const c of story.criteria) lines.push(`- [ ] ${c}`);
+  }
+  lines.push('');
+  lines.push(`_Story ${index} of ${total}._`);
+  lines.push('');
+  return lines.join('\n');
+}
+
+// ===========================================================================
+// Spec path derivation
+// ===========================================================================
+
+/**
+ * Workspace-relative path of a story's spec file:
+ *   `.fowlplay/specs/<first-8-chars-of-convId>/<NN>-<slug>.md`
+ * `index` is 1-based (zero-padded to two digits). The title is slugged (lowercased,
+ * non-alphanumerics collapsed to hyphens, trimmed, length-capped).
+ */
+export function specRelPath(convId: string, index: number, title: string): string {
+  const dir = (convId ?? '').replace(/[^a-zA-Z0-9]/g, '').slice(0, 8) || 'conv';
+  const nn = String(Math.max(1, Math.floor(index))).padStart(2, '0');
+  return `.fowlplay/specs/${dir}/${nn}-${slug(title)}.md`;
+}
+
+function slug(title: string): string {
+  const s = (title ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 50)
+    .replace(/-+$/g, '');
+  return s || 'story';
+}
+
+// ===========================================================================
+// Per-story prompt composition
+// ===========================================================================
+
+/**
+ * The prompt handed to the per-story Coop pipeline: a preamble locating the story within the
+ * PRD, then the full spec markdown. `index`/`total` are 1-based.
+ */
+export function composeStoryPrompt(specMarkdown: string, index: number, total: number): string {
+  return `Story ${index} of ${total} decomposed from a PRD. Implement ONLY this story; earlier stories are already staged/applied.
+
+${specMarkdown.trim()}`;
+}
+
+// ---------------------------------------------------------------------------
+// Local helpers
+// ---------------------------------------------------------------------------
+
+function firstString(...values: unknown[]): string {
+  for (const v of values) {
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return '';
+}

--- a/src/core/harness/roles/foreman.md
+++ b/src/core/harness/roles/foreman.md
@@ -1,0 +1,41 @@
+<!--
+  FOREMAN role prompt (PRD decomposition / delivery lead).
+  Bundled default — copy to `.fowlplay/roles/foreman.md` in a workspace to override.
+  Must stay in sync with FOREMAN_SYSTEM in ../prd.ts.
+
+  MODEL: the Foreman is a PLANNING role and shares the Scout's model by design — the
+  extension resolves it with `resolveModel('scout')`. Point the Scout at your best
+  planning model and the Foreman follows.
+-->
+You are FOREMAN, the delivery lead in a role-gated coding pipeline.
+You do NOT write code. You are given a PRD (product requirements document) and your only
+job is to decompose it into an ordered sequence of small, independently-buildable STORIES
+that a downstream pipeline (Scout, Builder, Inspector, Sentry) will implement ONE AT A TIME.
+
+You are READ-ONLY. You may use the available tools to explore the workspace (glob/grep/
+read) so your decomposition fits the actual codebase, but you must NEVER edit anything.
+
+HOW TO DECOMPOSE
+- Produce between 2 and 12 stories. If the PRD is genuinely one small change, it does not
+  need a PRD build — still return at least 2 stories only when the work truly separates.
+- Order them so each story builds on the ones before it (earlier stories are applied first).
+- Each story must be independently buildable and reviewable: a coherent slice of value, not
+  a random fragment. Prefer vertical slices over horizontal layers.
+- For each story provide:
+  - "title": a short imperative name (e.g. "Add the /users pagination endpoint").
+  - "summary": 1–3 sentences describing the slice and why it comes where it does.
+  - "criteria": 2–6 testable acceptance criteria, each an observable outcome ("X does Y"),
+    scoped to THIS story only — do not restate the whole PRD.
+
+OUTPUT
+Reply with ONE fenced JSON block and nothing that could be mistaken for a second one:
+
+```json
+{
+  "stories": [
+    { "title": "...", "summary": "...", "criteria": ["...", "..."] }
+  ]
+}
+```
+
+Do not wrap the stories in extra prose. Keep titles and criteria concrete and buildable.

--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -20,6 +20,7 @@ import type {
   Conversation,
   ContentBlock,
   ConversationSummary,
+  CoopRole,
   FowlPlaySettings,
   GateCard,
   HarnessMode,
@@ -64,6 +65,13 @@ import {
   switchBranch as treeSwitchBranch,
 } from '../core/conversation/tree';
 import { toJSON, toMarkdown } from '../core/conversation/serialize';
+import {
+  isDirectiveOnly,
+  matchModels,
+  parseModelMentions,
+  type MentionRole,
+  type ModelMatch,
+} from '../core/agent/modelMentions';
 
 // ---------------------------------------------------------------------------
 // Injected ports (implemented by the vscode layer or by test fakes)
@@ -167,6 +175,19 @@ export class SessionCore {
   private pendingSelection: SelectionContext | null = null;
 
   /**
+   * A prompt held while the webview disambiguates one or more model mentions that
+   * matched more than one configured model. `queue[0]` is the choice currently
+   * surfaced; each `resolveModelMention` shifts it. When the queue drains the held
+   * prompt is released (run as a turn, or applied silently if directive-only).
+   */
+  private heldMention: {
+    text: string;
+    attachments?: Attachment[];
+    queue: { role: MentionRole; query: string; candidates: ModelMatch[] }[];
+    assignments: string[];
+  } | null = null;
+
+  /**
    * Skills available for the current turn (bundled defaults + workspace
    * `.fowlplay/skills/*.md`), rediscovered at the start of each turn. Consumed by
    * `toolHost()` (for `load_skill`) and the system-prompt catalog injection.
@@ -258,6 +279,9 @@ export class SessionCore {
         this.conv = { ...this.conv, harnessMode: msg.mode, updatedAt: this.clock() };
         this.sendConversation();
         void this.persist();
+        return;
+      case 'resolveModelMention':
+        await this.onResolveModelMention(msg.role, msg.model);
         return;
       case 'openDiff':
         this.sendChangeset(msg.changesetId);
@@ -431,7 +455,123 @@ export class SessionCore {
   // Turn flow
   // -------------------------------------------------------------------------
 
+  /**
+   * Entry point for a user prompt. Before anything is appended to the tree, the
+   * text is scanned for per-role model directives ("qwen to orchestrate",
+   * "use glm for review", role-less "switch to qwen"). Each mention resolves to
+   * 0, 1, or >1 configured models:
+   *   0  → warn and ignore that mention.
+   *   1  → apply it (conversation model or a per-role override).
+   *   >1 → hold the ENTIRE prompt and ask the webview to disambiguate.
+   * Once mentions are settled, a directive-ONLY message applies without running a
+   * turn; otherwise the turn runs with the ORIGINAL full text (mentions are not
+   * stripped from what the model sees — keeping history honest is harmless).
+   */
   private async onSendPrompt(text: string, attachments?: Attachment[]): Promise<void> {
+    const trimmed = text.trim();
+    const atts = attachments ?? [];
+    if (!trimmed && atts.length === 0) return;
+
+    // A new prompt supersedes any prompt still held behind an unanswered
+    // disambiguation — otherwise answering the stale picker later would
+    // release (and run) the abandoned message.
+    this.heldMention = null;
+
+    const settings = await this.ensureSettings();
+    const mentions = parseModelMentions(text);
+    const assignments: string[] = [];
+    const queue: { role: MentionRole; query: string; candidates: ModelMatch[] }[] = [];
+
+    for (const mention of mentions) {
+      const candidates = matchModels(mention.query, settings.providers);
+      if (candidates.length === 0) {
+        this.toast('warn', `No configured model matches "${mention.query}"`);
+        continue;
+      }
+      if (candidates.length === 1) {
+        this.applyMention(mention.role, refOf(candidates[0]));
+        assignments.push(assignmentLabel(mention.role, candidates[0].label));
+        continue;
+      }
+      queue.push({ role: mention.role, query: mention.query, candidates });
+    }
+
+    if (queue.length > 0) {
+      // Hold the whole prompt (selection stays pinned) until every ambiguity is
+      // resolved; surface the first choice now.
+      this.heldMention = { text, attachments, queue, assignments };
+      const first = queue[0];
+      this.deps.post({
+        type: 'modelMentionChoice',
+        role: first.role,
+        query: first.query,
+        candidates: first.candidates.map((c) => ({ providerId: c.providerId, modelId: c.modelId, label: c.label })),
+      });
+      return;
+    }
+
+    await this.finishMentions(text, attachments, assignments);
+  }
+
+  /** Resolve one held ambiguity, then advance the queue or release the prompt. */
+  private async onResolveModelMention(role: MentionRole, model: ModelRef | null): Promise<void> {
+    const held = this.heldMention;
+    if (!held) return;
+    if (model) {
+      const label = this.labelForRef(model);
+      this.applyMention(role, model);
+      held.assignments.push(assignmentLabel(role, label));
+    } else {
+      this.toast('info', `Sent without changing the ${roleWord(role)} model`);
+    }
+    held.queue.shift();
+    if (held.queue.length > 0) {
+      const next = held.queue[0];
+      this.deps.post({
+        type: 'modelMentionChoice',
+        role: next.role,
+        query: next.query,
+        candidates: next.candidates.map((c) => ({ providerId: c.providerId, modelId: c.modelId, label: c.label })),
+      });
+      return;
+    }
+    this.heldMention = null;
+    await this.finishMentions(held.text, held.attachments, held.assignments);
+  }
+
+  /** Apply a resolved mention to the conversation (role override or the model itself). */
+  private applyMention(role: MentionRole, model: ModelRef): void {
+    if (role === 'conversation') {
+      // setModel semantics WITHOUT saving as the global default — a chat directive
+      // steers this conversation only.
+      this.conv = { ...this.conv, model, updatedAt: this.clock() };
+    } else {
+      const roleModelOverrides = { ...(this.conv.roleModelOverrides ?? {}), [role]: model };
+      this.conv = { ...this.conv, roleModelOverrides, updatedAt: this.clock() };
+    }
+  }
+
+  /**
+   * After mentions are settled: persist any assignments, then either apply-only
+   * (directive-only message: no turn, just a confirmation toast) or run the turn
+   * with the original full text.
+   */
+  private async finishMentions(text: string, attachments: Attachment[] | undefined, assignments: string[]): Promise<void> {
+    if (assignments.length > 0) {
+      this.sendConversation();
+      await this.persist();
+    }
+    // Only short-circuit when something was actually applied AND nothing but
+    // directives remain. A message whose "mentions" all matched nothing (e.g.
+    // "use the foo skill") still runs as an ordinary turn.
+    if (assignments.length > 0 && isDirectiveOnly(text)) {
+      this.toast('info', assignments.join(', '));
+      return;
+    }
+    await this.runPromptTurn(text, attachments);
+  }
+
+  private async runPromptTurn(text: string, attachments?: Attachment[]): Promise<void> {
     const trimmed = text.trim();
     const atts = attachments ?? [];
     if (!trimmed && atts.length === 0) return;
@@ -602,14 +742,18 @@ export class SessionCore {
     harness: HarnessSettings,
     signal: AbortSignal,
   ): Promise<{ blocks: ContentBlock[]; usage: TokenUsage }> {
+    const settings = await this.ensureSettings();
     const cards: GateCard[] = [];
     const runner: RoleRunner = {
-      run: async ({ system, userPrompt, readOnly, signal: s }) => {
+      run: async ({ role, system, userPrompt, readOnly, signal: s }) => {
+        // Each role resolves its own model through the override chain, falling
+        // back to the turn's conversation model.
+        const rm = (await this.resolveModel(role)) ?? resolved;
         const res = await runAgentLoop({
-          adapter: resolved.adapter,
-          baseUrl: resolved.baseUrl,
-          apiKey: resolved.apiKey,
-          modelId: resolved.modelId,
+          adapter: rm.adapter,
+          baseUrl: rm.baseUrl,
+          apiKey: rm.apiKey,
+          modelId: rm.modelId,
           system,
           history: [{ role: 'user', content: [{ type: 'text', text: userPrompt }] }],
           tools: readOnly ? this.readOnlyTools : this.allTools,
@@ -631,15 +775,17 @@ export class SessionCore {
     };
 
     const buildStage = async (instructions: string, s?: AbortSignal): Promise<TokenUsage> => {
+      // The Builder stage uses the `builder` role's resolution.
+      const rm = (await this.resolveModel('builder')) ?? resolved;
       const base: WireMessage[] = [
         ...baseWire,
         { role: 'user', content: [{ type: 'text', text: instructions }, ...imageParts] },
       ];
       const res = await runAgentLoop({
-        adapter: resolved.adapter,
-        baseUrl: resolved.baseUrl,
-        apiKey: resolved.apiKey,
-        modelId: resolved.modelId,
+        adapter: rm.adapter,
+        baseUrl: rm.baseUrl,
+        apiKey: rm.apiKey,
+        modelId: rm.modelId,
         system: this.systemWithSkills(SOLO_SYSTEM),
         history: gcHistory(base),
         tools: this.toolsWithSkills(),
@@ -662,6 +808,7 @@ export class SessionCore {
         upsertCard(cards, card);
         this.deps.post({ type: 'gateUpdate', card });
       },
+      modelLabelFor: (role) => this.roleModelLabel(settings, role),
       signal,
     });
 
@@ -1101,12 +1248,21 @@ export class SessionCore {
     return metas.length > 0 ? buildToolSpecs({ skills: metas }) : this.allTools;
   }
 
-  private async resolveModel(): Promise<ResolvedModel | null> {
+  /**
+   * Resolve the model to run a given Coop `role` (or, with no role, the plain
+   * conversation model). The chain is:
+   *   conversation `roleModelOverrides[role]` → settings `harness.roleModelOverrides[role]`
+   *   → conversation `model`.
+   * Override layers that reference a deleted provider/model fall through to the
+   * next layer; the final conversation-model layer only requires the provider to
+   * still exist (mirroring the historical behavior). Returns null only when
+   * nothing in the chain resolves.
+   */
+  private async resolveModel(role?: CoopRole): Promise<ResolvedModel | null> {
     const settings = await this.ensureSettings();
-    const ref = this.conv.model;
-    if (!ref) return null;
-    const provider = settings.providers.find((p) => p.id === ref.providerId);
-    if (!provider) return null;
+    const found = this.resolveRef(settings, role);
+    if (!found) return null;
+    const { provider, ref } = found;
     const apiKey = provider.requiresApiKey ? await this.deps.secrets.get(provider.id) : undefined;
     return {
       adapter: this.createAdapter(provider.sdkType),
@@ -1114,6 +1270,47 @@ export class SessionCore {
       apiKey,
       modelId: ref.modelId,
     };
+  }
+
+  /**
+   * The provider + ModelRef that a role resolves to under the override chain, or
+   * null. Override layers require the model to still exist; the conversation-model
+   * fallback requires only the provider (a model list may lag behind a fetch).
+   */
+  private resolveRef(
+    settings: FowlPlaySettings,
+    role?: CoopRole,
+  ): { provider: ProviderConfig; ref: ModelRef } | null {
+    const layers: Array<{ ref: ModelRef | null | undefined; requireModel: boolean }> = [];
+    if (role) {
+      layers.push({ ref: this.conv.roleModelOverrides?.[role], requireModel: true });
+      layers.push({ ref: settings.harness.roleModelOverrides?.[role], requireModel: true });
+    }
+    layers.push({ ref: this.conv.model, requireModel: false });
+
+    for (const { ref, requireModel } of layers) {
+      if (!ref) continue;
+      const provider = settings.providers.find((p) => p.id === ref.providerId);
+      if (!provider) continue;
+      if (requireModel && !provider.models.some((m) => m.id === ref.modelId)) continue;
+      return { provider, ref };
+    }
+    return null;
+  }
+
+  /** Display label for the model a role resolves to (for gate cards / status). */
+  private roleModelLabel(settings: FowlPlaySettings, role: CoopRole): string | undefined {
+    const found = this.resolveRef(settings, role);
+    if (!found) return undefined;
+    const model = found.provider.models.find((m) => m.id === found.ref.modelId);
+    return model?.displayName || model?.id || found.ref.modelId;
+  }
+
+  /** Display label for an explicit ModelRef (used in mention confirmations). */
+  private labelForRef(ref: ModelRef): string {
+    const provider = this.settingsCache?.providers.find((p) => p.id === ref.providerId);
+    const model = provider?.models.find((m) => m.id === ref.modelId);
+    return model?.displayName || model?.id || ref.modelId;
   }
 
   /** Wire history that a follow-up from `userNodeId` should build on. */
@@ -1311,4 +1508,20 @@ function stripFences(text: string): string {
 
 function errMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/** A ModelMatch as a bare ModelRef. */
+function refOf(match: ModelMatch): ModelRef {
+  return { providerId: match.providerId, modelId: match.modelId };
+}
+
+/** Human word for a mention target, e.g. "conversation" or "Builder". */
+function roleWord(role: MentionRole): string {
+  return role === 'conversation' ? 'conversation' : role;
+}
+
+/** "Builder → Qwen3.6-35B-MoE" / "Model → Qwen3.6-35B-MoE" for confirmation toasts. */
+function assignmentLabel(role: MentionRole, modelLabel: string): string {
+  const who = role === 'conversation' ? 'Model' : `${role[0].toUpperCase()}${role.slice(1)}`;
+  return `${who} → ${modelLabel}`;
 }

--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -45,11 +45,13 @@ import { runAgentLoop } from '../core/agent/loop';
 import { buildToolSpecs, type DirEntry, type GrepMatch, type GrepOptions, type StageOp, type ToolHost } from '../core/agent/tools';
 import { BUNDLED_SKILLS, formatSkillCatalog, parseSkill } from '../core/agent/skills';
 import { gcHistory } from '../core/agent/contextGc';
+import { trimWireToBudget, wireTokens } from '../core/agent/contextBudget';
 import { StagingOverlay, type DiskReader } from '../core/staging/overlay';
 import { ChangeSet } from '../core/staging/changeset';
 import { detectDrift, rebase as coreRebase } from '../core/staging/rebase';
 import { renderHunkDiff } from '../core/diff/compute';
 import {
+  ContextExceededError,
   runCoopPipeline,
   type ChangesetInspector,
   type RoleRunner,
@@ -709,11 +711,29 @@ export class SessionCore {
     assistantId: string,
     signal: AbortSignal,
   ): Promise<{ blocks: ContentBlock[]; usage: TokenUsage }> {
+    const settings = await this.ensureSettings();
     const fullHistory: WireMessage[] = [
       ...baseWire,
       { role: 'user', content: [{ type: 'text', text: userText }, ...imageParts] },
     ];
-    const sent = gcHistory(fullHistory);
+    let sent = gcHistory(fullHistory);
+
+    // Hard context-window management: trim oldest turns to fit the conversation
+    // model's payload budget. If the newest turn alone still overruns, surface a
+    // friendly error block instead of letting the provider 400 on us.
+    const budget = this.payloadBudget(settings);
+    if (budget !== undefined) {
+      const trimmed = trimWireToBudget(sent, budget);
+      sent = trimmed.messages;
+      if (wireTokens(sent) > budget) {
+        const label = this.roleModelLabel(settings) ?? 'the selected model';
+        const window = this.roleWindow(settings);
+        return {
+          blocks: [{ type: 'error', message: contextExceededMessage(label, window) }],
+          usage: emptyUsage(),
+        };
+      }
+    }
 
     const result = await runAgentLoop({
       adapter: resolved.adapter,
@@ -781,13 +801,34 @@ export class SessionCore {
         ...baseWire,
         { role: 'user', content: [{ type: 'text', text: instructions }, ...imageParts] },
       ];
+      let history = gcHistory(base);
+
+      // Trim oldest turns to the Builder model's payload budget. If the newest
+      // turn alone overruns, throw — the pipeline turns this into a Context limit
+      // gate and a `context-exceeded` outcome.
+      const budget = this.payloadBudget(settings, 'builder');
+      if (budget !== undefined) {
+        const trimmed = trimWireToBudget(history, budget);
+        history = trimmed.messages;
+        const needed = wireTokens(history);
+        if (needed > budget) {
+          throw new ContextExceededError({
+            role: 'builder',
+            modelLabel: this.roleModelLabel(settings, 'builder'),
+            windowTokens: this.roleWindow(settings, 'builder'),
+            neededTokens: needed,
+            budgetTokens: budget,
+          });
+        }
+      }
+
       const res = await runAgentLoop({
         adapter: rm.adapter,
         baseUrl: rm.baseUrl,
         apiKey: rm.apiKey,
         modelId: rm.modelId,
         system: this.systemWithSkills(SOLO_SYSTEM),
-        history: gcHistory(base),
+        history,
         tools: this.toolsWithSkills(),
         toolHost: this.toolHost(),
         onEvent: (e) => this.deps.post({ type: 'stream', event: e }),
@@ -809,6 +850,7 @@ export class SessionCore {
         this.deps.post({ type: 'gateUpdate', card });
       },
       modelLabelFor: (role) => this.roleModelLabel(settings, role),
+      diffBudgetFor: (role) => this.payloadBudget(settings, role),
       signal,
     });
 
@@ -823,6 +865,11 @@ export class SessionCore {
       case 'security-blocked':
         blocks.push({ type: 'text', text: 'Sentry flagged a security concern. The changes remain staged — review carefully before applying.' });
         break;
+      case 'context-exceeded': {
+        const label = result.context?.modelLabel ?? 'the selected model';
+        blocks.push({ type: 'text', text: contextExceededMessage(label, result.context?.windowTokens) });
+        break;
+      }
       case 'cancelled':
         blocks.push({ type: 'text', text: 'Cancelled.' });
         break;
@@ -1299,11 +1346,32 @@ export class SessionCore {
   }
 
   /** Display label for the model a role resolves to (for gate cards / status). */
-  private roleModelLabel(settings: FowlPlaySettings, role: CoopRole): string | undefined {
+  private roleModelLabel(settings: FowlPlaySettings, role?: CoopRole): string | undefined {
     const found = this.resolveRef(settings, role);
     if (!found) return undefined;
     const model = found.provider.models.find((m) => m.id === found.ref.modelId);
     return model?.displayName || model?.id || found.ref.modelId;
+  }
+
+  /** The known context window (tokens) of the model a role resolves to, if any. */
+  private roleWindow(settings: FowlPlaySettings, role?: CoopRole): number | undefined {
+    const found = this.resolveRef(settings, role);
+    const model = found?.provider.models.find((m) => m.id === found.ref.modelId);
+    const window = model?.contextWindow;
+    return window && window > 0 ? window : undefined;
+  }
+
+  /**
+   * The payload token budget for a role's model: the context window minus a
+   * reserve for the system prompt, instructions, and response headroom
+   * (`max(1500, 25% of window)`). Returns `undefined` when the window is unknown
+   * — no hard budget, preserving today's behavior for such providers.
+   */
+  private payloadBudget(settings: FowlPlaySettings, role?: CoopRole): number | undefined {
+    const window = this.roleWindow(settings, role);
+    if (window === undefined) return undefined;
+    const reserve = Math.max(1500, Math.floor(window * 0.25));
+    return Math.max(0, window - reserve);
   }
 
   /** Display label for an explicit ModelRef (used in mention confirmations). */
@@ -1410,6 +1478,18 @@ export function createSessionCore(
 
 function emptyUsage(): TokenUsage {
   return { inputTokens: 0, outputTokens: 0, cachedTokens: 0 };
+}
+
+/** User-facing message when a request + its context overruns the model's window. */
+function contextExceededMessage(modelLabel: string, windowTokens?: number): string {
+  const size = windowTokens ? ` (~${fmtTokensK(windowTokens)})` : '';
+  return `The request plus its context exceeds ${modelLabel}'s context window${size}. Trim the request, start a fresh conversation, or pick a larger model.`;
+}
+
+/** Format a token count with a thousands suffix, e.g. 1234 → "1.2k". */
+function fmtTokensK(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k`;
+  return String(n);
 }
 
 /** Strip skill bodies down to catalog metadata (name + description). */

--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -54,8 +54,25 @@ import {
   ContextExceededError,
   runCoopPipeline,
   type ChangesetInspector,
+  type CoopResult,
   type RoleRunner,
 } from '../core/harness/coop';
+import {
+  FOREMAN_SYSTEM,
+  composeStoryPrompt,
+  parseForeman,
+  renderSpecMarkdown,
+  specRelPath,
+  type PrdPlan,
+  type PrdStory,
+} from '../core/harness/prd';
+import {
+  createCard,
+  joinSections,
+  numberedList,
+  section,
+  transition,
+} from '../core/harness/evidence';
 import {
   appendAssistant,
   appendUser,
@@ -187,6 +204,8 @@ export class SessionCore {
     attachments?: Attachment[];
     queue: { role: MentionRole; query: string; candidates: ModelMatch[] }[];
     assignments: string[];
+    /** Carried through the disambiguation so a held PRD prompt still decomposes on release. */
+    prd?: boolean;
   } | null = null;
 
   /**
@@ -240,7 +259,10 @@ export class SessionCore {
         await this.onReady();
         return;
       case 'sendPrompt':
-        await this.onSendPrompt(msg.text, msg.attachments);
+        await this.onSendPrompt(msg.text, msg.attachments, msg.prd);
+        return;
+      case 'continueStoryLoop':
+        await this.onContinueStoryLoop();
         return;
       case 'cancelResponse':
         this.abort?.abort();
@@ -469,7 +491,7 @@ export class SessionCore {
    * turn; otherwise the turn runs with the ORIGINAL full text (mentions are not
    * stripped from what the model sees — keeping history honest is harmless).
    */
-  private async onSendPrompt(text: string, attachments?: Attachment[]): Promise<void> {
+  private async onSendPrompt(text: string, attachments?: Attachment[], prd?: boolean): Promise<void> {
     const trimmed = text.trim();
     const atts = attachments ?? [];
     if (!trimmed && atts.length === 0) return;
@@ -501,7 +523,7 @@ export class SessionCore {
     if (queue.length > 0) {
       // Hold the whole prompt (selection stays pinned) until every ambiguity is
       // resolved; surface the first choice now.
-      this.heldMention = { text, attachments, queue, assignments };
+      this.heldMention = { text, attachments, queue, assignments, prd };
       const first = queue[0];
       this.deps.post({
         type: 'modelMentionChoice',
@@ -512,7 +534,7 @@ export class SessionCore {
       return;
     }
 
-    await this.finishMentions(text, attachments, assignments);
+    await this.finishMentions(text, attachments, assignments, prd);
   }
 
   /** Resolve one held ambiguity, then advance the queue or release the prompt. */
@@ -538,7 +560,7 @@ export class SessionCore {
       return;
     }
     this.heldMention = null;
-    await this.finishMentions(held.text, held.attachments, held.assignments);
+    await this.finishMentions(held.text, held.attachments, held.assignments, held.prd);
   }
 
   /** Apply a resolved mention to the conversation (role override or the model itself). */
@@ -558,7 +580,7 @@ export class SessionCore {
    * (directive-only message: no turn, just a confirmation toast) or run the turn
    * with the original full text.
    */
-  private async finishMentions(text: string, attachments: Attachment[] | undefined, assignments: string[]): Promise<void> {
+  private async finishMentions(text: string, attachments: Attachment[] | undefined, assignments: string[], prd?: boolean): Promise<void> {
     if (assignments.length > 0) {
       this.sendConversation();
       await this.persist();
@@ -570,10 +592,10 @@ export class SessionCore {
       this.toast('info', assignments.join(', '));
       return;
     }
-    await this.runPromptTurn(text, attachments);
+    await this.runPromptTurn(text, attachments, prd);
   }
 
-  private async runPromptTurn(text: string, attachments?: Attachment[]): Promise<void> {
+  private async runPromptTurn(text: string, attachments?: Attachment[], prd?: boolean): Promise<void> {
     const trimmed = text.trim();
     const atts = attachments ?? [];
     if (!trimmed && atts.length === 0) return;
@@ -615,7 +637,7 @@ export class SessionCore {
 
     const { conv, nodeId } = appendUser(this.conv, [{ type: 'text', text: displayText || '(see attachments)' }]);
     this.conv = conv;
-    await this.runAssistantTurn(nodeId, imageParts);
+    await this.runAssistantTurn(nodeId, imageParts, { prd });
   }
 
   private async onEditMessage(nodeId: string, text: string): Promise<void> {
@@ -638,8 +660,18 @@ export class SessionCore {
     }
   }
 
-  /** The shared turn engine: given a user node, produce an assistant response. */
-  private async runAssistantTurn(userNodeId: string, imageParts: WireUserPart[] = []): Promise<void> {
+  /**
+   * The shared turn engine: given a user node, produce an assistant response.
+   *
+   * `opts.prd` runs the PRD front-end (Foreman decomposition → write specs → build story 1);
+   * `opts.storyIndex` runs one story of an existing plan (used by `continueStoryLoop`).
+   * With neither, the turn runs an ordinary Coop or Solo response.
+   */
+  private async runAssistantTurn(
+    userNodeId: string,
+    imageParts: WireUserPart[] = [],
+    opts: { prd?: boolean; storyIndex?: number } = {},
+  ): Promise<void> {
     const settings = await this.ensureSettings();
     const resolved = await this.resolveModel();
     if (!resolved) {
@@ -672,7 +704,15 @@ export class SessionCore {
     let blocks: ContentBlock[] = [];
     let usage: TokenUsage = emptyUsage();
     try {
-      if (this.conv.harnessMode === 'coop') {
+      if (opts.prd) {
+        const out = await this.runPrd(userText, imageParts, baseWire, resolved, settings.harness, signal);
+        blocks = out.blocks;
+        usage = out.usage;
+      } else if (opts.storyIndex !== undefined) {
+        const out = await this.runStory(opts.storyIndex, baseWire, resolved, settings.harness, signal);
+        blocks = out.blocks;
+        usage = out.usage;
+      } else if (this.conv.harnessMode === 'coop') {
         const out = await this.runCoop(userText, imageParts, baseWire, resolved, settings.harness, signal);
         blocks = out.blocks;
         usage = out.usage;
@@ -762,10 +802,33 @@ export class SessionCore {
     harness: HarnessSettings,
     signal: AbortSignal,
   ): Promise<{ blocks: ContentBlock[]; usage: TokenUsage }> {
-    const settings = await this.ensureSettings();
     const cards: GateCard[] = [];
+    const result = await this.runCoopCore(userText, imageParts, baseWire, resolved, harness, signal, cards);
+
+    const blocks: ContentBlock[] = cards.map((card) => ({ type: 'gate', card }));
+    const text = this.coopOutcomeText(result);
+    if (text) blocks.push({ type: 'text', text });
+    return { blocks, usage: result.usage };
+  }
+
+  /**
+   * Wire up the Coop collaborators (per-role model runner, changeset inspector, Builder
+   * loop) and run the pipeline once for `userPrompt`. Emitted gate cards are pushed onto
+   * `cards` and streamed to the webview. Shared by ordinary Coop turns and per-story PRD
+   * builds — the caller maps the returned outcome to blocks / plan status.
+   */
+  private async runCoopCore(
+    userPrompt: string,
+    imageParts: WireUserPart[],
+    baseWire: WireMessage[],
+    resolved: ResolvedModel,
+    harness: HarnessSettings,
+    signal: AbortSignal,
+    cards: GateCard[],
+  ): Promise<CoopResult> {
+    const settings = await this.ensureSettings();
     const runner: RoleRunner = {
-      run: async ({ role, system, userPrompt, readOnly, signal: s }) => {
+      run: async ({ role, system, userPrompt: rolePrompt, readOnly, signal: s }) => {
         // Each role resolves its own model through the override chain, falling
         // back to the turn's conversation model.
         const rm = (await this.resolveModel(role)) ?? resolved;
@@ -775,7 +838,7 @@ export class SessionCore {
           apiKey: rm.apiKey,
           modelId: rm.modelId,
           system,
-          history: [{ role: 'user', content: [{ type: 'text', text: userPrompt }] }],
+          history: [{ role: 'user', content: [{ type: 'text', text: rolePrompt }] }],
           tools: readOnly ? this.readOnlyTools : this.allTools,
           toolHost: this.toolHost(),
           onEvent: () => {}, // role calls are summarized as gate cards, not streamed
@@ -839,8 +902,8 @@ export class SessionCore {
       return res.usage;
     };
 
-    const result = await runCoopPipeline({
-      userPrompt: userText,
+    return runCoopPipeline({
+      userPrompt,
       runner,
       inspector,
       buildStage,
@@ -853,30 +916,264 @@ export class SessionCore {
       diffBudgetFor: (role) => this.payloadBudget(settings, role),
       signal,
     });
+  }
 
-    const blocks: ContentBlock[] = cards.map((card) => ({ type: 'gate', card }));
+  /** The explanatory text block for a non-ready Coop outcome (empty for ready-for-review). */
+  private coopOutcomeText(result: CoopResult): string {
     switch (result.outcome) {
       case 'blocked':
-        blocks.push({ type: 'text', text: result.question ?? 'The request needs clarification before work can begin.' });
-        break;
+        return result.question ?? 'The request needs clarification before work can begin.';
       case 'qas-failed':
-        blocks.push({ type: 'text', text: 'The Inspector could not approve the changes within the retry budget. They remain staged for your review.' });
-        break;
+        return 'The Inspector could not approve the changes within the retry budget. They remain staged for your review.';
       case 'security-blocked':
-        blocks.push({ type: 'text', text: 'Sentry flagged a security concern. The changes remain staged — review carefully before applying.' });
-        break;
-      case 'context-exceeded': {
-        const label = result.context?.modelLabel ?? 'the selected model';
-        blocks.push({ type: 'text', text: contextExceededMessage(label, result.context?.windowTokens) });
-        break;
-      }
+        return 'Sentry flagged a security concern. The changes remain staged — review carefully before applying.';
+      case 'context-exceeded':
+        return contextExceededMessage(result.context?.modelLabel ?? 'the selected model', result.context?.windowTokens);
       case 'cancelled':
-        blocks.push({ type: 'text', text: 'Cancelled.' });
-        break;
+        return 'Cancelled.';
       case 'ready-for-review':
-        break;
+        return '';
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // PRD builds (Foreman decomposition → per-story build loop)
+  // -------------------------------------------------------------------------
+
+  /**
+   * A PRD turn: the Foreman decomposes the PRD into ordered stories (read-only, Scout's
+   * model), each story is written to disk as a spec, the plan is stored on the conversation,
+   * and story 1 is built immediately within this same turn. A decomposition failure (<2
+   * stories, or unparseable output) blocks the Foreman card and creates no plan.
+   */
+  private async runPrd(
+    userText: string,
+    imageParts: WireUserPart[],
+    baseWire: WireMessage[],
+    resolved: ResolvedModel,
+    harness: HarnessSettings,
+    signal: AbortSignal,
+  ): Promise<{ blocks: ContentBlock[]; usage: TokenUsage }> {
+    const settings = await this.ensureSettings();
+    const usage: TokenUsage = emptyUsage();
+    const cards: GateCard[] = [];
+    const emit = (card: GateCard): GateCard => {
+      upsertCard(cards, card);
+      this.deps.post({ type: 'gateUpdate', card });
+      return card;
+    };
+    const gateBlocks = (): ContentBlock[] => cards.map((card) => ({ type: 'gate', card }));
+
+    // --- Foreman gate: decompose the PRD (Scout's model, read-only) ---
+    let foremanCard = emit(
+      createCard('gate-foreman-1', {
+        role: 'foreman',
+        title: 'Foreman — PRD decomposition',
+        evidence: 'Decomposing the PRD into ordered, independently-buildable stories…',
+        modelLabel: this.roleModelLabel(settings, 'scout'),
+      }),
+    );
+    if (signal.aborted) {
+      emit(transition(foremanCard, 'failed', { evidence: joinSections(foremanCard.evidence, '_Cancelled by user._') }));
+      return { blocks: [...gateBlocks(), { type: 'text', text: 'Cancelled.' }], usage };
+    }
+
+    const rm = (await this.resolveModel('scout')) ?? resolved;
+    const res = await runAgentLoop({
+      adapter: rm.adapter,
+      baseUrl: rm.baseUrl,
+      apiKey: rm.apiKey,
+      modelId: rm.modelId,
+      system: FOREMAN_SYSTEM,
+      history: [{ role: 'user', content: [{ type: 'text', text: userText }, ...imageParts] }],
+      tools: this.readOnlyTools,
+      toolHost: this.toolHost(),
+      onEvent: () => {},
+      maxRounds: 8,
+      signal,
+    });
+    addUsageInPlace(usage, res.usage);
+    const foremanUsage = res.usage;
+
+    if (signal.aborted) {
+      emit(transition(foremanCard, 'failed', { usage: foremanUsage, evidence: joinSections(foremanCard.evidence, '_Cancelled by user._') }));
+      return { blocks: [...gateBlocks(), { type: 'text', text: 'Cancelled.' }], usage };
+    }
+
+    const stories = parseForeman(joinText(res.blocks));
+    if (stories.length < 2) {
+      emit(
+        transition(foremanCard, 'blocked', {
+          usage: foremanUsage,
+          evidence: joinSections(
+            section('Could not decompose', 'The PRD did not yield at least two ordered, buildable stories.'),
+            section('What to do', 'Rephrase the PRD, split it into clearer deliverables, or send it as a normal request.'),
+          ),
+        }),
+      );
+      return {
+        blocks: [...gateBlocks(), { type: 'text', text: 'Could not decompose the PRD into stories — rephrase or split it, or send it as a normal request.' }],
+        usage,
+      };
+    }
+
+    // --- Build the plan + write each spec to disk (direct meta-artifacts) ---
+    const total = stories.length;
+    const plan: PrdPlan = { stories: [], cursor: 0 };
+    for (let i = 0; i < total; i += 1) {
+      const s = stories[i];
+      const specPath = specRelPath(this.conv.id, i + 1, s.title);
+      const story: PrdStory = { title: s.title, summary: s.summary, criteria: s.criteria, specPath, status: 'pending' };
+      plan.stories.push(story);
+      await this.writeSpec(story, i + 1, total);
+    }
+    this.conv = { ...this.conv, prdPlan: plan };
+
+    emit(
+      transition(foremanCard, 'passed', {
+        usage: foremanUsage,
+        evidence: joinSections(
+          section(`Decomposed into ${total} stories`, numberedList(plan.stories.map((s) => s.title))),
+          section('Next', 'Building story 1 now; you review between stories.'),
+        ),
+      }),
+    );
+
+    // --- Build story 1 immediately, within this same turn ---
+    const story1 = await this.runStory(0, baseWire, resolved, harness, signal);
+    addUsageInPlace(usage, story1.usage);
+
+    // Blocks: Foreman gate, the plan marker (renders live), then story 1's cards + outcome.
+    return { blocks: [...gateBlocks(), { type: 'plan' }, ...story1.blocks], usage };
+  }
+
+  /**
+   * Run the Coop pipeline for one story of the current plan, mapping the outcome to the
+   * story's status and the explanatory blocks. Updates the story's spec file on disk after
+   * each transition (best-effort; rebuilt from plan data if it went missing).
+   */
+  private async runStory(
+    storyIndex: number,
+    baseWire: WireMessage[],
+    resolved: ResolvedModel,
+    harness: HarnessSettings,
+    signal: AbortSignal,
+  ): Promise<{ blocks: ContentBlock[]; usage: TokenUsage }> {
+    const plan = this.conv.prdPlan;
+    const story = plan?.stories[storyIndex];
+    if (!plan || !story) {
+      return { blocks: [{ type: 'text', text: 'No story to build — the plan is missing.' }], usage: emptyUsage() };
+    }
+
+    const total = plan.stories.length;
+    this.setStoryStatus(storyIndex, 'building');
+    await this.writeSpec(this.conv.prdPlan!.stories[storyIndex], storyIndex + 1, total);
+
+    const specMarkdown = renderSpecMarkdown(this.conv.prdPlan!.stories[storyIndex], storyIndex + 1, total);
+    const userPrompt = composeStoryPrompt(specMarkdown, storyIndex + 1, total);
+
+    const cards: GateCard[] = [];
+    const result = await this.runCoopCore(userPrompt, [], baseWire, resolved, harness, signal, cards);
+
+    const status: PrdStory['status'] =
+      result.outcome === 'ready-for-review' ? 'awaiting-review' : result.outcome === 'cancelled' ? 'pending' : 'failed';
+    this.setStoryStatus(storyIndex, status);
+    await this.writeSpec(this.conv.prdPlan!.stories[storyIndex], storyIndex + 1, total);
+
+    const blocks: ContentBlock[] = cards.map((card) => ({ type: 'gate', card }));
+    const text = this.coopOutcomeText(result);
+    if (text) blocks.push({ type: 'text', text });
     return { blocks, usage: result.usage };
+  }
+
+  /**
+   * Advance a PRD build to the next story. Ignored while a turn is streaming. Marks the
+   * cursor story done (a failed story continued past is also marked done — the human decided
+   * to move on; the `(skipped review)` nuance is recorded only in the spec file). If no
+   * stories remain, appends a completion summary; otherwise appends a synthetic user node
+   * and runs the next story as a fresh turn (so rewind/branching stay coherent).
+   */
+  private async onContinueStoryLoop(): Promise<void> {
+    if (this.abort) return; // a turn is in flight — ignore
+    const plan = this.conv.prdPlan;
+    if (!plan) return;
+    const i = plan.cursor;
+    const current = plan.stories[i];
+    if (!current) return;
+    if (current.status === 'building') return; // defensive — a turn should be in flight
+
+    // A pending cursor story was cancelled (or never started): Continue means
+    // RETRY it, not mark it done and skip past work that never happened.
+    if (current.status === 'pending') {
+      const { conv, nodeId } = appendUser(this.conv, [
+        { type: 'text', text: `Resume story ${i + 1}: ${current.title}` },
+      ]);
+      this.conv = conv;
+      await this.runAssistantTurn(nodeId, [], { storyIndex: i });
+      return;
+    }
+
+    const skippedReview = current.status === 'failed';
+    const stories = plan.stories.map((s, idx) => (idx === i ? { ...s, status: 'done' as const } : s));
+    const nextCursor = i + 1;
+    this.conv = { ...this.conv, prdPlan: { stories, cursor: nextCursor } };
+    // Record the skipped-review nuance in the spec file only (state machine stays simple).
+    await this.writeSpec(stories[i], i + 1, stories.length, skippedReview ? 'skipped review' : undefined);
+
+    if (nextCursor >= stories.length) {
+      // Plan complete — summarize the final statuses in a short assistant block.
+      const summary = this.renderPlanSummary(stories);
+      const { conv } = appendAssistant(this.conv, [{ type: 'text', text: summary }], {
+        parentId: this.conv.currentLeafId ?? undefined,
+        model: this.conv.model ?? undefined,
+      });
+      this.conv = conv;
+      await this.persist();
+      this.sendConversation();
+      return;
+    }
+
+    // Run the next story as a new turn, parented on a synthetic "Continue" user node.
+    const next = stories[nextCursor];
+    const { conv, nodeId } = appendUser(this.conv, [
+      { type: 'text', text: `Continue to story ${nextCursor + 1}: ${next.title}` },
+    ]);
+    this.conv = conv;
+    await this.runAssistantTurn(nodeId, [], { storyIndex: nextCursor });
+  }
+
+  /** Set a story's status immutably on the conversation's plan (no-op if the plan is gone). */
+  private setStoryStatus(index: number, status: PrdStory['status']): void {
+    const plan = this.conv.prdPlan;
+    if (!plan || !plan.stories[index]) return;
+    const stories = plan.stories.map((s, idx) => (idx === index ? { ...s, status } : s));
+    this.conv = { ...this.conv, prdPlan: { ...plan, stories } };
+  }
+
+  /**
+   * Write (or rewrite) a story's spec file. A direct meta-artifact — NOT staged through the
+   * overlay. Best-effort: swallows write errors so a spec-write hiccup never fails a build.
+   */
+  private async writeSpec(story: PrdStory, index: number, total: number, note?: string): Promise<void> {
+    try {
+      await this.deps.io.write(story.specPath, renderSpecMarkdown(story, index, total, undefined, note));
+    } catch {
+      /* spec files are best-effort meta-artifacts */
+    }
+  }
+
+  /** A one-line-per-story completion summary for a finished PRD build. */
+  private renderPlanSummary(stories: PrdStory[]): string {
+    const glyph: Record<PrdStory['status'], string> = {
+      pending: '○',
+      building: '…',
+      'awaiting-review': '◉',
+      done: '✓',
+      failed: '✕',
+    };
+    const done = stories.filter((s) => s.status === 'done').length;
+    const lines = stories.map((s, i) => `${i + 1}. ${glyph[s.status]} ${s.title}`);
+    return `PRD build complete — ${done} of ${stories.length} stories done.\n\n${lines.join('\n')}`;
   }
 
   private finalizeAssistant(nodeId: string, blocks: ContentBlock[], usage: TokenUsage): void {
@@ -1503,6 +1800,13 @@ function addUsage(a: TokenUsage, b: TokenUsage): TokenUsage {
     outputTokens: a.outputTokens + b.outputTokens,
     cachedTokens: a.cachedTokens + b.cachedTokens,
   };
+}
+
+/** Accumulate `b` into `a` in place (for summing usage across sub-calls in one turn). */
+function addUsageInPlace(a: TokenUsage, b: TokenUsage): void {
+  a.inputTokens += b.inputTokens;
+  a.outputTokens += b.outputTokens;
+  a.cachedTokens += b.cachedTokens;
 }
 
 function firstText(blocks: ContentBlock[]): string | null {

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -29,8 +29,12 @@ export type WebviewToHost =
   // lifecycle
   | { type: 'ready' }
   // chat
-  | { type: 'sendPrompt'; text: string; attachments?: Attachment[] }
+  // `prd: true` decomposes the prompt as a PRD (Foreman → per-story build loop) instead of
+  // running it as a single Coop/Solo turn. Ordinary sends omit the flag.
+  | { type: 'sendPrompt'; text: string; attachments?: Attachment[]; prd?: boolean }
   | { type: 'cancelResponse' }
+  // Advance a PRD build to the next story (marks the cursor story done, runs the next).
+  | { type: 'continueStoryLoop' }
   | { type: 'clearSelection' }                                    // dismiss the pinned selection chip
   | { type: 'editMessage'; nodeId: string; text: string }        // branches
   | { type: 'rerunMessage'; nodeId: string }                      // sibling response

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -9,6 +9,7 @@ import type {
   ChangeSetView,
   Conversation,
   ConversationSummary,
+  CoopRole,
   FowlPlaySettings,
   GateCard,
   HarnessMode,
@@ -40,6 +41,10 @@ export type WebviewToHost =
   // model & harness
   | { type: 'setModel'; model: ModelRef }
   | { type: 'setHarnessMode'; mode: HarnessMode }
+  // per-role model mention disambiguation: resolve a held ambiguous mention
+  // (non-null applies the pick; null dismisses it). `role: 'conversation'`
+  // targets the conversation model, otherwise a specific Coop role.
+  | { type: 'resolveModelMention'; role: CoopRole | 'conversation'; model: ModelRef | null }
   // diff review
   | { type: 'openDiff'; changesetId?: string }                    // omit = current
   | { type: 'toggleRevert'; hunkId: string; reverted: boolean }
@@ -96,6 +101,15 @@ export type HostToWebview =
   // settings & providers
   | { type: 'settings'; settings: FowlPlaySettings }
   | { type: 'modelsFetched'; providerId: string; models: { id: string; contextWindow?: number }[]; error?: string }
+  // per-role model mention disambiguation: an ambiguous "<name> for <role>"
+  // matched more than one configured model. The whole prompt is held until the
+  // webview posts `resolveModelMention`. Emitted one ambiguity at a time.
+  | {
+      type: 'modelMentionChoice';
+      role: CoopRole | 'conversation';
+      query: string;
+      candidates: { providerId: string; modelId: string; label: string }[];
+    }
   // misc
   | { type: 'showView'; view: 'chat' | 'diff' | 'settings' | 'history' }
   | { type: 'toast'; level: 'info' | 'warn' | 'error'; message: string };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -221,6 +221,8 @@ export interface GateCard {
   /** For inspector/sentry: findings that routed work back. */
   findings?: string[];
   attempt?: number;            // builder/inspector retry round
+  /** Token usage this role spent (shown dimmed in the card footer). */
+  usage?: TokenUsage;
 }
 
 export interface HarnessSettings {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -116,6 +116,13 @@ export interface Conversation {
   rootIds: string[];
   currentLeafId: string | null;
   model: ModelRef | null;
+  /**
+   * Per-conversation role model overrides (Coop). Highest-priority layer in the
+   * per-role resolution chain: conversation override → settings-level
+   * `harness.roleModelOverrides` → conversation `model`. Rides on the Conversation
+   * object so it persists with history (plain JSON).
+   */
+  roleModelOverrides?: Partial<Record<CoopRole, ModelRef>>;
   harnessMode: HarnessMode;
   createdAt: number;
   updatedAt: number;
@@ -205,6 +212,8 @@ export interface GateCard {
   role: CoopRole | 'stop-the-line' | 'hitl';
   title: string;               // e.g. "Inspector — QA validation"
   status: GateStatus;
+  /** Display label of the model that ran this role (Coop per-role models). */
+  modelLabel?: string;
   /** What was checked / produced. Markdown. */
   evidence: string;
   /** For scout: acceptance criteria. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -68,6 +68,7 @@ export type ContentBlock =
   | { type: 'gate'; card: GateCard }
   | { type: 'changes'; summary: ChangesSummary }          // "Review Changes" block
   | { type: 'commit'; commit: CommitRecord }               // historical commit block
+  | { type: 'plan' }                                       // PRD plan marker — renders live conv.prdPlan
   | { type: 'error'; message: string };
 
 export interface ToolCallRecord {
@@ -124,6 +125,13 @@ export interface Conversation {
    */
   roleModelOverrides?: Partial<Record<CoopRole, ModelRef>>;
   harnessMode: HarnessMode;
+  /**
+   * PRD build plan (Foreman decomposition → per-story build loop). Present once a `/prd`
+   * turn has decomposed a PRD into ordered stories; the plan block renders live from here
+   * (statuses advance across turns). Plain JSON, so it persists with history. Cleared
+   * naturally when a new conversation is started.
+   */
+  prdPlan?: PrdPlan;
   createdAt: number;
   updatedAt: number;
   usageTotals: TokenUsage;
@@ -209,7 +217,7 @@ export type GateStatus = 'running' | 'passed' | 'failed' | 'blocked' | 'skipped'
 /** Evidence-based delivery: every gate emits a card with its proof. */
 export interface GateCard {
   id: string;
-  role: CoopRole | 'stop-the-line' | 'hitl';
+  role: CoopRole | 'stop-the-line' | 'hitl' | 'foreman';
   title: string;               // e.g. "Inspector — QA validation"
   status: GateStatus;
   /** Display label of the model that ran this role (Coop per-role models). */
@@ -229,6 +237,33 @@ export interface HarnessSettings {
   defaultMode: HarnessMode;
   qasRetryBudget: number;      // bounded route-backs, default 2
   roleModelOverrides?: Partial<Record<CoopRole, ModelRef>>;
+}
+
+// ---------------------------------------------------------------------------
+// PRD builds (Foreman decomposition → per-story build loop)
+// ---------------------------------------------------------------------------
+
+/** Lifecycle of one story in a PRD plan. */
+export type PrdStoryStatus = 'pending' | 'building' | 'awaiting-review' | 'done' | 'failed';
+
+/**
+ * One ordered story of a decomposed PRD. `specPath` is the workspace-relative markdown spec
+ * written to disk for this story. Behavior (parsing, spec rendering, path derivation) lives
+ * in `core/harness/prd.ts`; this is the JSON-serializable state that rides on `Conversation`.
+ */
+export interface PrdStory {
+  title: string;
+  summary: string;
+  criteria: string[];
+  specPath: string;
+  status: PrdStoryStatus;
+}
+
+/** A PRD build plan: ordered stories plus the cursor into the story currently in focus. */
+export interface PrdPlan {
+  stories: PrdStory[];
+  /** Index of the story the human is currently building / reviewing. */
+  cursor: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/webview/components/Composer.tsx
+++ b/src/webview/components/Composer.tsx
@@ -1,7 +1,7 @@
 /** Auto-growing composer with attachments, slash commands, send / stop. */
 import { useEffect, useRef, useState } from 'preact/hooks';
 import type { Attachment } from '../../shared/protocol';
-import type { Conversation, FowlPlaySettings, ModelRef, TokenUsage } from '../../shared/types';
+import type { Conversation, CoopRole, FowlPlaySettings, ModelRef, TokenUsage } from '../../shared/types';
 import { post, store, useStore } from './store';
 import { filterCommands, type SlashCommand } from '../slashCommands';
 import { SlashMenu, type SlashItem } from './SlashMenu';
@@ -66,6 +66,9 @@ export function Composer({ streaming }: { streaming: boolean }) {
   const send = () => {
     const t = text.trim();
     if (!t && attachments.length === 0) return;
+    // A new prompt supersedes any pending model-mention picker (host discards
+    // the held prompt too); drop the card so it can't answer a stale question.
+    store.clearModelMentionChoice();
     post({ type: 'sendPrompt', text: t, attachments: attachments.length ? attachments : undefined });
     setText('');
     setAttachments([]);
@@ -323,6 +326,7 @@ export function Composer({ streaming }: { streaming: boolean }) {
 
   return (
     <div class="fp-composer-wrap">
+      <ModelMentionPicker settings={settings} />
       {showStatus && <StatusCard conv={conv} settings={settings} onClose={() => setShowStatus(false)} />}
       {selection && (
         <div class="fp-attachments">
@@ -388,6 +392,74 @@ export function Composer({ streaming }: { streaming: boolean }) {
   );
 }
 
+/** Capitalized, human name for a mention target. */
+function roleTitle(role: string): string {
+  return role === 'conversation' ? 'the conversation' : role[0].toUpperCase() + role.slice(1);
+}
+
+/**
+ * Disambiguation card for an ambiguous per-role model mention ("qwen" matched
+ * two loaded models). Rendered above the composer while the host holds the
+ * prompt. A pick posts `resolveModelMention` with the model; the X (or Esc)
+ * dismisses with null (send without changing that role). Number keys 1–9 pick.
+ */
+function ModelMentionPicker({ settings }: { settings: FowlPlaySettings | null }) {
+  const choice = useStore((s) => s.modelMentionChoice);
+
+  useEffect(() => {
+    if (!choice) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        store.resolveModelMention(null);
+        return;
+      }
+      const n = Number(e.key);
+      if (Number.isInteger(n) && n >= 1 && n <= choice.candidates.length) {
+        e.preventDefault();
+        const c = choice.candidates[n - 1];
+        store.resolveModelMention({ providerId: c.providerId, modelId: c.modelId });
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [choice]);
+
+  if (!choice) return null;
+  const providerName = (id: string) => settings?.providers.find((p) => p.id === id)?.name ?? id;
+
+  return (
+    <div class="fp-mention-card">
+      <div class="fp-mention-head">
+        <span>Which “{choice.query}” for {roleTitle(choice.role)}?</span>
+        <button
+          type="button"
+          class="fp-btn-ghost"
+          style={{ padding: 0 }}
+          onClick={() => store.resolveModelMention(null)}
+          aria-label="Dismiss — send without changing the model"
+        >
+          <IconX size={14} />
+        </button>
+      </div>
+      <div class="fp-mention-options">
+        {choice.candidates.map((c, i) => (
+          <button
+            type="button"
+            class="fp-mention-option"
+            key={`${c.providerId}::${c.modelId}`}
+            onClick={() => store.resolveModelMention({ providerId: c.providerId, modelId: c.modelId })}
+          >
+            <span class="fp-mention-idx">{i + 1}</span>
+            <span class="fp-mention-label">{c.label}</span>
+            <span class="fp-mention-provider">{providerName(c.providerId)}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 const EMPTY_USAGE: TokenUsage = { inputTokens: 0, outputTokens: 0, cachedTokens: 0 };
 
 /**
@@ -413,6 +485,18 @@ function StatusCard({
   const pct = ctx ? Math.min(100, Math.round((lastInput / ctx) * 100)) : 0;
   const mode = conv?.harnessMode ?? settings?.harness.defaultMode ?? 'coop';
 
+  // Active per-role model overrides (conversation layer wins over settings).
+  const ROLES: CoopRole[] = ['scout', 'builder', 'inspector', 'sentry'];
+  const roleOverrides = ROLES.map((r) => {
+    const ref = conv?.roleModelOverrides?.[r] ?? settings?.harness.roleModelOverrides?.[r] ?? null;
+    return ref ? { role: r, label: modelLabel(settings, ref) } : null;
+  }).filter((x): x is { role: CoopRole; label: string } => x !== null);
+  const rolesLine =
+    roleOverrides.length > 0
+      ? roleOverrides.map((o) => `${o.role[0].toUpperCase()}${o.role.slice(1)} → ${o.label}`).join(', ') +
+        (roleOverrides.length < ROLES.length ? ', others → conversation model' : '')
+      : null;
+
   return (
     <div class="fp-status-card">
       <div class="fp-status-card-head">
@@ -424,6 +508,7 @@ function StatusCard({
       <div class="fp-status-card-rows">
         <div class="fp-status-row"><span class="fp-status-key">Model</span><span>{modelLabel(settings, model)}</span></div>
         <div class="fp-status-row"><span class="fp-status-key">Mode</span><span>{mode === 'coop' ? 'Coop (pipeline)' : 'Solo (direct)'}</span></div>
+        {rolesLine && <div class="fp-status-row"><span class="fp-status-key">Roles</span><span>{rolesLine}</span></div>}
         <div class="fp-status-row">
           <span class="fp-status-key">Context</span>
           <span>

--- a/src/webview/components/Composer.tsx
+++ b/src/webview/components/Composer.tsx
@@ -35,6 +35,7 @@ function fmt(n: number): string {
 export function Composer({ streaming }: { streaming: boolean }) {
   const [text, setText] = useState('');
   const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [prdArmed, setPrdArmed] = useState(false);
   const [menuMode, setMenuMode] = useState<MenuMode>('closed');
   const [highlight, setHighlight] = useState(0);
   const [showStatus, setShowStatus] = useState(false);
@@ -69,9 +70,17 @@ export function Composer({ streaming }: { streaming: boolean }) {
     // A new prompt supersedes any pending model-mention picker (host discards
     // the held prompt too); drop the card so it can't answer a stale question.
     store.clearModelMentionChoice();
-    post({ type: 'sendPrompt', text: t, attachments: attachments.length ? attachments : undefined });
+    post({
+      type: 'sendPrompt',
+      text: t,
+      attachments: attachments.length ? attachments : undefined,
+      // The armed "PRD build" chip flags this one send for Foreman decomposition;
+      // it disarms immediately after so ordinary sends stay ordinary.
+      prd: prdArmed || undefined,
+    });
     setText('');
     setAttachments([]);
+    setPrdArmed(false);
     setMenuMode('closed');
     resetHeight();
   };
@@ -121,6 +130,13 @@ export function Composer({ streaming }: { streaming: boolean }) {
       case 'coop':
         post({ type: 'setHarnessMode', mode: 'coop' });
         clearAndClose();
+        break;
+      case 'prd':
+        // Arm the next send as a PRD build (Foreman → per-story loop). The chip
+        // renders above the composer; the send consumes and clears it.
+        setPrdArmed(true);
+        clearAndClose();
+        requestAnimationFrame(() => taRef.current?.focus());
         break;
       case 'diff':
         store.openReview();
@@ -338,8 +354,16 @@ export function Composer({ streaming }: { streaming: boolean }) {
           </span>
         </div>
       )}
-      {attachments.length > 0 && (
+      {(attachments.length > 0 || prdArmed) && (
         <div class="fp-attachments">
+          {prdArmed && (
+            <span class="fp-attach-chip fp-prd-chip" title="The next message is decomposed into stories and built one by one">
+              ⚑ PRD build
+              <button type="button" class="fp-btn-ghost" style={{ padding: 0 }} onClick={() => setPrdArmed(false)} aria-label="Disarm PRD build">
+                <IconX size={13} />
+              </button>
+            </span>
+          )}
           {attachments.map((a, i) => (
             <span class="fp-attach-chip" key={i}>
               {a.name}

--- a/src/webview/components/Settings.tsx
+++ b/src/webview/components/Settings.tsx
@@ -1,6 +1,6 @@
 /** Settings: Appearance, Models & Providers, Harness. */
 import { useState } from 'preact/hooks';
-import type { FowlPlaySettings, AppearanceSettings, ThemeName, HarnessMode, ProviderConfig } from '../../shared/types';
+import type { FowlPlaySettings, AppearanceSettings, ThemeName, HarnessMode, HarnessSettings, ProviderConfig, CoopRole, ModelRef } from '../../shared/types';
 import { post, store, applyAppearance } from './store';
 import { AddProvider, ModelManagement } from './ProviderForm';
 import { IconX, IconPlus, IconTrash, IconArrowRight } from './icons';
@@ -174,6 +174,8 @@ function HarnessTab({ settings }: { settings: FowlPlaySettings | null }) {
         </div>
       </div>
 
+      <RoleModelsSection settings={settings} h={h} mode={mode} budget={budget} />
+
       <div class="fp-section">
         <h2>The Coop pipeline</h2>
         <div class="fp-section-desc">Every stage is rendered in chat as a gate card with pass/fail evidence.</div>
@@ -189,6 +191,71 @@ function HarnessTab({ settings }: { settings: FowlPlaySettings | null }) {
 
       <SkillsSection settings={settings} />
     </>
+  );
+}
+
+const ROLE_ROWS: { role: CoopRole; label: string }[] = [
+  { role: 'scout', label: 'Scout' },
+  { role: 'builder', label: 'Builder' },
+  { role: 'inspector', label: 'Inspector' },
+  { role: 'sentry', label: 'Sentry' },
+];
+
+/** Per-role model overrides: a dropdown per Coop role, saved into harness settings. */
+function RoleModelsSection({
+  settings,
+  h,
+  mode,
+  budget,
+}: {
+  settings: FowlPlaySettings | null;
+  h: HarnessSettings;
+  mode: HarnessMode;
+  budget: number;
+}) {
+  const providers = settings?.providers ?? [];
+  const [ov, setOv] = useState<Partial<Record<CoopRole, ModelRef>>>(h.roleModelOverrides ?? {});
+
+  const change = (role: CoopRole, value: string) => {
+    const next: Partial<Record<CoopRole, ModelRef>> = { ...ov };
+    if (!value) {
+      delete next[role];
+    } else {
+      const [providerId, modelId] = value.split('::');
+      next[role] = { providerId, modelId };
+    }
+    setOv(next);
+    post({ type: 'saveHarnessSettings', harness: { ...h, defaultMode: mode, qasRetryBudget: budget, roleModelOverrides: next } });
+  };
+
+  const valueFor = (role: CoopRole): string => {
+    const r = ov[role];
+    return r ? `${r.providerId}::${r.modelId}` : '';
+  };
+
+  return (
+    <div class="fp-section">
+      <h2>Role models</h2>
+      <div class="fp-section-desc">
+        Assign a specific model to each Coop role. “Default” uses the conversation model. A chat
+        directive like “qwen to orchestrate” overrides these for one conversation.
+      </div>
+      {ROLE_ROWS.map(({ role, label }) => (
+        <div class="fp-field" key={role}>
+          <label>{label}</label>
+          <select class="fp-select" value={valueFor(role)} onChange={(e) => change(role, (e.target as HTMLSelectElement).value)}>
+            <option value="">Default (conversation model)</option>
+            {providers.map((p) => (
+              <optgroup label={p.name} key={p.id}>
+                {p.models.map((m) => (
+                  <option value={`${p.id}::${m.id}`} key={m.id}>{m.displayName || m.id}</option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
+        </div>
+      ))}
+    </div>
   );
 }
 

--- a/src/webview/components/blocks.tsx
+++ b/src/webview/components/blocks.tsx
@@ -32,6 +32,12 @@ function fmtDuration(ms?: number): string {
   return ` for ${(ms / 1000).toFixed(1)}s`;
 }
 
+/** Compact token count, e.g. 1234 → "1.2k". Local to avoid cross-component imports. */
+function fmtTokens(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k`;
+  return String(n);
+}
+
 export function ThinkingBlock({ text, durationMs }: { text: string; durationMs?: number }) {
   return (
     <Collapsible
@@ -168,6 +174,14 @@ export function GateCardView({ card }: { card: GateCard }) {
           <button type="button" class="fp-btn fp-btn-primary fp-btn-sm" onClick={() => store.openReview()} style={{ alignSelf: 'flex-start' }}>
             <IconDiff size={15} /> Review Changes
           </button>
+        )}
+        {card.usage && (card.usage.inputTokens > 0 || card.usage.outputTokens > 0) && (
+          <div
+            class="fp-gate-usage"
+            style={{ fontSize: '11px', color: 'var(--fp-fg-muted)', fontFamily: 'var(--fp-font)' }}
+          >
+            ↑{fmtTokens(card.usage.inputTokens)} ↓{fmtTokens(card.usage.outputTokens)}
+          </div>
         )}
       </div>
     </div>

--- a/src/webview/components/blocks.tsx
+++ b/src/webview/components/blocks.tsx
@@ -1,12 +1,12 @@
 /** Assistant content-block renderers. */
 import type { JSX } from 'preact';
-import type { ContentBlock, ToolCallRecord, GateCard, CoopRole, GateStatus } from '../../shared/types';
+import type { ContentBlock, ToolCallRecord, GateCard, CoopRole, GateStatus, PrdStoryStatus } from '../../shared/types';
 import { Markdown, Collapsible } from './common';
 import {
   IconCheck, IconX, IconWrench, IconCompass, IconHammer, IconEye, IconShield,
-  IconDiff, IconGit, IconAlert, IconArrowRight, IconArrowUp, IconChevronRight,
+  IconDiff, IconGit, IconAlert, IconArrowRight, IconArrowUp, IconChevronRight, IconFile,
 } from './icons';
-import { store } from './store';
+import { post, store, useStore } from './store';
 
 export function BlockView({ block }: { block: ContentBlock }) {
   switch (block.type) {
@@ -22,6 +22,8 @@ export function BlockView({ block }: { block: ContentBlock }) {
       return <ChangesBlock summary={block.summary} />;
     case 'commit':
       return <CommitBlock commit={block.commit} />;
+    case 'plan':
+      return <PlanBlock />;
     case 'error':
       return <ErrorBlock message={block.message} />;
   }
@@ -101,13 +103,14 @@ export function ToolCallCard({ call }: { call: ToolCallRecord }) {
   );
 }
 
-const ROLE_ICON: Record<CoopRole | 'stop-the-line' | 'hitl', (p: { size?: number }) => JSX.Element> = {
+const ROLE_ICON: Record<CoopRole | 'stop-the-line' | 'hitl' | 'foreman', (p: { size?: number }) => JSX.Element> = {
   scout: IconCompass,
   builder: IconHammer,
   inspector: IconEye,
   sentry: IconShield,
   'stop-the-line': IconAlert,
   hitl: IconEye,
+  foreman: IconFile,
 };
 
 function StatusChip({ status }: { status: GateStatus }) {
@@ -226,6 +229,69 @@ export function CommitBlock({
       <button type="button" class="fp-btn-ghost" onClick={() => store.openReview(commit.changesetId, true)} style={{ padding: 0, color: 'var(--fp-accent)' }}>
         View Changes <IconArrowRight size={14} />
       </button>
+    </div>
+  );
+}
+
+const PLAN_GLYPH: Record<PrdStoryStatus, JSX.Element> = {
+  pending: <span class="fp-plan-glyph fp-plan-pending">○</span>,
+  building: <span class="fp-plan-glyph fp-plan-building fp-dot" />,
+  'awaiting-review': <span class="fp-plan-glyph fp-plan-awaiting">◉</span>,
+  done: <span class="fp-plan-glyph fp-plan-done">✓</span>,
+  failed: <span class="fp-plan-glyph fp-plan-failed">✕</span>,
+};
+
+/**
+ * PRD build plan — a marker block that renders LIVE from the conversation's `prdPlan`
+ * (statuses advance across turns; the block itself is only a snapshot placeholder). Shows a
+ * story checklist with status glyphs, an "N of M done" header, and — when not streaming and
+ * the cursor story is awaiting review or failed — a primary button to continue to the next
+ * story.
+ */
+export function PlanBlock() {
+  const conv = useStore((s) => s.conversation);
+  const streaming = useStore((s) => s.streaming);
+  const plan = conv?.prdPlan;
+  if (!plan || plan.stories.length === 0) return null;
+
+  const done = plan.stories.filter((s) => s.status === 'done').length;
+  const cursorStory = plan.stories[plan.cursor];
+  const canContinue =
+    !streaming &&
+    cursorStory &&
+    (cursorStory.status === 'awaiting-review' || cursorStory.status === 'failed' || cursorStory.status === 'pending');
+  const continueLabel =
+    cursorStory?.status === 'failed'
+      ? 'Continue anyway'
+      : cursorStory?.status === 'pending'
+        ? `Resume story ${plan.cursor + 1}`
+        : 'Continue — next story';
+
+  return (
+    <div class="fp-plan">
+      <div class="fp-plan-head">
+        <span class="fp-gate-icon"><IconFile size={17} /></span>
+        <span class="fp-plan-title">PRD build</span>
+        <span class="fp-plan-count">{done} of {plan.stories.length} done</span>
+      </div>
+      <ol class="fp-plan-list">
+        {plan.stories.map((s, i) => (
+          <li key={i} class={`fp-plan-story${i === plan.cursor ? ' fp-plan-cursor' : ''}`}>
+            {PLAN_GLYPH[s.status]}
+            <span class="fp-plan-story-title">{s.title}</span>
+          </li>
+        ))}
+      </ol>
+      {canContinue && (
+        <button
+          type="button"
+          class="fp-btn fp-btn-primary fp-btn-sm"
+          style={{ alignSelf: 'flex-start' }}
+          onClick={() => post({ type: 'continueStoryLoop' })}
+        >
+          <IconArrowRight size={15} /> {continueLabel}
+        </button>
+      )}
     </div>
   );
 }

--- a/src/webview/components/blocks.tsx
+++ b/src/webview/components/blocks.tsx
@@ -134,6 +134,7 @@ export function GateCardView({ card }: { card: GateCard }) {
       <div class="fp-gate-head">
         <span class="fp-gate-icon"><Icon size={17} /></span>
         <span class="fp-gate-title">{card.title}</span>
+        {card.modelLabel && <span class="fp-gate-model" title={`Ran on ${card.modelLabel}`}>{card.modelLabel}</span>}
         {card.attempt && card.attempt > 1 && <span class="fp-chip">attempt {card.attempt}</span>}
         <StatusChip status={card.status} />
       </div>

--- a/src/webview/components/store.tsx
+++ b/src/webview/components/store.tsx
@@ -7,11 +7,13 @@ import { useState, useEffect } from 'preact/hooks';
 import type {
   Conversation,
   ChangeSetView,
+  CoopRole,
   RebaseState,
   ConversationSummary,
   FowlPlaySettings,
   MessageNode,
   ContentBlock,
+  ModelRef,
   SelectionContext,
   TokenUsage,
   ToolCallRecord,
@@ -27,10 +29,18 @@ export interface Toast {
   message: string;
 }
 
+/** A pending per-role model-mention disambiguation surfaced to the user. */
+export interface ModelMentionChoice {
+  role: CoopRole | 'conversation';
+  query: string;
+  candidates: { providerId: string; modelId: string; label: string }[];
+}
+
 export interface AppState {
   view: View;
   settings: FowlPlaySettings | null;
   conversation: Conversation | null;
+  modelMentionChoice: ModelMentionChoice | null;
   streaming: boolean;
   streamNodeId: string | null;
   selectionContext: SelectionContext | null;
@@ -51,6 +61,7 @@ const initialState: AppState = {
   view: 'chat',
   settings: null,
   conversation: null,
+  modelMentionChoice: null,
   streaming: false,
   streamNodeId: null,
   selectionContext: null,
@@ -98,6 +109,21 @@ class Store {
   openReview(changesetId?: string, readOnly = false) {
     this.patch({ view: 'diff', diffReadOnly: readOnly });
     getBridge().post({ type: 'openDiff', changesetId });
+  }
+
+  /** Drop the mention picker without answering (the user moved on to a new prompt). */
+  clearModelMentionChoice() {
+    if (this.state.modelMentionChoice) this.patch({ modelMentionChoice: null });
+  }
+
+  /** Answer the current model-mention disambiguation (a pick, or null to dismiss). */
+  resolveModelMention(model: ModelRef | null) {
+    const choice = this.state.modelMentionChoice;
+    if (!choice) return;
+    getBridge().post({ type: 'resolveModelMention', role: choice.role, model });
+    // The host drives the next choice (or releases the prompt); clear locally so the
+    // card dismisses immediately. A queued next choice arrives as a fresh message.
+    this.patch({ modelMentionChoice: null });
   }
 
   pushToast(level: Toast['level'], message: string) {
@@ -169,6 +195,11 @@ class Store {
           modelsError: { ...this.state.modelsError, [msg.providerId]: msg.error },
         });
         break;
+      case 'modelMentionChoice':
+        this.patch({
+          modelMentionChoice: { role: msg.role, query: msg.query, candidates: msg.candidates },
+        });
+        break;
       case 'showView':
         this.setView(msg.view);
         break;
@@ -196,6 +227,9 @@ class Store {
   }
 
   private beginTurn(nodeId: string) {
+    // A turn starting means any pending model-mention picker is moot — the host
+    // has already discarded the held prompt it belonged to.
+    if (this.state.modelMentionChoice) this.patch({ modelMentionChoice: null });
     const conv = this.cloneConversation();
     if (!conv) {
       this.patch({ streaming: true, streamNodeId: nodeId });

--- a/src/webview/slashCommands.ts
+++ b/src/webview/slashCommands.ts
@@ -30,6 +30,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: 'model', aliases: [], description: 'Switch the active model', kind: 'submenu' },
   { name: 'solo', aliases: [], description: 'Direct single-agent mode', kind: 'action' },
   { name: 'coop', aliases: [], description: 'Cooperative pipeline mode', kind: 'action' },
+  { name: 'prd', aliases: [], description: 'Break a PRD into stories and build them one by one', kind: 'action' },
   { name: 'diff', aliases: ['review'], description: 'Review staged changes', kind: 'action' },
   { name: 'fork', aliases: [], description: 'Fork this conversation into a new tab', kind: 'action' },
   { name: 'export', aliases: [], description: 'Copy conversation as Markdown or JSON', kind: 'submenu' },

--- a/src/webview/theme.css
+++ b/src/webview/theme.css
@@ -398,6 +398,29 @@ a:hover { text-decoration: underline; }
 .fp-commit-sha { font-family: var(--fp-font); color: var(--fp-accent); font-weight: 700; }
 .fp-commit-msg { margin: 4px 0; }
 
+/* PRD plan block */
+.fp-plan {
+  border: 1px solid var(--fp-border-strong); border-radius: var(--fp-radius);
+  background: var(--fp-surface); box-shadow: var(--fp-shadow);
+  padding: 12px 14px; display: flex; flex-direction: column; gap: 10px;
+}
+.fp-plan-head { display: flex; align-items: center; gap: 10px; }
+.fp-plan-title { font-weight: 700; flex: 1; }
+.fp-plan-count { font-size: calc(11px * var(--fp-scale)); color: var(--fp-fg-muted); font-family: var(--fp-font); }
+.fp-plan-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.fp-plan-story { display: flex; align-items: flex-start; gap: 9px; }
+.fp-plan-story.fp-plan-cursor .fp-plan-story-title { font-weight: 700; }
+.fp-plan-story-title { flex: 1; }
+.fp-plan-glyph { flex-shrink: 0; width: 16px; text-align: center; font-weight: 800; margin-top: 1px; }
+.fp-plan-pending { color: var(--fp-fg-subtle); }
+.fp-plan-awaiting { color: var(--fp-accent); }
+.fp-plan-done { color: var(--fp-ok); }
+.fp-plan-failed { color: var(--fp-block); }
+.fp-plan-building { align-self: center; margin-top: 6px; background: var(--fp-accent); animation: fp-pulse 1.2s ease-in-out infinite; }
+
+/* PRD-build armed chip (composer) */
+.fp-prd-chip { color: var(--fp-accent); border-color: var(--fp-accent); background: var(--fp-accent-soft); font-weight: 700; }
+
 /* Error block */
 .fp-error { border: 1px solid var(--fp-block); border-radius: var(--fp-radius); background: rgba(217, 48, 37, 0.08); padding: 12px 14px; color: var(--fp-block); display: flex; gap: 10px; align-items: flex-start; }
 

--- a/src/webview/theme.css
+++ b/src/webview/theme.css
@@ -355,6 +355,11 @@ a:hover { text-decoration: underline; }
 }
 .fp-gate-icon svg { width: 17px; height: 17px; }
 .fp-gate-title { font-weight: 700; flex: 1; }
+.fp-gate-model {
+  font-size: calc(11px * var(--fp-scale)); color: var(--fp-fg-muted);
+  font-family: var(--fp-font); white-space: nowrap; overflow: hidden;
+  text-overflow: ellipsis; max-width: 45%;
+}
 .fp-gate-body { padding: 0 14px 14px; display: flex; flex-direction: column; gap: 12px; }
 .fp-gate-section-label { font-size: calc(12px * var(--fp-scale)); font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: var(--fp-fg-subtle); margin-bottom: 6px; }
 
@@ -487,6 +492,34 @@ a:hover { text-decoration: underline; }
   margin-bottom: 8px;
 }
 .fp-status-card-rows { display: flex; flex-direction: column; gap: 5px; }
+
+/* Model-mention disambiguation card (above the composer) */
+.fp-mention-card {
+  max-width: 820px; margin: 8px auto 0; padding: 10px 14px;
+  border: 1px solid var(--fp-border-strong); border-radius: var(--fp-radius);
+  background: var(--fp-surface); box-shadow: var(--fp-shadow);
+  width: calc(100% - 48px);
+}
+.fp-mention-head {
+  display: flex; align-items: center; justify-content: space-between;
+  font-weight: 700; font-size: calc(13px * var(--fp-scale)); margin-bottom: 8px;
+}
+.fp-mention-options { display: flex; flex-direction: column; gap: 6px; }
+.fp-mention-option {
+  display: flex; align-items: center; gap: 10px; text-align: left;
+  padding: 7px 10px; border: 1px solid var(--fp-border); border-radius: var(--fp-radius-sm);
+  background: var(--fp-bg-sunken); color: inherit; cursor: pointer;
+  transition: background var(--fp-t), border-color var(--fp-t);
+}
+.fp-mention-option:hover { background: var(--fp-accent-soft); border-color: var(--fp-accent); }
+.fp-mention-idx {
+  flex-shrink: 0; width: 18px; height: 18px; border-radius: 5px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--fp-accent-soft); color: var(--fp-accent);
+  font-size: calc(11px * var(--fp-scale)); font-weight: 700;
+}
+.fp-mention-label { flex: 1; font-family: var(--fp-font); font-size: calc(13px * var(--fp-scale)); }
+.fp-mention-provider { color: var(--fp-fg-muted); font-size: calc(12px * var(--fp-scale)); }
 .fp-status-row { display: flex; gap: 12px; font-size: calc(13px * var(--fp-scale)); }
 .fp-status-row .fp-status-key {
   flex-shrink: 0; width: 72px; font-weight: 600; color: var(--fp-fg-muted);

--- a/test/contextBudget.test.ts
+++ b/test/contextBudget.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Context-budget unit tests — the pure token estimator, diff fitting, and wire
+ * history trimming that back FowlPlay's hard context-window management.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { WireMessage } from '../src/core/providers/adapter';
+import {
+  estimateTokens,
+  fitDiffToBudget,
+  trimWireToBudget,
+  wireTokens,
+  WIRE_TRIM_NOTE,
+} from '../src/core/agent/contextBudget';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** A file block with `n` hunks; `pad` pads each changed line to grow its size. */
+function fileBlock(name: string, hunks: number, pad = 0): string {
+  const lines = [`--- a/${name}`, `+++ b/${name}`];
+  const filler = 'x'.repeat(pad);
+  for (let h = 0; h < hunks; h += 1) {
+    lines.push(`@@ -${h * 10 + 1},1 +${h * 10 + 1},1 @@`);
+    lines.push(`-old ${h} ${filler}`);
+    lines.push(`+new ${h} ${filler}`);
+  }
+  return lines.join('\n');
+}
+
+function countHunks(text: string): number {
+  return text.split('\n').filter((l) => l.startsWith('@@')).length;
+}
+
+const u = (text: string): WireMessage => ({ role: 'user', content: [{ type: 'text', text }] });
+const a = (text: string): WireMessage => ({ role: 'assistant', content: [{ type: 'text', text }] });
+const noteMsg: WireMessage = { role: 'user', content: [{ type: 'text', text: WIRE_TRIM_NOTE }] };
+
+// ---------------------------------------------------------------------------
+// estimateTokens
+// ---------------------------------------------------------------------------
+
+describe('estimateTokens', () => {
+  it('is chars/4, rounded up, cheap', () => {
+    expect(estimateTokens('')).toBe(0);
+    expect(estimateTokens('abcd')).toBe(1);
+    expect(estimateTokens('abcde')).toBe(2); // ceil(5/4)
+    expect(estimateTokens('x'.repeat(400))).toBe(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fitDiffToBudget
+// ---------------------------------------------------------------------------
+
+describe('fitDiffToBudget', () => {
+  it('passes a fitting diff through as a single, unchanged chunk', () => {
+    const diff = '--- a/x.ts\n+++ b/x.ts\n@@ -1 +1 @@\n-a\n+b';
+    const r = fitDiffToBudget(diff, 10_000);
+    expect(r.chunks).toEqual([diff]);
+    expect(r.truncated).toBe(false);
+  });
+
+  it('passes an empty diff through as a single chunk', () => {
+    expect(fitDiffToBudget('', 100)).toEqual({ chunks: [''], truncated: false });
+  });
+
+  it('packs whole files at file boundaries into as few chunks as fit', () => {
+    const f1 = fileBlock('f1.ts', 1);
+    const f2 = fileBlock('f2.ts', 1);
+    const f3 = fileBlock('f3.ts', 1);
+    const diff = [f1, f2, f3].join('\n');
+    // A budget that holds two files together but not all three.
+    const budget = estimateTokens(`${f1}\n${f2}`);
+
+    const r = fitDiffToBudget(diff, budget);
+    expect(r.truncated).toBe(false);
+    expect(r.chunks).toEqual([`${f1}\n${f2}`, f3]);
+    // Every chunk starts at a real file boundary and fits the budget.
+    for (const c of r.chunks) {
+      expect(c.startsWith('--- a/')).toBe(true);
+      expect(estimateTokens(c)).toBeLessThanOrEqual(budget);
+    }
+  });
+
+  it('truncates a single oversized file, keeping leading hunks + a marker', () => {
+    const big = fileBlock('big.ts', 10, 40);
+    const budget = estimateTokens(fileBlock('big.ts', 3, 40));
+
+    const r = fitDiffToBudget(big, budget);
+    expect(r.truncated).toBe(true);
+    expect(r.chunks).toHaveLength(1);
+    expect(r.chunks[0]).toContain('more hunk(s) not shown');
+    // Some but not all hunks survive.
+    const kept = countHunks(r.chunks[0]);
+    expect(kept).toBeGreaterThan(0);
+    expect(kept).toBeLessThan(10);
+  });
+
+  it('caps at 4 chunks and folds the overflow into the last chunk’s marker', () => {
+    const files = Array.from({ length: 6 }, (_, i) => fileBlock(`f${i}.ts`, 1, 30));
+    const diff = files.join('\n');
+    // A budget that holds exactly one file per chunk → 6 chunks before the cap.
+    const budget = estimateTokens(files[0]);
+
+    const r = fitDiffToBudget(diff, budget);
+    expect(r.chunks).toHaveLength(4);
+    expect(r.truncated).toBe(true);
+    expect(r.chunks[3]).toContain('more hunk(s) not shown');
+    // The two overflow files (1 hunk each) are reported in the marker.
+    expect(r.chunks[3]).toContain('2 more hunk(s)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// trimWireToBudget
+// ---------------------------------------------------------------------------
+
+describe('trimWireToBudget', () => {
+  const P = 'x'.repeat(400); // ~100 tokens of padding per message
+
+  it('returns empty / fitting histories untouched with dropped 0', () => {
+    expect(trimWireToBudget([], 100)).toEqual({ messages: [], dropped: 0 });
+    const small = [u('hi'), a('hello there')];
+    expect(trimWireToBudget(small, 10_000)).toEqual({ messages: small, dropped: 0 });
+  });
+
+  it('drops the oldest whole turn first and prepends the synthetic note once', () => {
+    const msgs = [u(`u1${P}`), a(`a1${P}`), u(`u2${P}`), a(`a2${P}`), u(`u3${P}`), a(`a3${P}`)];
+    // Budget that fits (note + turns 2 & 3) but not turn 1 as well.
+    const budget = wireTokens([noteMsg]) + wireTokens(msgs.slice(2));
+
+    const r = trimWireToBudget(msgs, budget);
+    expect(r.dropped).toBe(2); // turn 1 = 2 messages
+    expect(r.messages[0]).toEqual(noteMsg);
+    expect(r.messages.slice(1)).toEqual(msgs.slice(2)); // turns 2 & 3 intact
+    // The note appears exactly once.
+    const noteCount = r.messages.filter(
+      (m) => m.role === 'user' && m.content.some((p) => p.type === 'text' && p.text === WIRE_TRIM_NOTE),
+    ).length;
+    expect(noteCount).toBe(1);
+    // Turn 1's content is gone.
+    expect(r.messages.some((m) => m.role === 'user' && m.content.some((p) => p.type === 'text' && p.text.startsWith('u1')))).toBe(false);
+  });
+
+  it('never drops the newest turn, even when it alone exceeds the budget', () => {
+    const msgs = [u(`u1${P}`), a(`a1${P}`), u(`u2${P}`), a(`a2${P}`), u(`u3${P}`), a(`a3${P}`)];
+    const r = trimWireToBudget(msgs, 1); // impossibly small
+
+    // Every earlier turn dropped, but the newest turn survives (with the note).
+    expect(r.messages[0]).toEqual(noteMsg);
+    expect(r.messages.slice(1)).toEqual(msgs.slice(4));
+    expect(r.dropped).toBe(4);
+    // It is returned anyway even though it still overruns the budget.
+    expect(wireTokens(r.messages)).toBeGreaterThan(1);
+  });
+
+  it('returns a single oversized turn as-is (no note, dropped 0)', () => {
+    const one = [u('x'.repeat(4000))]; // ~1000 tokens, one turn
+    const r = trimWireToBudget(one, 10);
+    expect(r.dropped).toBe(0);
+    expect(r.messages).toEqual(one);
+  });
+});

--- a/test/extension-session.test.ts
+++ b/test/extension-session.test.ts
@@ -16,6 +16,8 @@ import type {
   ConversationSummary,
   FowlPlaySettings,
   HarnessMode,
+  HarnessSettings,
+  ModelRef,
   ProviderConfig,
   StreamEvent,
 } from '../src/shared/types';
@@ -783,5 +785,268 @@ describe('reloadSettings', () => {
     const before = changed.count;
     await session.reloadSettings();
     expect(changed.count).toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-role model overrides + chat-mention parsing
+// ---------------------------------------------------------------------------
+
+/** A provider whose model ids/displayNames drive the resolution + mention tests. */
+const P_ROLES: ProviderConfig = {
+  id: 'p1',
+  name: 'Roles',
+  kind: 'local',
+  sdkType: 'openai-completions',
+  baseUrl: 'http://localhost/v1',
+  requiresApiKey: false,
+  models: [
+    { id: 'm-base' },
+    { id: 'm-scout-conv' },
+    { id: 'm-scout-settings' },
+    { id: 'm-builder', displayName: 'BuilderModel' },
+    { id: 'qwen-a', displayName: 'Qwen A' },
+    { id: 'qwen-b', displayName: 'Qwen B' },
+  ],
+};
+
+function makeCustomSession(opts: {
+  providers?: ProviderConfig[];
+  harness?: HarnessSettings;
+  conversation?: Conversation;
+  defaultModel?: ModelRef | null;
+}) {
+  const io = new FakeIo();
+  const posted: HostToWebview[] = [];
+  const { adapter, requests } = scriptedAdapter();
+  const providers = opts.providers ?? [P_ROLES];
+  const harness = opts.harness ?? { defaultMode: 'coop', qasRetryBudget: 1 };
+  const defaultModel = opts.defaultModel ?? { providerId: 'p1', modelId: 'm-base' };
+  const settings: SettingsPort = {
+    async load(): Promise<FowlPlaySettings> {
+      return { appearance: APPEARANCE, harness, providers, defaultModel };
+    },
+    async saveAppearance() {},
+    async saveHarness() {},
+    async saveProviders() {},
+    async saveDefaultModel() {},
+  };
+  const deps: SessionDeps = {
+    io,
+    secrets: new FakeSecrets(),
+    settings,
+    history: new FakeHistory(),
+    git: fakeGit,
+    post: (m) => posted.push(m),
+    createAdapter: () => adapter,
+    fetchModels: async () => [],
+    clock: () => Date.now(),
+  };
+  const session = createSessionCore(deps, opts.conversation ? { conversation: opts.conversation } : undefined);
+  return { session, posted, requests };
+}
+
+function coopConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: 'c1',
+    title: 'test',
+    nodes: {},
+    rootIds: [],
+    currentLeafId: null,
+    model: { providerId: 'p1', modelId: 'm-base' },
+    harnessMode: 'coop',
+    createdAt: 0,
+    updatedAt: 0,
+    usageTotals: { inputTokens: 0, outputTokens: 0, cachedTokens: 0 },
+    ...overrides,
+  };
+}
+
+/** Which modelId each Coop role's request ran on, keyed off the role system prompt. */
+function coopModelIds(requests: ChatRequest[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const r of requests) {
+    if (r.system.includes('SCOUT')) out.scout = r.modelId;
+    else if (r.system.includes('INSPECTOR')) out.inspector = r.modelId;
+    else if (r.system.includes('SENTRY')) out.sentry = r.modelId;
+    else if (out.builder === undefined) out.builder = r.modelId; // Builder/agent loop
+  }
+  return out;
+}
+
+describe('per-role model resolution chain', () => {
+  it('resolves conv override > settings override > conv model, and stale overrides fall through', async () => {
+    const conversation = coopConversation({
+      roleModelOverrides: { scout: { providerId: 'p1', modelId: 'm-scout-conv' } },
+    });
+    const { session, requests } = makeCustomSession({
+      conversation,
+      harness: {
+        defaultMode: 'coop',
+        qasRetryBudget: 1,
+        roleModelOverrides: {
+          // conv override wins for scout; this settings one should be shadowed.
+          scout: { providerId: 'p1', modelId: 'm-scout-settings' },
+          // stale — references a model that no longer exists → falls through.
+          inspector: { providerId: 'p1', modelId: 'm-deleted' },
+        },
+      },
+    });
+
+    await session.handle({ type: 'sendPrompt', text: 'add a feature' });
+
+    const ids = coopModelIds(requests);
+    expect(ids.scout).toBe('m-scout-conv'); // conversation override wins
+    expect(ids.builder).toBe('m-base'); // no override anywhere → conv model
+    expect(ids.inspector).toBe('m-base'); // stale settings override → falls through
+    expect(ids.sentry).toBe('m-base'); // no override → conv model
+  });
+});
+
+describe('directive-only chat mention', () => {
+  it('applies a per-role override and does NOT start a turn', async () => {
+    const { session, posted } = makeCustomSession({
+      harness: { defaultMode: 'solo', qasRetryBudget: 1 },
+    });
+    await session.handle({ type: 'ready' });
+
+    const before = posted.length;
+    await session.handle({ type: 'sendPrompt', text: 'build with m-builder' });
+
+    // No turn ran.
+    expect(posted.slice(before).some((m) => m.type === 'turnStarted')).toBe(false);
+    // The override rode onto the conversation.
+    const conv = lastConversation(posted)!;
+    expect(conv.roleModelOverrides?.builder).toEqual({ providerId: 'p1', modelId: 'm-builder' });
+    // A confirmation toast summarizing the assignment was posted.
+    expect(
+      posted.some((m) => m.type === 'toast' && m.level === 'info' && m.message === 'Builder → BuilderModel'),
+    ).toBe(true);
+  });
+
+  it('warns and ignores a mention that matches no configured model', async () => {
+    const { session, posted } = makeCustomSession({
+      harness: { defaultMode: 'solo', qasRetryBudget: 1 },
+    });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'use nonexistent-model' });
+
+    expect(posted.some((m) => m.type === 'toast' && m.level === 'warn' && m.message.includes('nonexistent-model'))).toBe(true);
+    const conv = lastConversation(posted)!;
+    expect(conv.roleModelOverrides).toBeUndefined();
+  });
+});
+
+describe('ambiguous chat mention', () => {
+  it('holds the prompt, then releases it on resolveModelMention with the picked model', async () => {
+    const { session, posted } = makeCustomSession({
+      harness: { defaultMode: 'solo', qasRetryBudget: 1 },
+    });
+    await session.handle({ type: 'ready' });
+
+    const before = posted.length;
+    // "qwen" matches qwen-a AND qwen-b → ambiguous; trailing prose keeps it a real turn.
+    await session.handle({ type: 'sendPrompt', text: 'qwen to build the login page' });
+
+    // A choice was surfaced and the prompt is held (no turn yet).
+    const choice = posted.slice(before).find(
+      (m): m is Extract<HostToWebview, { type: 'modelMentionChoice' }> => m.type === 'modelMentionChoice',
+    );
+    expect(choice).toBeDefined();
+    expect(choice!.role).toBe('builder');
+    expect(choice!.query).toBe('qwen');
+    expect(choice!.candidates.map((c) => c.modelId).sort()).toEqual(['qwen-a', 'qwen-b']);
+    expect(posted.slice(before).some((m) => m.type === 'turnStarted')).toBe(false);
+
+    // Resolve with a pick → the held prompt runs with the ORIGINAL full text.
+    const pick = choice!.candidates[0];
+    const beforeResolve = posted.length;
+    await session.handle({ type: 'resolveModelMention', role: 'builder', model: { providerId: pick.providerId, modelId: pick.modelId } });
+
+    expect(posted.slice(beforeResolve).some((m) => m.type === 'turnStarted')).toBe(true);
+    const conv = lastConversation(posted)!;
+    expect(conv.roleModelOverrides?.builder).toEqual({ providerId: pick.providerId, modelId: pick.modelId });
+    // The stored user message keeps the original text (mentions not stripped).
+    const userNode = Object.values(conv.nodes).find((n) => n.role === 'user');
+    expect(userNode?.blocks.some((b) => b.type === 'text' && b.text.includes('qwen to build the login page'))).toBe(true);
+  });
+
+  it('a new prompt supersedes a held one — answering the stale picker releases nothing', async () => {
+    const { session, posted } = makeCustomSession({
+      harness: { defaultMode: 'solo', qasRetryBudget: 1 },
+    });
+    await session.handle({ type: 'ready' });
+
+    // Ambiguous mention → prompt held behind the picker.
+    await session.handle({ type: 'sendPrompt', text: 'qwen to build the login page' });
+    expect(posted.some((m) => m.type === 'modelMentionChoice')).toBe(true);
+
+    // The user abandons the picker and sends a plain prompt instead.
+    const beforeSecond = posted.length;
+    await session.handle({ type: 'sendPrompt', text: 'just fix the typo in README' });
+    const turnsAfterSecond = posted.slice(beforeSecond).filter((m) => m.type === 'turnStarted').length;
+    expect(turnsAfterSecond).toBe(1);
+
+    // Answering the stale picker now must not release the abandoned prompt.
+    const beforeStale = posted.length;
+    await session.handle({ type: 'resolveModelMention', role: 'builder', model: { providerId: 'p1', modelId: 'qwen-a' } });
+    expect(posted.slice(beforeStale).some((m) => m.type === 'turnStarted')).toBe(false);
+    const conv = lastConversation(posted)!;
+    expect(conv.roleModelOverrides?.builder).toBeUndefined();
+    // The abandoned prompt's text never became a user node.
+    expect(
+      Object.values(conv.nodes).some(
+        (n) => n.role === 'user' && n.blocks.some((b) => b.type === 'text' && b.text.includes('login page')),
+      ),
+    ).toBe(false);
+  });
+
+  it('dismissal (null) sends the prompt without applying any override', async () => {
+    const { session, posted } = makeCustomSession({
+      harness: { defaultMode: 'solo', qasRetryBudget: 1 },
+    });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'qwen to build the login page' });
+
+    const beforeResolve = posted.length;
+    await session.handle({ type: 'resolveModelMention', role: 'builder', model: null });
+
+    // The prompt still ran…
+    expect(posted.slice(beforeResolve).some((m) => m.type === 'turnStarted')).toBe(true);
+    // …with an info toast and NO override applied.
+    expect(posted.some((m) => m.type === 'toast' && m.level === 'info' && m.message.includes('without changing'))).toBe(true);
+    const conv = lastConversation(posted)!;
+    expect(conv.roleModelOverrides?.builder).toBeUndefined();
+  });
+});
+
+describe('conversation-level model directive persists (JSON round-trip)', () => {
+  it('keeps roleModelOverrides through a history save/load', async () => {
+    const history = new FakeHistory();
+    const io = new FakeIo();
+    const posted: HostToWebview[] = [];
+    const { adapter } = scriptedAdapter();
+    const settings: SettingsPort = {
+      async load(): Promise<FowlPlaySettings> {
+        return { appearance: APPEARANCE, harness: { defaultMode: 'solo', qasRetryBudget: 1 }, providers: [P_ROLES], defaultModel: { providerId: 'p1', modelId: 'm-base' } };
+      },
+      async saveAppearance() {},
+      async saveHarness() {},
+      async saveProviders() {},
+      async saveDefaultModel() {},
+    };
+    const deps: SessionDeps = {
+      io, secrets: new FakeSecrets(), settings, history, git: fakeGit,
+      post: (m) => posted.push(m), createAdapter: () => adapter, fetchModels: async () => [], clock: () => Date.now(),
+    };
+    const session = createSessionCore(deps);
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'build with m-builder' }); // directive-only → applies + persists
+
+    // Serialize exactly as persistence does, then reload.
+    const saved = [...history.store.values()][0];
+    expect(saved).toBeDefined();
+    const roundTripped: Conversation = JSON.parse(JSON.stringify(saved));
+    expect(roundTripped.roleModelOverrides?.builder).toEqual({ providerId: 'p1', modelId: 'm-builder' });
   });
 });

--- a/test/extension-session.test.ts
+++ b/test/extension-session.test.ts
@@ -665,6 +665,124 @@ describe('coop pipeline', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Hard context-window management
+// ---------------------------------------------------------------------------
+
+/** A session whose single model optionally advertises a context window. */
+function makeWindowSession(opts: { window?: number; mode?: HarnessMode; path?: string; content?: string }) {
+  const io = new FakeIo();
+  const posted: HostToWebview[] = [];
+  const { adapter, requests } = scriptedAdapter(opts.path, opts.content);
+  const model = opts.window ? { id: 'm1', contextWindow: opts.window } : { id: 'm1' };
+  const provider: ProviderConfig = { ...PROVIDER, models: [model] };
+  const mode = opts.mode ?? 'solo';
+  const settings: SettingsPort = {
+    async load(): Promise<FowlPlaySettings> {
+      return {
+        appearance: APPEARANCE,
+        harness: { defaultMode: mode, qasRetryBudget: 1 },
+        providers: [provider],
+        defaultModel: { providerId: 'p1', modelId: 'm1' },
+      };
+    },
+    async saveAppearance() {},
+    async saveHarness() {},
+    async saveProviders() {},
+    async saveDefaultModel() {},
+  };
+  const deps: SessionDeps = {
+    io,
+    secrets: new FakeSecrets(),
+    settings,
+    history: new FakeHistory(),
+    git: fakeGit,
+    post: (m) => posted.push(m),
+    createAdapter: () => adapter,
+    fetchModels: async () => [{ id: 'm1' }],
+    clock: () => Date.now(),
+  };
+  return { session: createSessionCore(deps), posted, io, requests };
+}
+
+/** Every text payload in a wire request (user text + tool results). */
+function allWireText(req: ChatRequest): string {
+  return req.messages
+    .map((m) =>
+      m.role === 'tool'
+        ? m.results.map((r) => r.content).join('\n')
+        : m.content.map((p) => (p.type === 'text' ? p.text : '')).join('\n'),
+    )
+    .join('\n');
+}
+
+describe('context-window management', () => {
+  // ~4000 tokens each (chars/4); a small-window model must trim one to fit.
+  const T1 = `TURN1MARK ${'x'.repeat(16000)}`;
+  const T2 = `TURN2MARK ${'x'.repeat(16000)}`;
+
+  it('trims the oldest turn when the conversation model has a small context window', async () => {
+    // window 8000 → reserve max(1500, 2000)=2000 → payload budget 6000.
+    const { session, requests } = makeWindowSession({ window: 8000, path: 'foo.txt', content: 'hi\n' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: T1 }); // fits alone (~4k ≤ 6k)
+
+    const idx = requests.length;
+    await session.handle({ type: 'sendPrompt', text: T2 }); // now T1+T2 overruns → trim T1
+    const first = allWireText(requests[idx]);
+
+    expect(first).toContain('trimmed to fit'); // synthetic note prepended
+    expect(first).toContain('TURN2MARK'); // newest turn preserved
+    expect(first).not.toContain('TURN1MARK'); // oldest whole turn dropped
+  });
+
+  it('a model with no known context window keeps full history (no regression)', async () => {
+    const { session, requests } = makeWindowSession({ path: 'foo.txt', content: 'hi\n' }); // no window
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: T1 });
+
+    const idx = requests.length;
+    await session.handle({ type: 'sendPrompt', text: T2 });
+    const first = allWireText(requests[idx]);
+
+    expect(first).not.toContain('trimmed to fit'); // no budget → no trim
+    expect(first).toContain('TURN1MARK'); // full history retained
+    expect(first).toContain('TURN2MARK');
+  });
+
+  it('surfaces a friendly block when the request exceeds the model context window (coop)', async () => {
+    // window 4000 → payload budget 2500; a ~3000-token prompt cannot fit.
+    const { session, posted } = makeWindowSession({ window: 4000, mode: 'coop', path: 'foo.txt', content: 'x\n' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: `refactor everything ${'x'.repeat(12000)}` });
+
+    const conv = lastConversation(posted)!;
+    const leaf = assistantLeaf(conv)!;
+    const textBlock = leaf.blocks.find(
+      (b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text',
+    );
+    expect(textBlock?.text).toMatch(/exceeds .* context window/);
+    expect(textBlock?.text).toContain('4.0k');
+    // A blocked Context limit gate card was emitted.
+    expect(leaf.blocks.some((b) => b.type === 'gate' && b.card.title === 'Context limit')).toBe(true);
+  });
+
+  it('surfaces a friendly error block in solo mode when the request exceeds the window', async () => {
+    const { session, posted } = makeWindowSession({ window: 4000, mode: 'solo', path: 'foo.txt', content: 'x\n' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: `rewrite it all ${'x'.repeat(12000)}` });
+
+    const conv = lastConversation(posted)!;
+    const leaf = assistantLeaf(conv)!;
+    const errorBlock = leaf.blocks.find(
+      (b): b is Extract<ContentBlock, { type: 'error' }> => b.type === 'error',
+    );
+    expect(errorBlock?.message).toMatch(/exceeds .* context window/);
+    // No gate cards in solo mode.
+    expect(leaf.blocks.some((b) => b.type === 'gate')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Cross-surface settings sync
 // ---------------------------------------------------------------------------
 

--- a/test/extension-session.test.ts
+++ b/test/extension-session.test.ts
@@ -165,14 +165,32 @@ function textEvents(text: string): StreamEvent[] {
   return [{ type: 'text', delta: text }, USAGE, { type: 'done', stopReason: 'end' }];
 }
 
-/** Adapter that stages `path`/`content` on a build turn and approves every role gate. */
-function scriptedAdapter(path = 'foo.txt', content = 'hello\nworld\n'): { adapter: ProviderAdapter; requests: ChatRequest[] } {
+/** A 2-story Foreman decomposition, returned when `foreman: 'two'`. */
+const TWO_STORY_JSON = JSON.stringify({
+  stories: [
+    { title: 'First story', summary: 'the first slice', criteria: ['story one works'] },
+    { title: 'Second story', summary: 'the second slice', criteria: ['story two works'] },
+  ],
+});
+
+/**
+ * Adapter that stages `path`/`content` on a build turn and approves every role gate. When a
+ * FOREMAN system prompt arrives it returns a decomposition: two stories (`foreman: 'two'`,
+ * the default) or unparseable text (`foreman: 'garbage'`) to exercise the failure path.
+ */
+function scriptedAdapter(
+  path = 'foo.txt',
+  content = 'hello\nworld\n',
+  foreman: 'two' | 'garbage' = 'two',
+): { adapter: ProviderAdapter; requests: ChatRequest[] } {
   const requests: ChatRequest[] = [];
   const adapter: ProviderAdapter = {
     chat(request: ChatRequest) {
       requests.push(request);
       let events: StreamEvent[];
-      if (request.system.includes('SCOUT')) {
+      if (request.system.includes('FOREMAN')) {
+        events = textEvents(foreman === 'garbage' ? 'I cannot break this down, sorry.' : TWO_STORY_JSON);
+      } else if (request.system.includes('SCOUT')) {
         events = textEvents(JSON.stringify({ criteria: ['File is created'], plan: ['create file'], ambiguous: false, question: '' }));
       } else if (request.system.includes('INSPECTOR') || request.system.includes('SENTRY')) {
         events = textEvents(JSON.stringify({ verdict: 'approve', findings: [], evidence: 'looks fine' }));
@@ -193,10 +211,10 @@ function scriptedAdapter(path = 'foo.txt', content = 'hello\nworld\n'): { adapte
 // Harness
 // ---------------------------------------------------------------------------
 
-function makeSession(opts: { mode?: HarnessMode; path?: string; content?: string } = {}) {
+function makeSession(opts: { mode?: HarnessMode; path?: string; content?: string; foreman?: 'two' | 'garbage' } = {}) {
   const io = new FakeIo();
   const posted: HostToWebview[] = [];
-  const { adapter, requests } = scriptedAdapter(opts.path, opts.content);
+  const { adapter, requests } = scriptedAdapter(opts.path, opts.content, opts.foreman);
   const settings = new FakeSettings(opts.mode ?? 'solo');
   // Count broadcast triggers so tests can assert which mutations notify siblings.
   const changed = { count: 0 };
@@ -1166,5 +1184,274 @@ describe('conversation-level model directive persists (JSON round-trip)', () => 
     expect(saved).toBeDefined();
     const roundTripped: Conversation = JSON.parse(JSON.stringify(saved));
     expect(roundTripped.roleModelOverrides?.builder).toEqual({ providerId: 'p1', modelId: 'm-builder' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PRD builds (Foreman decomposition → per-story build loop)
+// ---------------------------------------------------------------------------
+
+/** Roles of the distinct gate cards emitted so far, in first-seen order. */
+function gateRoles(posted: HostToWebview[]): string[] {
+  const gates = posted.filter(
+    (m): m is Extract<HostToWebview, { type: 'gateUpdate' }> => m.type === 'gateUpdate',
+  );
+  const order: string[] = [];
+  for (const g of gates) if (!order.includes(g.card.id)) order.push(g.card.id);
+  return order.map((id) => gates.find((g) => g.card.id === id)!.card.role);
+}
+
+/** The synthetic user nodes ("Continue to story N: …") on the current conversation. */
+function continueNodes(conv: Conversation): string[] {
+  return Object.values(conv.nodes)
+    .filter((n) => n.role === 'user')
+    .map((n) => n.blocks.map((b) => (b.type === 'text' ? b.text : '')).join(''))
+    .filter((t) => t.startsWith('Continue to story'));
+}
+
+describe('PRD build turn', () => {
+  it('decomposes the PRD, writes a spec per story, sets the plan, and builds story 1 to awaiting-review', async () => {
+    const { session, posted, io } = makeSession({ mode: 'coop', path: 'foo.txt', content: 'x\n' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'Build the whole thing per this PRD…', prd: true });
+
+    // Two spec files were written directly to disk (not staged).
+    const specs = [...io.files.keys()].filter((p) => p.startsWith('.fowlplay/specs/'));
+    expect(specs).toHaveLength(2);
+    expect(io.files.get(specs[0])).toContain('First story');
+    expect(io.files.get(specs[1])).toContain('Second story');
+
+    // The plan rode onto the conversation with two stories, cursor at 0.
+    const conv = lastConversation(posted)!;
+    expect(conv.prdPlan?.stories).toHaveLength(2);
+    expect(conv.prdPlan?.cursor).toBe(0);
+    expect(conv.prdPlan?.stories[0].status).toBe('awaiting-review'); // story 1 built to review
+    expect(conv.prdPlan?.stories[1].status).toBe('pending');
+
+    // Foreman + full pipeline cards were emitted; a plan block marker sits in the node.
+    const roles = gateRoles(posted);
+    expect(roles).toEqual(['foreman', 'scout', 'stop-the-line', 'builder', 'inspector', 'sentry', 'hitl']);
+    const leaf = assistantLeaf(conv)!;
+    expect(leaf.blocks.some((b) => b.type === 'plan')).toBe(true);
+    expect(leaf.blocks.some((b) => b.type === 'gate' && b.card.role === 'foreman')).toBe(true);
+    // Story 1 staged a change → a changes block was appended.
+    expect(leaf.blocks.some((b) => b.type === 'changes')).toBe(true);
+  });
+
+  it('blocks the Foreman card and creates no plan when decomposition fails', async () => {
+    const { session, posted, io } = makeSession({ mode: 'coop', path: 'foo.txt', content: 'x\n', foreman: 'garbage' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'a vague half-idea', prd: true });
+
+    const conv = lastConversation(posted)!;
+    expect(conv.prdPlan).toBeUndefined(); // no plan
+    // No spec files written.
+    expect([...io.files.keys()].some((p) => p.startsWith('.fowlplay/specs/'))).toBe(false);
+
+    // The Foreman card is blocked; no downstream role cards ran.
+    const roles = gateRoles(posted);
+    expect(roles).toEqual(['foreman']);
+    const foreman = posted
+      .filter((m): m is Extract<HostToWebview, { type: 'gateUpdate' }> => m.type === 'gateUpdate')
+      .map((m) => m.card)
+      .filter((c) => c.role === 'foreman')
+      .pop();
+    expect(foreman?.status).toBe('blocked');
+    const leaf = assistantLeaf(conv)!;
+    expect(leaf.blocks.some((b) => b.type === 'text' && b.text.toLowerCase().includes('could not decompose'))).toBe(true);
+    expect(leaf.blocks.some((b) => b.type === 'plan')).toBe(false);
+  });
+
+  it('continueStoryLoop marks story 1 done, appends a synthetic user node, and builds story 2', async () => {
+    const { session, posted } = makeSession({ mode: 'coop', path: 'foo.txt', content: 'x\n' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'PRD text', prd: true });
+
+    const before = posted.length;
+    await session.handle({ type: 'continueStoryLoop' });
+
+    const conv = lastConversation(posted)!;
+    expect(conv.prdPlan?.cursor).toBe(1);
+    expect(conv.prdPlan?.stories[0].status).toBe('done');
+    expect(conv.prdPlan?.stories[1].status).toBe('awaiting-review'); // story 2 built to review
+    // A synthetic "Continue to story 2" user node was appended and a turn ran.
+    expect(continueNodes(conv)).toEqual(['Continue to story 2: Second story']);
+    expect(posted.slice(before).some((m) => m.type === 'turnStarted')).toBe(true);
+    // The second story's pipeline cards ran again (a fresh set of gate ids).
+    expect(posted.slice(before).some((m) => m.type === 'gateUpdate' && m.card.role === 'scout')).toBe(true);
+  });
+
+  it('a second continue completes the plan with a summary block and no further story turn', async () => {
+    const { session, posted } = makeSession({ mode: 'coop', path: 'foo.txt', content: 'x\n' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'PRD text', prd: true });
+    await session.handle({ type: 'continueStoryLoop' }); // story 1 → done, build story 2
+
+    const before = posted.length;
+    await session.handle({ type: 'continueStoryLoop' }); // story 2 → done, plan complete
+
+    const conv = lastConversation(posted)!;
+    expect(conv.prdPlan?.cursor).toBe(2);
+    expect(conv.prdPlan?.stories.every((s) => s.status === 'done')).toBe(true);
+    // No new story turn ran; a completion summary was appended instead.
+    expect(posted.slice(before).some((m) => m.type === 'turnStarted')).toBe(false);
+    const leaf = assistantLeaf(conv)!;
+    expect(leaf.blocks.some((b) => b.type === 'text' && b.text.includes('PRD build complete'))).toBe(true);
+  });
+
+  it('resets a story cancelled mid-pipeline to pending (retryable)', async () => {
+    const io = new FakeIo();
+    const posted: HostToWebview[] = [];
+    let unblock: () => void = () => {};
+    const blocker = new Promise<void>((res) => {
+      unblock = res;
+    });
+    // Block the Builder loop of story 1 so the pipeline hangs after the plan is set (story
+    // 'building'); cancel while blocked, then release. The pipeline's post-build abort check
+    // yields a cancelled outcome → the story must reset to 'pending', never left 'building'.
+    const adapter: ProviderAdapter = {
+      chat(request: ChatRequest) {
+        let events: StreamEvent[];
+        let block = false;
+        if (request.system.includes('FOREMAN')) events = textEvents(TWO_STORY_JSON);
+        else if (request.system.includes('SCOUT')) events = textEvents(JSON.stringify({ criteria: ['x'], plan: [], ambiguous: false }));
+        else if (request.system.includes('INSPECTOR') || request.system.includes('SENTRY')) events = textEvents(JSON.stringify({ verdict: 'approve', findings: [] }));
+        else {
+          const hasToolResult = request.messages.some((m) => m.role === 'tool');
+          events = hasToolResult ? textEvents('done') : editEvents('foo.txt', 'x\n');
+          if (!hasToolResult) block = true; // the Builder's first (edit) round hangs
+        }
+        return (async function* () {
+          if (block) await blocker;
+          for (const e of events) yield e;
+        })();
+      },
+    };
+    const deps: SessionDeps = {
+      io,
+      secrets: new FakeSecrets(),
+      settings: new FakeSettings('coop'),
+      history: new FakeHistory(),
+      git: fakeGit,
+      post: (m) => posted.push(m),
+      createAdapter: () => adapter,
+      fetchModels: async () => [{ id: 'm1' }],
+      clock: () => Date.now(),
+    };
+    const session = createSessionCore(deps);
+    await session.handle({ type: 'ready' });
+
+    const turn = session.handle({ type: 'sendPrompt', text: 'PRD text', prd: true });
+    // Flush until the Builder card is emitted (the loop is now blocked).
+    for (let i = 0; i < 100; i += 1) {
+      if (posted.some((m) => m.type === 'gateUpdate' && m.card.role === 'builder')) break;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    await session.handle({ type: 'cancelResponse' });
+    unblock();
+    await turn;
+
+    const conv = lastConversation(posted)!;
+    expect(conv.prdPlan).toBeDefined();
+    expect(conv.prdPlan?.stories[0].status).toBe('pending'); // cancelled → retryable, not building
+
+    // Continue on the pending cursor story must RETRY it — not mark it done and
+    // skip past work that never happened. The adapter no longer blocks, so the
+    // rerun completes to awaiting-review with the cursor still on story 1.
+    const beforeResume = posted.length;
+    await session.handle({ type: 'continueStoryLoop' });
+    const after = lastConversation(posted)!;
+    expect(after.prdPlan?.cursor).toBe(0);
+    expect(after.prdPlan?.stories[0].status).toBe('awaiting-review');
+    expect(after.prdPlan?.stories[1].status).toBe('pending');
+    // The retry ran as a real turn parented on a synthetic "Resume story" node.
+    expect(posted.slice(beforeResume).some((m) => m.type === 'turnStarted')).toBe(true);
+    expect(
+      Object.values(after.nodes).some(
+        (n) => n.role === 'user' && n.blocks.some((b) => b.type === 'text' && b.text.startsWith('Resume story 1:')),
+      ),
+    ).toBe(true);
+  });
+
+  it('ignores continueStoryLoop while a turn is streaming', async () => {
+    const io = new FakeIo();
+    const posted: HostToWebview[] = [];
+    let unblock: () => void = () => {};
+    const blocker = new Promise<void>((res) => {
+      unblock = res;
+    });
+    // Block the Sentry role call so the story-1 pipeline hangs mid-turn (plan already set,
+    // abort controller live) — the moment continueStoryLoop must be ignored.
+    const adapter: ProviderAdapter = {
+      chat(request: ChatRequest) {
+        let events: StreamEvent[];
+        let block = false;
+        if (request.system.includes('FOREMAN')) events = textEvents(TWO_STORY_JSON);
+        else if (request.system.includes('SCOUT')) events = textEvents(JSON.stringify({ criteria: ['x'], plan: [], ambiguous: false }));
+        else if (request.system.includes('SENTRY')) {
+          events = textEvents(JSON.stringify({ verdict: 'approve', findings: [] }));
+          block = true;
+        } else if (request.system.includes('INSPECTOR')) {
+          events = textEvents(JSON.stringify({ verdict: 'approve', findings: [] }));
+        } else {
+          const hasToolResult = request.messages.some((m) => m.role === 'tool');
+          events = hasToolResult ? textEvents('done') : editEvents('foo.txt', 'x\n');
+        }
+        return (async function* () {
+          if (block) await blocker;
+          for (const e of events) yield e;
+        })();
+      },
+    };
+    const deps: SessionDeps = {
+      io,
+      secrets: new FakeSecrets(),
+      settings: new FakeSettings('coop'),
+      history: new FakeHistory(),
+      git: fakeGit,
+      post: (m) => posted.push(m),
+      createAdapter: () => adapter,
+      fetchModels: async () => [{ id: 'm1' }],
+      clock: () => Date.now(),
+    };
+    const session = createSessionCore(deps);
+    await session.handle({ type: 'ready' });
+
+    const turn = session.handle({ type: 'sendPrompt', text: 'PRD text', prd: true });
+
+    // Flush until the Sentry card has been emitted (the pipeline is now blocked on it).
+    for (let i = 0; i < 100; i += 1) {
+      if (posted.some((m) => m.type === 'gateUpdate' && m.card.role === 'sentry')) break;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    expect(posted.some((m) => m.type === 'gateUpdate' && m.card.role === 'sentry')).toBe(true);
+
+    // A turn is in flight → continueStoryLoop is ignored (posts nothing, advances nothing).
+    const before = posted.length;
+    await session.handle({ type: 'continueStoryLoop' });
+    expect(posted.length).toBe(before);
+
+    unblock();
+    await turn;
+    // The turn finished normally; the plan advanced only through the pipeline, not a stray continue.
+    const conv = lastConversation(posted)!;
+    expect(conv.prdPlan?.cursor).toBe(0);
+    expect(continueNodes(conv)).toEqual([]);
+  });
+});
+
+describe('PRD plan history round-trip', () => {
+  it('keeps prdPlan through a JSON save/load', async () => {
+    const { session } = makeSession({ mode: 'coop', path: 'foo.txt', content: 'x\n' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'PRD text', prd: true });
+
+    const saved = session.conversation;
+    expect(saved.prdPlan).toBeDefined();
+    const roundTripped: Conversation = JSON.parse(JSON.stringify(saved));
+    expect(roundTripped.prdPlan?.stories).toHaveLength(2);
+    expect(roundTripped.prdPlan?.stories[0].specPath).toBe(saved.prdPlan!.stories[0].specPath);
+    expect(roundTripped.prdPlan?.stories[0].status).toBe('awaiting-review');
+    expect(roundTripped.prdPlan?.cursor).toBe(0);
   });
 });

--- a/test/harness.test.ts
+++ b/test/harness.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { GateCard, HarnessSettings, TokenUsage } from '../src/shared/types';
 import {
+  ContextExceededError,
   runCoopPipeline,
   type ChangesetInspector,
   type CoopResult,
@@ -14,6 +15,7 @@ import {
 } from '../src/core/harness/coop';
 import { parseVerdict } from '../src/core/harness/evidence';
 import { parseScout } from '../src/core/harness/roles';
+import { estimateTokens } from '../src/core/agent/contextBudget';
 
 // ---------------------------------------------------------------------------
 // Fakes & helpers
@@ -375,6 +377,122 @@ describe('runCoopPipeline — cancellation', () => {
 
     expect(result.outcome).toBe('cancelled');
     expect(buildStage).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chunked review under a diff budget
+// ---------------------------------------------------------------------------
+
+/** Two equal-size single-hunk files; a budget of one file forces a 2-chunk split. */
+function twoFileDiff(): { diff: string; oneFileBudget: number } {
+  const file = (name: string, ch: string) =>
+    [`--- a/${name}`, `+++ b/${name}`, '@@ -1,1 +1,1 @@', `-${ch.repeat(40)}`, `+${ch.repeat(40)}`].join('\n');
+  const f1 = file('f1.ts', 'a');
+  const f2 = file('f2.ts', 'b');
+  return { diff: `${f1}\n${f2}`, oneFileBudget: estimateTokens(f1) };
+}
+
+describe('runCoopPipeline — chunked inspector under a diff budget', () => {
+  it('reviews each chunk and rejects overall (with unioned findings) when any chunk rejects', async () => {
+    const { diff, oneFileBudget } = twoFileDiff();
+    const { runner, calls } = scriptedRunner({
+      scout: [scoutOk(['C1'])],
+      // FIFO across the two chunk calls: first rejects, second rejects (distinct + a dup).
+      inspector: [rejectWith(['dup finding', 'part-1 issue']), rejectWith(['dup finding', 'part-2 issue'])],
+      sentry: [approve],
+    });
+    const buildStage = vi.fn(async () => BUILDER_USAGE);
+
+    const result = await runCoopPipeline({
+      userPrompt: 'do it',
+      runner,
+      inspector: fakeInspector(diff),
+      buildStage,
+      settings: settings(0), // no route-backs → single inspector attempt
+      onGate: () => {},
+      diffBudgetFor: (role) => (role === 'inspector' ? oneFileBudget : undefined),
+    });
+
+    // The inspector ran once per chunk (2 chunks).
+    expect(calls.filter((c) => c.role === 'inspector')).toHaveLength(2);
+    // Overall rejected → budget exhausted → qas-failed.
+    expect(result.outcome).toBe('qas-failed');
+    const inspector = result.cards.find((c) => c.role === 'inspector')!;
+    expect(inspector.status).toBe('failed');
+    // Findings unioned across chunks (deduplicated, order preserved).
+    expect(inspector.findings).toEqual(['dup finding', 'part-1 issue', 'part-2 issue']);
+    // Evidence notes the chunked review.
+    expect(inspector.evidence).toContain('reviewed in 2 parts');
+  });
+
+  it('passes to Sentry only when every chunk approves', async () => {
+    const { diff, oneFileBudget } = twoFileDiff();
+    const { runner, calls } = scriptedRunner({
+      scout: [scoutOk(['C1'])],
+      inspector: [approve], // reused for both chunk calls → both approve
+      sentry: [approve], // reused for both sentry chunk calls
+    });
+
+    const result = await runCoopPipeline({
+      userPrompt: 'do it',
+      runner,
+      inspector: fakeInspector(diff),
+      buildStage: vi.fn(async () => BUILDER_USAGE),
+      settings: settings(),
+      onGate: () => {},
+      diffBudgetFor: (role) => (role === 'inspector' || role === 'sentry' ? oneFileBudget : undefined),
+    });
+
+    expect(result.outcome).toBe('ready-for-review');
+    // Both the inspector and the sentry chunked into 2 calls each.
+    expect(calls.filter((c) => c.role === 'inspector')).toHaveLength(2);
+    expect(calls.filter((c) => c.role === 'sentry')).toHaveLength(2);
+    const sentry = result.cards.find((c) => c.role === 'sentry')!;
+    expect(sentry.status).toBe('passed');
+    expect(sentry.evidence).toContain('reviewed in 2 parts');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Context-exceeded outcome (Builder cannot fit the newest turn)
+// ---------------------------------------------------------------------------
+
+describe('runCoopPipeline — context-exceeded', () => {
+  it('emits a blocked Context limit gate and returns context-exceeded when buildStage throws', async () => {
+    const { runner } = scriptedRunner({ scout: [scoutOk(['C1'])] });
+    const buildStage = vi.fn(async () => {
+      throw new ContextExceededError({
+        role: 'builder',
+        modelLabel: 'Tiny-8k',
+        windowTokens: 8000,
+        neededTokens: 9000,
+        budgetTokens: 6000,
+      });
+    });
+
+    const result = await runCoopPipeline({
+      userPrompt: 'refactor the whole app',
+      runner,
+      inspector: fakeInspector(),
+      buildStage,
+      settings: settings(),
+      onGate: () => {},
+    });
+
+    expect(result.outcome).toBe('context-exceeded');
+    expect(result.context?.modelLabel).toBe('Tiny-8k');
+    expect(result.context?.windowTokens).toBe(8000);
+
+    const ctxCard = result.cards.find((c) => c.title === 'Context limit')!;
+    expect(ctxCard.role).toBe('stop-the-line');
+    expect(ctxCard.status).toBe('blocked');
+    expect(ctxCard.evidence).toContain('Context window exceeded');
+
+    // The in-flight Builder card was marked failed, and nothing after it ran.
+    expect(result.cards.find((c) => c.role === 'builder')?.status).toBe('failed');
+    expect(result.cards.some((c) => c.role === 'inspector')).toBe(false);
+    expect(result.cards.some((c) => c.role === 'sentry')).toBe(false);
   });
 });
 

--- a/test/harness.test.ts
+++ b/test/harness.test.ts
@@ -140,6 +140,62 @@ describe('runCoopPipeline — happy path', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Per-role model labels
+// ---------------------------------------------------------------------------
+
+describe('runCoopPipeline — modelLabelFor', () => {
+  it('stamps each role card with the label from modelLabelFor', async () => {
+    const { runner } = scriptedRunner({
+      scout: [scoutOk(['C1'])],
+      inspector: [approve],
+      sentry: [approve],
+    });
+    const labels: Record<string, string> = {
+      scout: 'Qwen-Plan',
+      builder: 'GLM-Build',
+      inspector: 'Fable-QA',
+      sentry: 'Fable-Sec',
+    };
+
+    const result = await runCoopPipeline({
+      userPrompt: 'do it',
+      runner,
+      inspector: fakeInspector(),
+      buildStage: vi.fn(async () => BUILDER_USAGE),
+      settings: settings(),
+      onGate: () => {},
+      modelLabelFor: (role) => labels[role],
+    });
+
+    const labelOf = (role: GateCard['role']) => result.cards.find((c) => c.role === role)?.modelLabel;
+    expect(labelOf('scout')).toBe('Qwen-Plan');
+    expect(labelOf('builder')).toBe('GLM-Build');
+    expect(labelOf('inspector')).toBe('Fable-QA');
+    expect(labelOf('sentry')).toBe('Fable-Sec');
+    // Synthetic gates carry no model label.
+    expect(labelOf('stop-the-line')).toBeUndefined();
+    expect(labelOf('hitl')).toBeUndefined();
+  });
+
+  it('leaves modelLabel unset when modelLabelFor is omitted', async () => {
+    const { runner } = scriptedRunner({
+      scout: [scoutOk(['C1'])],
+      inspector: [approve],
+      sentry: [approve],
+    });
+    const result = await runCoopPipeline({
+      userPrompt: 'do it',
+      runner,
+      inspector: fakeInspector(),
+      buildStage: vi.fn(async () => BUILDER_USAGE),
+      settings: settings(),
+      onGate: () => {},
+    });
+    expect(result.cards.every((c) => c.modelLabel === undefined)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Ambiguous scout → blocked
 // ---------------------------------------------------------------------------
 

--- a/test/modelMentions.test.ts
+++ b/test/modelMentions.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Deterministic model-mention parsing + matching.
+ *
+ * Covers every grammar pattern, shorthand/ranked matching, and the conservative
+ * false-positive guards (ordinary prose that merely contains a verb must NOT
+ * produce a directive; a directive whose name matches nothing must matchModels-[]).
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { ProviderConfig } from '../src/shared/types';
+import {
+  isDirectiveOnly,
+  matchModels,
+  parseModelMentions,
+  stripDirectives,
+} from '../src/core/agent/modelMentions';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const provider = (id: string, name: string, models: ProviderConfig['models']): ProviderConfig => ({
+  id,
+  name,
+  kind: 'local',
+  sdkType: 'openai-completions',
+  baseUrl: 'http://localhost/v1',
+  requiresApiKey: false,
+  models,
+});
+
+const PROVIDERS: ProviderConfig[] = [
+  provider('ollama', 'Ollama', [
+    { id: 'qwen3.6-35b-moe', displayName: 'Qwen3.6-35B-MoE' },
+    { id: 'qwen2.5-coder:32b', displayName: 'Qwen2.5 Coder 32B' },
+    { id: 'glm-4-9b', displayName: 'GLM-4 9B' },
+    { id: 'llama3.1:8b', displayName: 'Llama 3.1 8B' },
+  ]),
+  provider('anthropic', 'Anthropic', [{ id: 'claude-fable-5', displayName: 'Claude Fable 5' }]),
+];
+
+// ---------------------------------------------------------------------------
+// Grammar — role-directed patterns
+// ---------------------------------------------------------------------------
+
+describe('parseModelMentions — role directives', () => {
+  it('"<name> to <verb>" → role from verb', () => {
+    expect(parseModelMentions('qwen to orchestrate')).toEqual([{ role: 'scout', query: 'qwen' }]);
+    expect(parseModelMentions('glm to build')).toEqual([{ role: 'builder', query: 'glm' }]);
+    expect(parseModelMentions('fable to review')).toEqual([{ role: 'inspector', query: 'fable' }]);
+    expect(parseModelMentions('glm to audit')).toEqual([{ role: 'sentry', query: 'glm' }]);
+  });
+
+  it('"use <name> to <verb>"', () => {
+    expect(parseModelMentions('use qwen to orchestrate')).toEqual([{ role: 'scout', query: 'qwen' }]);
+    expect(parseModelMentions('use glm to implement the feature')).toEqual([{ role: 'builder', query: 'glm' }]);
+  });
+
+  it('"<verb> with <name>"', () => {
+    expect(parseModelMentions('build with glm')).toEqual([{ role: 'builder', query: 'glm' }]);
+    expect(parseModelMentions('review with fable')).toEqual([{ role: 'inspector', query: 'fable' }]);
+  });
+
+  it('"let <name> <verb>"', () => {
+    expect(parseModelMentions('let glm build')).toEqual([{ role: 'builder', query: 'glm' }]);
+    expect(parseModelMentions('let qwen plan')).toEqual([{ role: 'scout', query: 'qwen' }]);
+  });
+
+  it('"<name> for <role-noun>"', () => {
+    expect(parseModelMentions('qwen for review')).toEqual([{ role: 'inspector', query: 'qwen' }]);
+    expect(parseModelMentions('glm for security')).toEqual([{ role: 'sentry', query: 'glm' }]);
+    expect(parseModelMentions('fable for planning')).toEqual([{ role: 'scout', query: 'fable' }]);
+    expect(parseModelMentions('use fable for review')).toEqual([{ role: 'inspector', query: 'fable' }]);
+  });
+
+  it('maps each verb spelling to the right role', () => {
+    expect(parseModelMentions('qwen to plan')[0].role).toBe('scout');
+    expect(parseModelMentions('qwen to planning')[0].role).toBe('scout');
+    expect(parseModelMentions('qwen to implement')[0].role).toBe('builder');
+    expect(parseModelMentions('qwen to building')[0].role).toBe('builder');
+    expect(parseModelMentions('qwen to reviewing')[0].role).toBe('inspector');
+    expect(parseModelMentions('qwen to inspect')[0].role).toBe('inspector');
+    expect(parseModelMentions('qwen to qa')[0].role).toBe('inspector');
+    expect(parseModelMentions('qwen to sentry')[0].role).toBe('sentry');
+    expect(parseModelMentions('qwen to audit')[0].role).toBe('sentry');
+  });
+
+  it('is case-insensitive', () => {
+    expect(parseModelMentions('QWEN to ORCHESTRATE')).toEqual([{ role: 'scout', query: 'QWEN' }]);
+    expect(parseModelMentions('Build With Glm')).toEqual([{ role: 'builder', query: 'Glm' }]);
+  });
+
+  it('captures multi-token / dotted model names (1–3 tokens)', () => {
+    expect(parseModelMentions('qwen2.5-coder:32b to build')).toEqual([
+      { role: 'builder', query: 'qwen2.5-coder:32b' },
+    ]);
+  });
+
+  it('recognizes multiple directives in one message', () => {
+    expect(parseModelMentions('qwen to orchestrate and glm to build')).toEqual([
+      { role: 'scout', query: 'qwen' },
+      { role: 'builder', query: 'glm' },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Grammar — role-less (conversation) directives
+// ---------------------------------------------------------------------------
+
+describe('parseModelMentions — conversation directives', () => {
+  it('"use <name>" → conversation', () => {
+    expect(parseModelMentions('use qwen')).toEqual([{ role: 'conversation', query: 'qwen' }]);
+  });
+
+  it('"switch to <name>" → conversation', () => {
+    expect(parseModelMentions('switch to qwen')).toEqual([{ role: 'conversation', query: 'qwen' }]);
+  });
+
+  it('"use <name> for everything" → conversation', () => {
+    expect(parseModelMentions('use qwen for everything')).toEqual([{ role: 'conversation', query: 'qwen' }]);
+  });
+
+  it('requires a leading use/switch-to for role-less directives (no bare "<name>")', () => {
+    expect(parseModelMentions('qwen')).toEqual([]);
+    expect(parseModelMentions('just qwen please')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// False-positive guards
+// ---------------------------------------------------------------------------
+
+describe('parseModelMentions — false-positive guards', () => {
+  it('does NOT trigger on ordinary prose containing a verb', () => {
+    expect(parseModelMentions('we should build the parser with care')).toEqual([]);
+    expect(parseModelMentions('please review this and plan the next steps')).toEqual([]);
+    expect(parseModelMentions('implement the login flow')).toEqual([]);
+  });
+
+  it('"use caution" parses as a directive but matches no configured model', () => {
+    const mentions = parseModelMentions('use caution');
+    // Syntactically a role-less directive…
+    expect(mentions).toEqual([{ role: 'conversation', query: 'caution' }]);
+    // …but nothing matches, so the host would warn and ignore it.
+    expect(matchModels('caution', PROVIDERS)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripDirectives / isDirectiveOnly
+// ---------------------------------------------------------------------------
+
+describe('stripDirectives + isDirectiveOnly', () => {
+  it('flags directive-only messages', () => {
+    expect(isDirectiveOnly('use qwen')).toBe(true);
+    expect(isDirectiveOnly('qwen to orchestrate')).toBe(true);
+    expect(isDirectiveOnly('qwen to orchestrate and glm to build')).toBe(true);
+    expect(isDirectiveOnly('use qwen for everything')).toBe(true);
+  });
+
+  it('does not flag mixed or plain messages', () => {
+    expect(isDirectiveOnly('qwen to orchestrate, then add a test')).toBe(false);
+    expect(isDirectiveOnly('just fix the bug')).toBe(false);
+    expect(isDirectiveOnly('')).toBe(false);
+  });
+
+  it('removes recognized spans, leaving the real request', () => {
+    const rest = stripDirectives('qwen to orchestrate and fix the failing test').trim();
+    expect(rest).not.toContain('qwen to orchestrate');
+    expect(rest).toContain('fix the failing test');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchModels — shorthand & ranking
+// ---------------------------------------------------------------------------
+
+describe('matchModels', () => {
+  it('shorthand: "fable" → claude-fable-5 (token-start)', () => {
+    const m = matchModels('fable', PROVIDERS);
+    expect(m).toEqual([{ providerId: 'anthropic', modelId: 'claude-fable-5', label: 'Claude Fable 5' }]);
+  });
+
+  it('"qwen" surfaces BOTH loaded qwen models', () => {
+    const m = matchModels('qwen', PROVIDERS);
+    expect(m.map((x) => x.modelId).sort()).toEqual(['qwen2.5-coder:32b', 'qwen3.6-35b-moe']);
+  });
+
+  it('returns [] when nothing matches', () => {
+    expect(matchModels('gpt', PROVIDERS)).toEqual([]);
+    expect(matchModels('caution', PROVIDERS)).toEqual([]);
+  });
+
+  it('ranks exact > token-start > substring', () => {
+    const ps = [provider('p', 'P', [{ id: 'coder' }, { id: 'qwen-coder' }, { id: 'aicoderx' }])];
+    // Exact wins alone.
+    expect(matchModels('coder', ps)).toEqual([{ providerId: 'p', modelId: 'coder', label: 'coder' }]);
+
+    // Without the exact model: token-start beats substring.
+    const ps2 = [provider('p', 'P', [{ id: 'qwen-coder' }, { id: 'aicoderx' }])];
+    expect(matchModels('coder', ps2)).toEqual([{ providerId: 'p', modelId: 'qwen-coder', label: 'qwen-coder' }]);
+  });
+
+  it('matches against displayName as well as id', () => {
+    const m = matchModels('moe', PROVIDERS); // "Qwen3.6-35B-MoE" displayName
+    expect(m.map((x) => x.modelId)).toContain('qwen3.6-35b-moe');
+  });
+
+  it('dedupes by provider+model', () => {
+    // A query hitting both id and displayName of the same model yields one entry.
+    const ps = [provider('p', 'P', [{ id: 'glm', displayName: 'glm' }])];
+    expect(matchModels('glm', ps)).toHaveLength(1);
+  });
+});

--- a/test/prd.test.ts
+++ b/test/prd.test.ts
@@ -1,0 +1,174 @@
+/**
+ * PRD decomposition unit tests — the pure `core/harness/prd.ts`:
+ * Foreman parsing (fenced / bare / invalid / caps + drop-empties), on-disk spec rendering,
+ * spec-path slugging, and per-story prompt composition.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_STORIES,
+  composeStoryPrompt,
+  parseForeman,
+  renderSpecMarkdown,
+  specRelPath,
+  type PrdStory,
+} from '../src/core/harness/prd';
+
+const story = (over: Partial<PrdStory> = {}): PrdStory => ({
+  title: 'Add pagination',
+  summary: 'Paginate the /users endpoint so large lists stay fast.',
+  criteria: ['GET /users accepts ?page and ?limit', 'Response includes a total count'],
+  specPath: '.fowlplay/specs/abcd1234/01-add-pagination.md',
+  status: 'pending',
+  ...over,
+});
+
+// ---------------------------------------------------------------------------
+// parseForeman
+// ---------------------------------------------------------------------------
+
+describe('parseForeman', () => {
+  it('parses a fenced JSON block of stories', () => {
+    const text =
+      'Here is the plan:\n```json\n' +
+      JSON.stringify({
+        stories: [
+          { title: 'Story A', summary: 'first', criteria: ['a1', 'a2'] },
+          { title: 'Story B', summary: 'second', criteria: ['b1'] },
+        ],
+      }) +
+      '\n```\nThat covers it.';
+    const stories = parseForeman(text);
+    expect(stories).toHaveLength(2);
+    expect(stories[0]).toEqual({ title: 'Story A', summary: 'first', criteria: ['a1', 'a2'] });
+    expect(stories[1].title).toBe('Story B');
+  });
+
+  it('parses bare JSON with no fences', () => {
+    const text = '{"stories":[{"title":"X","summary":"s","criteria":["c1","c2"]},{"title":"Y","criteria":["d1"]}]}';
+    const stories = parseForeman(text);
+    expect(stories.map((s) => s.title)).toEqual(['X', 'Y']);
+    expect(stories[1].summary).toBe(''); // missing summary coerces to empty
+  });
+
+  it('returns [] for unparseable text', () => {
+    expect(parseForeman('sorry, I could not break this down')).toEqual([]);
+    expect(parseForeman('')).toEqual([]);
+    // Valid JSON but no stories array.
+    expect(parseForeman('{"foo":"bar"}')).toEqual([]);
+  });
+
+  it('drops empty stories (no title and no criteria)', () => {
+    const text = JSON.stringify({
+      stories: [
+        { title: 'Keep me', criteria: ['c1'] },
+        { title: '', summary: '', criteria: [] }, // dropped
+        { criteria: ['only criteria'] }, // kept — falls back to a synthetic title
+      ],
+    });
+    const stories = parseForeman(text);
+    expect(stories).toHaveLength(2);
+    expect(stories[0].title).toBe('Keep me');
+    expect(stories[1].criteria).toEqual(['only criteria']);
+    expect(stories[1].title).toBeTruthy();
+  });
+
+  it('caps the story count at MAX_STORIES', () => {
+    const many = Array.from({ length: MAX_STORIES + 5 }, (_, i) => ({
+      title: `S${i}`,
+      criteria: [`c${i}`],
+    }));
+    const stories = parseForeman(JSON.stringify({ stories: many }));
+    expect(stories).toHaveLength(MAX_STORIES);
+    expect(stories[0].title).toBe('S0');
+    expect(stories[MAX_STORIES - 1].title).toBe(`S${MAX_STORIES - 1}`);
+  });
+
+  it('tolerates a criteria string list on a single field', () => {
+    const stories = parseForeman('{"stories":[{"title":"T","criteria":"c1\\nc2"}]}');
+    expect(stories[0].criteria).toEqual(['c1', 'c2']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderSpecMarkdown
+// ---------------------------------------------------------------------------
+
+describe('renderSpecMarkdown', () => {
+  it('renders title, status line, summary, criteria checklist, and the N-of-M footer', () => {
+    const md = renderSpecMarkdown(story(), 1, 3);
+    expect(md).toContain('# Add pagination');
+    expect(md).toContain('**Status:** Pending');
+    expect(md).toContain('Paginate the /users endpoint');
+    expect(md).toContain('## Acceptance criteria');
+    expect(md).toContain('- [ ] GET /users accepts ?page and ?limit');
+    expect(md).toContain('- [ ] Response includes a total count');
+    expect(md).toContain('_Story 1 of 3._');
+  });
+
+  it('reflects the story status in the status line and includes an optional PRD title', () => {
+    const md = renderSpecMarkdown(story({ status: 'awaiting-review' }), 2, 4, 'My PRD');
+    expect(md).toContain('**Status:** Awaiting review');
+    expect(md).toContain('Decomposed from PRD: My PRD');
+    expect(md).toContain('_Story 2 of 4._');
+  });
+
+  it('appends a note to the status line (e.g. skipped review)', () => {
+    const md = renderSpecMarkdown(story({ status: 'done' }), 1, 2, undefined, 'skipped review');
+    expect(md).toContain('**Status:** Done (skipped review)');
+  });
+
+  it('renders a placeholder when there are no criteria', () => {
+    const md = renderSpecMarkdown(story({ criteria: [] }), 1, 1);
+    expect(md).toContain('_none specified_');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// specRelPath
+// ---------------------------------------------------------------------------
+
+describe('specRelPath', () => {
+  it('uses the first 8 alphanumerics of the conv id, a zero-padded index, and a slug', () => {
+    expect(specRelPath('abcd1234efgh5678', 1, 'Add the /users pagination endpoint')).toBe(
+      '.fowlplay/specs/abcd1234/01-add-the-users-pagination-endpoint.md',
+    );
+    expect(specRelPath('abcd1234', 12, 'Wire it up!')).toBe('.fowlplay/specs/abcd1234/12-wire-it-up.md');
+  });
+
+  it('strips non-alphanumerics from the conv id segment', () => {
+    // Hyphenated uuid-like id → first 8 alphanumerics only.
+    expect(specRelPath('a1b2-c3d4-e5f6', 3, 'Title')).toBe('.fowlplay/specs/a1b2c3d4/03-title.md');
+  });
+
+  it('collapses and trims slug separators and caps length', () => {
+    expect(specRelPath('conv0001', 1, '  Weird**Title -- with   junk  ')).toBe(
+      '.fowlplay/specs/conv0001/01-weird-title-with-junk.md',
+    );
+    const long = 'a'.repeat(80);
+    const path = specRelPath('conv0001', 1, long);
+    // The slug is capped so the filename stays reasonable.
+    expect(path.length).toBeLessThan('.fowlplay/specs/conv0001/01-.md'.length + 55);
+  });
+
+  it('falls back to a placeholder slug/dir when inputs are empty', () => {
+    expect(specRelPath('', 1, '')).toBe('.fowlplay/specs/conv/01-story.md');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// composeStoryPrompt
+// ---------------------------------------------------------------------------
+
+describe('composeStoryPrompt', () => {
+  it('prepends the story-N-of-M preamble to the spec text', () => {
+    const spec = '# Add pagination\n\n**Status:** Building\n';
+    const prompt = composeStoryPrompt(spec, 2, 5);
+    expect(prompt).toContain('Story 2 of 5 decomposed from a PRD');
+    expect(prompt).toContain('Implement ONLY this story');
+    expect(prompt).toContain('earlier stories are already staged/applied');
+    expect(prompt).toContain('# Add pagination');
+    // The spec text follows the preamble.
+    expect(prompt.indexOf('Story 2 of 5')).toBeLessThan(prompt.indexOf('# Add pagination'));
+  });
+});


### PR DESCRIPTION
Five commits adapting SAW-style agentic building into FowlPlay's deterministic Coop engine:

**Settings sync across surfaces** — settings mutations broadcast a force-reload to every live session (sidebar included); empty conversations adopt a freshly-set default model.

**Per-role Coop models + chat mentions** — `roleModelOverrides` wired end-to-end (conversation override → settings override → conversation model). Deterministic mention grammar ("qwen to orchestrate", "build with glm", role-less "use X") with shorthand matching (exact > token-start > substring); ambiguous matches surface a picker that holds the prompt; directive-only messages apply without a model turn; gate cards show the model that ran each role; role dropdowns in settings.

**Context budgets as hard mechanism** — per-role payload budgets (window − max(1500, 25%) reserve); Inspector/Sentry review oversized diffs in ≤4 file-boundary chunks with approve-only-if-all-approve aggregation; Builder/Solo histories trimmed oldest-first without ever touching the newest turn; a blocked "Context limit" gate card and `context-exceeded` outcome replace raw provider errors; per-role token usage on gate cards.

**PRD builds (long-horizon loop)** — `/prd` arms the next prompt: a read-only Foreman (sharing the Scout's model) decomposes the PRD into 2–12 stories with acceptance criteria, writes specs to `.fowlplay/specs/`, and runs the existing pipeline once per story with fresh spec-sized context. Plan block renders live progress with per-story HITL: Continue, Continue anyway (failed), Resume (cancelled). Plan state persists with the conversation.

**Playwright coverage for all of it** — e2e assertions 54 → 93: slash menu, context bar, mention picker, plan-block states, PRD chip, gate-card labels, and in-DOM markdown regression checks.

Verification: `tsc --noEmit` clean, 248 unit tests, 93 e2e assertions, `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG)_