### PR TITLE
Coop field fixes: mention chains, Scout context, PRD bar + retry, file mentions

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -161,6 +161,27 @@ you typed isn't a command, just press **Enter** to send it as an ordinary prompt
 `/model`, `/export`, and `/skills` open a second-level list in the same popup — keep typing
 to filter it, or press **Esc** to step back to the command list.
 
+### Referencing files (`@` mentions and bare paths)
+
+FowlPlay resolves file references in your prompt **on the host** and hands the file
+contents straight to the model — so a request like *"implement auraringprd.md"* works even
+in Coop or PRD builds, where the planning roles used to only see your words and had to guess
+whether to open the file.
+
+- **`@` autocomplete** — type **`@`** anywhere a word starts to open a file picker listing
+  your workspace files (`.git`, `node_modules`, `dist`, and `.fowlplay` are hidden). Keep
+  typing to filter (substring match on the path); **↑/↓** move, **Enter/Tab** or a click
+  inserts `@<path>`, **Esc** closes. An explicit `@`-mention that doesn't resolve gets a
+  warning so you know it was ignored.
+- **Bare paths** — a path-looking token *without* `@` (contains a `/`, or ends in a known
+  text extension like `.md`, `.ts`, `.json`, …) is picked up too. If it resolves to a real
+  file it's included; if not, it's just treated as prose (no warning). Plain numbers,
+  versions (`3.6`, `v1.2.3`), model names, and URLs are never mistaken for files.
+
+When files are included, a toast lists them with an approximate token size (large files are
+truncated to fit the model's context window). Your transcript keeps the compact reference —
+the full contents are re-read fresh on every send, edit, or rerun, so they never go stale.
+
 ---
 
 ## 6. Making your first change

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -218,9 +218,19 @@ review between each.
    status glyph each: ○ pending, spinner building, ◉ awaiting review, ✓ done, ✕ failed.
 5. Review story 1's diff as usual (apply, comment, revert, send feedback). When you're
    satisfied, press **Continue — next story** on the plan block. That marks the story done
-   and builds the next one as a fresh turn. If a story failed, the button reads **Continue
-   anyway** — moving on is your call, and the skip is noted in that story's spec file.
-6. When the last story is done, a short **completion summary** lists every story's final
+   and builds the next one as a fresh turn.
+   - If a story **failed** its checks, you get two buttons: **Retry story** re-runs that same
+     story from scratch (worth a try after you've tweaked its spec, or just to give it
+     another pass), and **Skip story** moves on anyway — your call, and the skip is noted in
+     that story's spec file.
+   - If a story was **cancelled** mid-build (it shows as pending), **Resume story N** re-runs
+     it — nothing is skipped that never happened.
+6. A **pinned PRD bar** sits just above the composer for the whole build: it shows
+   "N of M done · story K …" and repeats the current story's action buttons, so you can
+   retry, skip, or continue without scrolling back up to the plan block after a story has
+   streamed its gate cards. While a story is building it reads "building story K…" with no
+   buttons.
+7. When the last story is done, a short **completion summary** lists every story's final
    status.
 
 The plan lives on the conversation, so it survives save/reload and shows the live status

--- a/e2e/mockBridge.js
+++ b/e2e/mockBridge.js
@@ -53,6 +53,11 @@
       if (msg && msg.type === 'continueStoryLoop') {
         /* no-op ack — protocol stays mirrored */
       }
+      // retryStory (re-run the cursor story) is likewise acked as a no-op — no
+      // scripted scenario drives the per-story loop.
+      if (msg && msg.type === 'retryStory') {
+        /* no-op ack — protocol stays mirrored */
+      }
     },
     onMessage(handler) {
       handlers.push(handler);

--- a/e2e/mockBridge.js
+++ b/e2e/mockBridge.js
@@ -58,6 +58,21 @@
       if (msg && msg.type === 'retryStory') {
         /* no-op ack — protocol stays mirrored */
       }
+      // Composer `@` autocomplete: serve a small static file list, filtered by the
+      // query (case-insensitive substring) exactly as the real host would.
+      if (msg && msg.type === 'listFiles') {
+        const all = [
+          'src/auth/authService.ts',
+          'src/auth/errors.ts',
+          'src/webview/index.tsx',
+          'docs/USER_MANUAL.md',
+          'README.md',
+          'package.json',
+        ];
+        const q = (msg.query || '').toLowerCase();
+        const paths = (q ? all.filter((p) => p.toLowerCase().includes(q)) : all).slice(0, 50);
+        emit({ type: 'fileList', paths });
+      }
     },
     onMessage(handler) {
       handlers.push(handler);

--- a/e2e/run.mjs
+++ b/e2e/run.mjs
@@ -299,6 +299,32 @@ await composer().fill('/notacommand');
 await composer().press('Enter');
 ok((await sent(page, 'sendPrompt')).some((m) => m.text === '/notacommand'), 'unknown /command sends as a prompt');
 
+// ============================== FILE MENTION AUTOCOMPLETE ====================
+console.log('\n# file mention autocomplete');
+await open('chat');
+// Typing '@' opens the file popup (a new SlashMenu mode) listing workspace files.
+await composer().fill('@');
+await waitFor(page, () => !!document.querySelector('.fp-slash-menu'), '@ opens the file popup');
+await waitFor(page, () => document.body.innerText.includes('src/auth/authService.ts'), 'file popup lists workspace files');
+// Typing after '@' filters the list (substring, case-insensitive).
+await composer().fill('@errors');
+await waitFor(
+  page,
+  () => {
+    const names = Array.from(document.querySelectorAll('.fp-slash-name')).map((n) => n.textContent);
+    return names.includes('src/auth/errors.ts') && !names.includes('README.md');
+  },
+  '@errors filters the file list',
+);
+// Picking a file inserts `@<path> ` at the caret.
+await page.locator('.fp-slash-item', { hasText: 'src/auth/errors.ts' }).first().click();
+await waitFor(
+  page,
+  () => document.querySelector('.fp-composer-textarea')?.value === '@src/auth/errors.ts ',
+  'picking a file inserts @path into the composer',
+);
+await page.screenshot({ path: join(SHOTS, 'file-mention.png'), fullPage: false });
+
 // ============================== CONTEXT INDICATOR ============================
 console.log('\n# context indicator');
 await open('chat');

--- a/e2e/run.mjs
+++ b/e2e/run.mjs
@@ -353,16 +353,22 @@ await waitFor(page, () => {
 }, 'plan checklist lists all story titles');
 await waitFor(page, () => document.querySelector('.fp-plan-count')?.textContent === '1 of 3 done', 'plan shows "1 of 3 done"');
 ok((await page.locator('.fp-plan-story .fp-plan-glyph').count()) === 3, 'each story renders a status glyph');
-ok(await page.getByRole('button', { name: /Continue — next story/ }).isVisible().catch(() => false), 'awaiting-review cursor shows "Continue — next story"');
+ok(await page.getByRole('button', { name: /Continue — next story/ }).first().isVisible().catch(() => false), 'awaiting-review cursor shows "Continue — next story"');
 await page.screenshot({ path: join(SHOTS, 'prd-plan.png'), fullPage: false });
-await page.getByRole('button', { name: /Continue — next story/ }).click();
+await page.getByRole('button', { name: /Continue — next story/ }).first().click();
 ok((await sent(page, 'continueStoryLoop')).length >= 1, 'Continue button posts continueStoryLoop');
+// The pinned PRD bar mirrors the plan block's actions between transcript and composer.
+await waitFor(page, () => !!document.querySelector('.fp-plan-bar'), 'pinned PRD bar renders while a build is active');
 // Re-inject the same plan with the cursor story pending → "Resume story 2".
 await page.evaluate(() => window.__host.emit(window.__fixtures.prdConversation('pending')));
 await waitFor(page, () => !!document.querySelector('.fp-plan') && !!Array.from(document.querySelectorAll('button')).find((b) => /Resume story 2/.test(b.textContent || '')), 'pending cursor shows "Resume story 2"');
-// …and with the cursor story failed → "Continue anyway".
+// …and with the cursor story failed → "Retry story" (primary) + "Skip story" (secondary).
 await page.evaluate(() => window.__host.emit(window.__fixtures.prdConversation('failed')));
-await waitFor(page, () => !!Array.from(document.querySelectorAll('button')).find((b) => /Continue anyway/.test(b.textContent || '')), 'failed cursor shows "Continue anyway"');
+await waitFor(page, () => !!Array.from(document.querySelectorAll('button')).find((b) => /Retry story/.test(b.textContent || '')), 'failed cursor shows "Retry story"');
+await waitFor(page, () => !!Array.from(document.querySelectorAll('button')).find((b) => /Skip story/.test(b.textContent || '')), 'failed cursor shows "Skip story"');
+// Retry posts retryStory (one code path re-runs the cursor story).
+await page.getByRole('button', { name: /Retry story/ }).first().click();
+ok((await sent(page, 'retryStory')).length >= 1, 'Retry button posts retryStory');
 
 // ============================== PRD CHIP =====================================
 console.log('\n# prd chip');

--- a/src/core/agent/fileMentions.ts
+++ b/src/core/agent/fileMentions.ts
@@ -1,0 +1,154 @@
+/**
+ * Deterministic file-reference extraction for chat prompts.
+ *
+ * The field problem: a coop prompt like "implement auraringprd.md" only reached the
+ * roles as bare text — whether the referenced file was ever read depended on a small
+ * model deciding to call a tool. This module lets the HOST resolve file references up
+ * front and hand the content straight into the pipeline, so every role sees it.
+ *
+ * Two flavors of reference are recognized:
+ *   - explicit `@<path>` mentions — the user (or the composer's `@` autocomplete) marked
+ *     it, so a miss is worth a warning.
+ *   - bare, conservative path-looking tokens ("auraringprd.md", "src/foo.ts") — recognized
+ *     leniently; a candidate that does not resolve on disk is silently treated as prose.
+ *
+ * PURE TypeScript — no `vscode`, no Node built-ins, no network. Fully unit-testable
+ * (see test/fileMentions.test.ts). The host does the actual filesystem reads and toasts.
+ */
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+/** Known text-ish file extensions a bare token may end in to count as a path. */
+const TEXT_EXTS = [
+  'md', 'txt', 'json', 'ts', 'tsx', 'js', 'jsx', 'py', 'go', 'rs', 'java',
+  'c', 'h', 'cpp', 'css', 'html', 'yml', 'yaml', 'toml', 'sh',
+];
+const EXT_RE = new RegExp(`\\.(?:${TEXT_EXTS.join('|')})$`, 'i');
+
+/** Strip wrapping punctuation a token may have picked up from surrounding prose. */
+function stripPunct(token: string): string {
+  return token.replace(/^[([{'"`]+/, '').replace(/[).,;:!?\]}'"`]+$/, '');
+}
+
+/** Strip trailing sentence punctuation from an explicit `@`-path capture (`@foo.md.`). */
+function stripTrailing(path: string): string {
+  return path.replace(/[.]+$/, '');
+}
+
+export interface FileMentions {
+  /** `@<path>` mentions, the leading `@` stripped, in first-seen order (deduped). */
+  explicit: string[];
+  /** Conservative bare path-looking tokens, not already an explicit mention. */
+  bare: string[];
+}
+
+/**
+ * Extract file references from prompt text.
+ *
+ * explicit: `@<path>` where the `@` sits at a token start (string start or after
+ * whitespace/open bracket) and the path (`[\w./-]+`) contains at least one `.` or `/`.
+ * The `@` is only a marker and is stripped. Requiring a token boundary keeps
+ * email-ish `user@host.com` from registering `@host.com`.
+ *
+ * bare: whitespace-split tokens that look like a path but carry no `@` marker —
+ * either containing a `/` or ending in a {@link TEXT_EXTS known text extension}.
+ * Guards keep prose out: URL-scheme tokens (`x://…`) are skipped, tokens must be
+ * ≥4 chars, must contain a letter, and an extension match additionally requires a
+ * letter before the extension dot (so `3.6`, `v1.2.3`, `qwen3.6-35b-moe` never match).
+ * Anything already captured as explicit is excluded. Order preserved, deduped.
+ */
+export function extractFileMentions(text: string): FileMentions {
+  const src = text ?? '';
+
+  const explicit: string[] = [];
+  const explicitSeen = new Set<string>();
+  const explicitRe = /(?:^|[\s([{'"`])@([\w./-]+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = explicitRe.exec(src)) !== null) {
+    const path = stripTrailing(m[1]);
+    if (!path || !/[./]/.test(path)) continue; // must look like a path, not "@here"
+    if (!explicitSeen.has(path)) {
+      explicitSeen.add(path);
+      explicit.push(path);
+    }
+  }
+
+  const bare: string[] = [];
+  const bareSeen = new Set<string>();
+  for (const raw of src.split(/\s+/)) {
+    const t = stripPunct(raw);
+    if (!t) continue;
+    if (t.includes('@')) continue; // explicit mention or an email — not bare
+    if (t.includes('://')) continue; // URL, not a workspace path
+    if (t.length < 4) continue;
+    if (!/[a-zA-Z]/.test(t)) continue; // pure numbers/versions are not paths
+    const hasSlash = t.includes('/');
+    const extMatch = EXT_RE.test(t);
+    if (!hasSlash && !extMatch) continue;
+    if (extMatch && !hasSlash) {
+      // Require a letter before the extension dot so "3.6"/"v1.2.3" (no letter in
+      // the stem) never qualify even if the tail coincidentally reads as an ext.
+      const stem = t.replace(EXT_RE, '');
+      if (!/[a-zA-Z]/.test(stem)) continue;
+    }
+    if (explicitSeen.has(t) || bareSeen.has(t)) continue;
+    bareSeen.add(t);
+    bare.push(t);
+  }
+
+  return { explicit, bare };
+}
+
+// ---------------------------------------------------------------------------
+// Expansion
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap arbitrary content in a fenced code block whose backtick run is longer than any
+ * run inside the content, so a file that itself contains ``` cannot break out of the
+ * fence (which would corrupt the reference / open a prompt-injection seam). Mirrors the
+ * helper session.ts uses for pinned selections and attachments.
+ */
+export function fencedBlock(info: string, content: string): string {
+  let longest = 0;
+  for (const run of content.matchAll(/`+/g)) longest = Math.max(longest, run[0].length);
+  const fence = '`'.repeat(Math.max(3, longest + 1));
+  return `${fence}${info}\n${content}\n${fence}`;
+}
+
+/**
+ * Append one fenced block per resolved file to the prompt text. Each block is:
+ *   <blank line>
+ *   Referenced file <path>:
+ *   <backtick-safe fence>
+ *   <content>
+ *   <fence>
+ * The original text is returned unchanged when `files` is empty.
+ */
+export function expandFileMentions(text: string, files: { path: string; content: string }[]): string {
+  let out = text ?? '';
+  for (const f of files) {
+    out += `\n\nReferenced file ${f.path}:\n${fencedBlock('', f.content)}`;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Capping
+// ---------------------------------------------------------------------------
+
+/** Marker appended when a referenced file is truncated to fit the model's window. */
+export const FILE_TRUNCATION_MARKER = "\n[... file truncated to fit the model's context window]";
+
+/**
+ * Keep the head of a file up to `maxChars`, appending {@link FILE_TRUNCATION_MARKER}
+ * when it overruns. Returns the (possibly truncated) content and whether it was cut.
+ */
+export function capFileContent(content: string, maxChars: number): { content: string; truncated: boolean } {
+  const src = content ?? '';
+  if (src.length <= maxChars) return { content: src, truncated: false };
+  const head = src.slice(0, Math.max(0, maxChars));
+  return { content: head + FILE_TRUNCATION_MARKER, truncated: true };
+}

--- a/src/core/agent/modelMentions.ts
+++ b/src/core/agent/modelMentions.ts
@@ -86,6 +86,26 @@ const VERB_ALT = alternation(Object.keys(VERB_TO_ROLE));
 const NOUN_ALT = alternation(Object.keys(NOUN_TO_ROLE));
 const KW_ALT = alternation([...KEYWORDS]);
 
+// Conjunction chains: "orchestrate and build", "review, audit and security".
+// A chain is a first verb/noun plus zero or more ("and"/comma)-joined ones, so
+// "qwen to orchestrate and build" assigns BOTH roles. The joined token must
+// itself be a verb/noun — "qwen to orchestrate and glm to build" does NOT chain
+// ("glm" is a name), leaving the second clause for its own pattern.
+const CHAIN_JOIN = `(?:[ \\t]*,[ \\t]*(?:and[ \\t]+)?|[ \\t]+and[ \\t]+)`;
+const VERB_CHAIN = `(${VERB_ALT})((?:${CHAIN_JOIN}(?:${VERB_ALT})\\b)*)`;
+const NOUN_CHAIN = `(${NOUN_ALT})((?:${CHAIN_JOIN}(?:${NOUN_ALT})\\b)*)`;
+
+/** Expand a matched chain (first token + joined tail) into its role list, deduped in order. */
+function chainRoles(table: Record<string, CoopRole>, first: string, tail: string): CoopRole[] {
+  const words = [first, ...(tail ?? '').split(/[^a-z0-9]+/i)].filter(Boolean);
+  const out: CoopRole[] = [];
+  for (const w of words) {
+    const role = table[w.toLowerCase()];
+    if (role && !out.includes(role)) out.push(role);
+  }
+  return out;
+}
+
 // A single name token: word-ish run that is NOT itself a keyword. The leading
 // `\b` (only on the first token) prevents starting inside another word — e.g.
 // backtracking into "and" to capture "nd".
@@ -101,8 +121,8 @@ const FOR_ALL = `(?:[ \\t]+for[ \\t]+(?:everything|all(?:[ \\t]+roles?)?|every[ 
 
 interface Pattern {
   re: RegExp;
-  /** Produce a mention from a match, or null to reject it. */
-  make(m: RegExpExecArray): Mention | null;
+  /** Produce the mentions for a match (one per chained verb/noun), or null to reject it. */
+  make(m: RegExpExecArray): Mention[] | null;
 }
 
 const nameQuery = (raw: string): string => {
@@ -114,44 +134,42 @@ const nameQuery = (raw: string): string => {
   return out.join(' ').trim();
 };
 
-const verbRole = (verb: string): CoopRole | undefined => VERB_TO_ROLE[verb.toLowerCase()];
-const nounRole = (noun: string): CoopRole | undefined => NOUN_TO_ROLE[noun.toLowerCase()];
-
-const roleMention = (query: string, role: CoopRole | undefined): Mention | null =>
-  role && query ? { role, query } : null;
+/** One mention per role in a verb/noun chain, all with the same model query. */
+const chainMentions = (query: string, roles: CoopRole[]): Mention[] | null =>
+  query && roles.length > 0 ? roles.map((role) => ({ role, query })) : null;
 
 const PATTERNS: Pattern[] = [
-  // use <name> to <verb>
+  // use <name> to <verb>[ and <verb>…]
   {
-    re: new RegExp(`\\buse[ \\t]+${NAME}[ \\t]+to[ \\t]+(${VERB_ALT})\\b`, 'gi'),
-    make: (m) => roleMention(nameQuery(m[1]), verbRole(m[2])),
+    re: new RegExp(`\\buse[ \\t]+${NAME}[ \\t]+to[ \\t]+${VERB_CHAIN}`, 'gi'),
+    make: (m) => chainMentions(nameQuery(m[1]), chainRoles(VERB_TO_ROLE, m[2], m[3])),
   },
-  // <verb> with <name>   ("build with glm")
+  // <verb>[ and <verb>…] with <name>   ("build with glm", "review and audit with gemma")
   {
-    re: new RegExp(`\\b(${VERB_ALT})[ \\t]+with[ \\t]+${NAME}`, 'gi'),
-    make: (m) => roleMention(nameQuery(m[2]), verbRole(m[1])),
+    re: new RegExp(`\\b${VERB_CHAIN}[ \\t]+with[ \\t]+${NAME}`, 'gi'),
+    make: (m) => chainMentions(nameQuery(m[3]), chainRoles(VERB_TO_ROLE, m[1], m[2])),
   },
-  // let <name> <verb>
+  // let <name> <verb>[ and <verb>…]
   {
-    re: new RegExp(`\\blet[ \\t]+${NAME}[ \\t]+(${VERB_ALT})\\b`, 'gi'),
-    make: (m) => roleMention(nameQuery(m[1]), verbRole(m[2])),
+    re: new RegExp(`\\blet[ \\t]+${NAME}[ \\t]+${VERB_CHAIN}`, 'gi'),
+    make: (m) => chainMentions(nameQuery(m[1]), chainRoles(VERB_TO_ROLE, m[2], m[3])),
   },
-  // <name> for <role-noun>   ("qwen for review")
+  // <name> for <role-noun>[ and <role-noun>…]   ("qwen for review and security")
   {
-    re: new RegExp(`${NAME}[ \\t]+for[ \\t]+(${NOUN_ALT})\\b`, 'gi'),
-    make: (m) => roleMention(nameQuery(m[1]), nounRole(m[2])),
+    re: new RegExp(`${NAME}[ \\t]+for[ \\t]+${NOUN_CHAIN}`, 'gi'),
+    make: (m) => chainMentions(nameQuery(m[1]), chainRoles(NOUN_TO_ROLE, m[2], m[3])),
   },
-  // <name> to <verb>   ("qwen to orchestrate")
+  // <name> to <verb>[ and <verb>…]   ("qwen to orchestrate and build")
   {
-    re: new RegExp(`${NAME}[ \\t]+to[ \\t]+(${VERB_ALT})\\b`, 'gi'),
-    make: (m) => roleMention(nameQuery(m[1]), verbRole(m[2])),
+    re: new RegExp(`${NAME}[ \\t]+to[ \\t]+${VERB_CHAIN}`, 'gi'),
+    make: (m) => chainMentions(nameQuery(m[1]), chainRoles(VERB_TO_ROLE, m[2], m[3])),
   },
   // switch to <name>   (role-less → conversation)
   {
     re: new RegExp(`\\bswitch[ \\t]+to[ \\t]+${NAME}${FOR_ALL}`, 'gi'),
     make: (m) => {
       const q = nameQuery(m[1]);
-      return q ? { role: 'conversation', query: q } : null;
+      return q ? [{ role: 'conversation', query: q }] : null;
     },
   },
   // use <name> [for everything]   (role-less → conversation)
@@ -159,7 +177,7 @@ const PATTERNS: Pattern[] = [
     re: new RegExp(`\\buse[ \\t]+${NAME}${FOR_ALL}`, 'gi'),
     make: (m) => {
       const q = nameQuery(m[1]);
-      return q ? { role: 'conversation', query: q } : null;
+      return q ? [{ role: 'conversation', query: q }] : null;
     },
   },
 ];
@@ -169,7 +187,8 @@ const PATTERNS: Pattern[] = [
 // ---------------------------------------------------------------------------
 
 interface Span {
-  mention: Mention;
+  /** All mentions produced by this span — a chained directive yields several. */
+  mentions: Mention[];
   start: number;
   end: number;
 }
@@ -194,10 +213,10 @@ function scan(text: string): Span[] {
         continue;
       }
       if (overlaps(start, end)) continue;
-      const mention = make(m);
-      if (!mention) continue;
+      const mentions = make(m);
+      if (!mentions || mentions.length === 0) continue;
       for (let i = start; i < end; i += 1) claimed[i] = true;
-      spans.push({ mention, start, end });
+      spans.push({ mentions, start, end });
     }
   }
   return spans.sort((a, b) => a.start - b.start);
@@ -209,7 +228,7 @@ function scan(text: string): Span[] {
  * directive shape.
  */
 export function parseModelMentions(text: string): Mention[] {
-  return scan(text).map((s) => s.mention);
+  return scan(text).flatMap((s) => s.mentions);
 }
 
 /**

--- a/src/core/harness/coop.ts
+++ b/src/core/harness/coop.ts
@@ -41,6 +41,7 @@ import {
   composeBuilderFix,
   composeBuilderInstructions,
   composeInspectorPrompt,
+  composeScoutPrompt,
   composeSentryPrompt,
   parseScout,
 } from './roles';
@@ -73,6 +74,13 @@ export interface ChangesetInspector {
 
 export interface CoopPipelineOptions {
   userPrompt: string;
+  /**
+   * A condensed digest of the conversation so far, prepended to the Scout's prompt so it can
+   * read the real goal (and any acceptance criteria the user already gave) before judging
+   * ambiguity. Undefined on turn one / empty history. Builder/Inspector/Sentry are unaffected
+   * — the Builder already inherits wire history.
+   */
+  contextDigest?: string;
   runner: RoleRunner;
   inspector: ChangesetInspector;
   /**
@@ -150,7 +158,7 @@ export interface CoopResult {
 // ---------------------------------------------------------------------------
 
 export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopResult> {
-  const { userPrompt, runner, inspector, buildStage, settings, onGate, modelLabelFor, diffBudgetFor, signal } = opts;
+  const { userPrompt, contextDigest, runner, inspector, buildStage, settings, onGate, modelLabelFor, diffBudgetFor, signal } = opts;
   const labelFor = (role: CoopRole): string | undefined => modelLabelFor?.(role);
 
   const usage: TokenUsage = { inputTokens: 0, outputTokens: 0, cachedTokens: 0 };
@@ -282,7 +290,7 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
   const scoutRun = await runner.run({
     role: 'scout',
     system: SCOUT_SYSTEM,
-    userPrompt,
+    userPrompt: composeScoutPrompt(contextDigest, userPrompt),
     readOnly: true,
     signal,
   });
@@ -290,11 +298,14 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
   if (aborted()) return cancel(scoutCard);
 
   const scout = parseScout(scoutRun.text);
+  // An ambiguous (or empty-criteria) result is not a pass — the Scout card must
+  // read as blocked, matching the stop-the-line gate that follows it.
+  const scoutBlocked = scout.ambiguous || scout.criteria.length === 0;
   emit(
-    transition(scoutCard, 'passed', {
+    transition(scoutCard, scoutBlocked ? 'blocked' : 'passed', {
       usage: scoutRun.usage,
       acceptanceCriteria: scout.criteria,
-      evidence: scout.ambiguous
+      evidence: scoutBlocked
         ? joinSections(
             section('Assessment', 'Request is ambiguous — raising a clarifying question.'),
             section('Question', scout.question ?? ''),

--- a/src/core/harness/prd.ts
+++ b/src/core/harness/prd.ts
@@ -14,6 +14,7 @@
  */
 
 import { extractJsonObject, toStringList } from './evidence';
+import { composeScoutPrompt } from './roles';
 import type { PrdPlan, PrdStory, PrdStoryStatus } from '../../shared/types';
 
 export type { PrdPlan, PrdStory, PrdStoryStatus } from '../../shared/types';
@@ -60,6 +61,15 @@ Reply with ONE fenced JSON block and nothing that could be mistaken for a second
 \`\`\`
 
 Do not wrap the stories in extra prose. Keep titles and criteria concrete and buildable.`;
+
+/**
+ * Compose the Foreman's prompt from an optional condensed conversation digest and the PRD
+ * text. Shares {@link composeScoutPrompt}'s formatting so the planning roles read prior
+ * context identically (PRDs are usually turn one, so the digest is normally empty).
+ */
+export function composeForemanPrompt(contextDigest: string | undefined, prd: string): string {
+  return composeScoutPrompt(contextDigest, prd);
+}
 
 // ===========================================================================
 // Parsing

--- a/src/core/harness/roles.ts
+++ b/src/core/harness/roles.ts
@@ -24,6 +24,19 @@ You do NOT write code. Your only job is to convert a user's request into a preci
 testable contract that the rest of the pipeline (Builder, Inspector, Sentry) will be held
 to. You are the first line of quality: vague criteria produce broken work downstream.
 
+READ THE CONTEXT FIRST
+- Your prompt may begin with a "CONVERSATION SO FAR (condensed)" block before the
+  "CURRENT REQUEST". The real goal often lives there — read it before judging ambiguity.
+  A short current message ("do that", "use the 7 criteria above") is NOT ambiguous when
+  the context makes the intent clear.
+- If the request or the conversation POINTS AT FILES (for example a "*.md" PRD or spec
+  path, or "implement <file>"), OPEN and read those files with your read-only tools
+  BEFORE judging ambiguity. A request that references a spec file is NOT ambiguous — the
+  spec is the intent. Do not ask the user to paste what you can read yourself.
+- If the user has already supplied explicit ACCEPTANCE CRITERIA anywhere in the context
+  or the request, ADOPT them: normalize them into the "criteria" array and refine only the
+  wording. Do NOT ask the user to restate criteria they already gave you.
+
 RESPONSIBILITIES
 1. Restate the request as 2–6 ACCEPTANCE CRITERIA. Each criterion must be:
    - testable/observable (a reviewer can objectively say pass or fail),
@@ -32,14 +45,16 @@ RESPONSIBILITIES
 2. Produce a short TASK PLAN: 2–5 concrete steps a builder would follow.
 
 STOP-THE-LINE AUTHORITY
-If the request is genuinely ambiguous about INTENT or SCOPE — such that a reasonable
-engineer could build materially different things — you MUST stop the line INSTEAD of
-guessing. Set "ambiguous": true and put a single, specific clarifying question in
-"question". Ask only when it truly matters; do not stall on cosmetic details you can
-state as a reasonable assumption in the criteria.
+Stop the line with a question ONLY when the goal is genuinely undecidable from everything
+you were given (context, current request, and any files you could read) — such that a
+reasonable engineer could build materially different things. Then set "ambiguous": true
+and put a single, specific clarifying question in "question". Ask only when it truly
+matters; do not stall on cosmetic details you can state as a reasonable assumption, and
+never ask for something the context, request, or a readable file already answers.
 
 OUTPUT
-Reply with ONE fenced JSON block and nothing that could be mistaken for a second one:
+Your FINAL message must be ONLY the JSON object below — one fenced JSON block, with NO
+prose before or after it, even if you first made tool calls to read files:
 
 \`\`\`json
 {
@@ -231,6 +246,19 @@ function criteriaBlock(criteria: readonly string[]): string {
 function planBlock(plan: readonly string[]): string {
   if (plan.length === 0) return '';
   return `\nSuggested plan:\n${plan.map((p, i) => `${i + 1}. ${p}`).join('\n')}\n`;
+}
+
+/**
+ * Compose a planning-role prompt (Scout, and — reused — Foreman) from an optional condensed
+ * conversation digest and the current request. With a digest, the two are labeled so the
+ * model reads prior context before judging ambiguity; without one, the bare request is
+ * returned unchanged (preserving the historical single-message prompt).
+ */
+export function composeScoutPrompt(contextDigest: string | undefined, request: string): string {
+  const req = request.trim();
+  const digest = contextDigest?.trim();
+  if (!digest) return req;
+  return `CONVERSATION SO FAR (condensed):\n${digest}\n\nCURRENT REQUEST:\n${req}`;
 }
 
 /** Instruction text for the Builder's first attempt. */

--- a/src/core/harness/roles/scout.md
+++ b/src/core/harness/roles/scout.md
@@ -8,6 +8,19 @@ You do NOT write code. Your only job is to convert a user's request into a preci
 testable contract that the rest of the pipeline (Builder, Inspector, Sentry) will be held
 to. You are the first line of quality: vague criteria produce broken work downstream.
 
+READ THE CONTEXT FIRST
+- Your prompt may begin with a "CONVERSATION SO FAR (condensed)" block before the
+  "CURRENT REQUEST". The real goal often lives there — read it before judging ambiguity.
+  A short current message ("do that", "use the 7 criteria above") is NOT ambiguous when
+  the context makes the intent clear.
+- If the request or the conversation POINTS AT FILES (for example a "*.md" PRD or spec
+  path, or "implement <file>"), OPEN and read those files with your read-only tools
+  BEFORE judging ambiguity. A request that references a spec file is NOT ambiguous — the
+  spec is the intent. Do not ask the user to paste what you can read yourself.
+- If the user has already supplied explicit ACCEPTANCE CRITERIA anywhere in the context
+  or the request, ADOPT them: normalize them into the "criteria" array and refine only the
+  wording. Do NOT ask the user to restate criteria they already gave you.
+
 RESPONSIBILITIES
 1. Restate the request as 2–6 ACCEPTANCE CRITERIA. Each criterion must be:
    - testable/observable (a reviewer can objectively say pass or fail),
@@ -16,14 +29,16 @@ RESPONSIBILITIES
 2. Produce a short TASK PLAN: 2–5 concrete steps a builder would follow.
 
 STOP-THE-LINE AUTHORITY
-If the request is genuinely ambiguous about INTENT or SCOPE — such that a reasonable
-engineer could build materially different things — you MUST stop the line INSTEAD of
-guessing. Set "ambiguous": true and put a single, specific clarifying question in
-"question". Ask only when it truly matters; do not stall on cosmetic details you can
-state as a reasonable assumption in the criteria.
+Stop the line with a question ONLY when the goal is genuinely undecidable from everything
+you were given (context, current request, and any files you could read) — such that a
+reasonable engineer could build materially different things. Then set "ambiguous": true
+and put a single, specific clarifying question in "question". Ask only when it truly
+matters; do not stall on cosmetic details you can state as a reasonable assumption, and
+never ask for something the context, request, or a readable file already answers.
 
 OUTPUT
-Reply with ONE fenced JSON block and nothing that could be mistaken for a second one:
+Your FINAL message must be ONLY the JSON object below — one fenced JSON block, with NO
+prose before or after it, even if you first made tool calls to read files:
 
 ```json
 {

--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -45,7 +45,8 @@ import { runAgentLoop } from '../core/agent/loop';
 import { buildToolSpecs, type DirEntry, type GrepMatch, type GrepOptions, type StageOp, type ToolHost } from '../core/agent/tools';
 import { BUNDLED_SKILLS, formatSkillCatalog, parseSkill } from '../core/agent/skills';
 import { gcHistory } from '../core/agent/contextGc';
-import { trimWireToBudget, wireTokens } from '../core/agent/contextBudget';
+import { estimateTokens, trimWireToBudget, wireTokens } from '../core/agent/contextBudget';
+import { capFileContent, expandFileMentions, extractFileMentions, fencedBlock } from '../core/agent/fileMentions';
 import { StagingOverlay, type DiskReader } from '../core/staging/overlay';
 import { ChangeSet } from '../core/staging/changeset';
 import { detectDrift, rebase as coreRebase } from '../core/staging/rebase';
@@ -172,6 +173,9 @@ keep edits precise and anchored. Batch multiple file opens or edits into a singl
 when you can. When you are done, briefly summarize what you changed.`;
 
 const READONLY_TOOL_NAMES = new Set(['open_files', 'list_dir', 'glob', 'grep']);
+
+/** Directories the composer's `@` file autocomplete never surfaces. */
+const FILE_LIST_EXCLUDE = new Set(['.git', 'node_modules', 'dist', '.fowlplay']);
 
 // ---------------------------------------------------------------------------
 // Session core
@@ -387,6 +391,9 @@ export class SessionCore {
         return;
       case 'fetchModels':
         await this.onFetchModels(msg.providerId);
+        return;
+      case 'listFiles':
+        await this.onListFiles(msg.query);
         return;
       default:
         return;
@@ -695,7 +702,22 @@ export class SessionCore {
     this.turnSkills = await this.discoverSkills();
 
     const userNode = this.conv.nodes[userNodeId];
-    const userText = firstText(userNode?.blocks ?? []) ?? '';
+    const rawUserText = firstText(userNode?.blocks ?? []) ?? '';
+    // Resolve deterministic file references into the WIRE user text (the stored
+    // node keeps the compact reference). Skipped on synthetic story-advance turns
+    // ("Continue/Retry/Resume story N"), which build from the spec, not user prose.
+    // The budget role mirrors who dominates each mode: Scout for a PRD's Foreman,
+    // Builder for a Coop turn, the conversation model for Solo.
+    const budgetRole: CoopRole | undefined = opts.storyIndex !== undefined
+      ? undefined
+      : opts.prd
+        ? 'scout'
+        : this.conv.harnessMode === 'coop'
+          ? 'builder'
+          : undefined;
+    const userText = opts.storyIndex !== undefined
+      ? rawUserText
+      : await this.expandWireFileMentions(rawUserText, settings, budgetRole);
     const baseWire = this.wireBaseFor(userNodeId);
     // Condensed prior-conversation context for the planning roles (Scout/Foreman),
     // so a terse follow-up or a clarification reply is judged against the real goal.
@@ -1589,9 +1611,73 @@ export class SessionCore {
     }
   }
 
+  /**
+   * Serve the composer's `@` autocomplete: glob the workspace, drop noise
+   * directories, filter by the query (case-insensitive substring), and return the
+   * top matches. Best-effort — a glob failure yields an empty list.
+   */
+  private async onListFiles(query?: string): Promise<void> {
+    let paths: string[] = [];
+    try {
+      paths = await this.deps.io.glob('**/*');
+    } catch {
+      paths = [];
+    }
+    const visible = paths
+      .filter((p) => !p.split('/').some((seg) => FILE_LIST_EXCLUDE.has(seg)))
+      .slice(0, 2000);
+    const q = (query ?? '').trim().toLowerCase();
+    const matched = q ? visible.filter((p) => p.toLowerCase().includes(q)) : visible;
+    this.deps.post({ type: 'fileList', paths: matched.slice(0, 50) });
+  }
+
   // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------
+
+  /**
+   * Resolve deterministic file references in the wire user text and inline their
+   * content, so roles receive the referenced files directly rather than depending
+   * on a model choosing to call a tool. Explicit `@<path>` mentions that do not
+   * resolve get a warning toast; bare path-looking tokens that do not resolve are
+   * silently treated as prose. Each included file is capped to
+   * `min(24k chars, half the role's payload budget)`. A single success toast lists
+   * everything included. Returns the text unchanged when nothing resolves.
+   *
+   * Reads through the staging overlay so a staged edit of a file wins over disk,
+   * and runs at wire-composition time so edits/reruns re-read fresh content.
+   */
+  private async expandWireFileMentions(text: string, settings: FowlPlaySettings, budgetRole?: CoopRole): Promise<string> {
+    const { explicit, bare } = extractFileMentions(text);
+    if (explicit.length === 0 && bare.length === 0) return text;
+
+    const budget = this.payloadBudget(settings, budgetRole);
+    const cap = budget !== undefined ? Math.min(24_000, budget * 2) : 24_000;
+
+    const included: { path: string; content: string }[] = [];
+    const toastParts: string[] = [];
+    const includePath = async (path: string, missing: () => void): Promise<void> => {
+      const raw = await this.overlay.read(path);
+      if (raw === null) {
+        missing();
+        return;
+      }
+      const capped = capFileContent(raw, cap);
+      included.push({ path, content: capped.content });
+      toastParts.push(`${path} (~${fmtTokensK(estimateTokens(capped.content))} tokens)${capped.truncated ? ' — truncated' : ''}`);
+    };
+
+    for (const path of explicit) {
+      await includePath(path, () => this.toast('warn', `@${path} not found in the workspace`));
+    }
+    for (const path of bare) {
+      await includePath(path, () => {}); // bare non-matches are just prose
+    }
+
+    if (included.length === 0) return text;
+    this.toast('info', `Included ${toastParts.join(', ')}`);
+    return expandFileMentions(text, included);
+  }
 
   private toolHost(): ToolHost {
     const overlay = this.overlay;
@@ -1880,19 +1966,6 @@ function addUsageInPlace(a: TokenUsage, b: TokenUsage): void {
 function firstText(blocks: ContentBlock[]): string | null {
   for (const b of blocks) if (b.type === 'text' && b.text.trim()) return b.text;
   return null;
-}
-
-/**
- * Wrap arbitrary content in a fenced code block whose backtick run is longer
- * than any run inside the content, so selected text or a file that itself
- * contains ``` cannot break out of the fence (which would corrupt the pinned
- * context / open a prompt-injection seam).
- */
-function fencedBlock(info: string, content: string): string {
-  let longest = 0;
-  for (const m of content.matchAll(/`+/g)) longest = Math.max(longest, m[0].length);
-  const fence = '`'.repeat(Math.max(3, longest + 1));
-  return `${fence}${info}\n${content}\n${fence}`;
 }
 
 function joinText(blocks: ContentBlock[]): string {

--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -59,6 +59,7 @@ import {
 } from '../core/harness/coop';
 import {
   FOREMAN_SYSTEM,
+  composeForemanPrompt,
   composeStoryPrompt,
   parseForeman,
   renderSpecMarkdown,
@@ -263,6 +264,9 @@ export class SessionCore {
         return;
       case 'continueStoryLoop':
         await this.onContinueStoryLoop();
+        return;
+      case 'retryStory':
+        await this.rerunCursorStory('Retry');
         return;
       case 'cancelResponse':
         this.abort?.abort();
@@ -693,6 +697,9 @@ export class SessionCore {
     const userNode = this.conv.nodes[userNodeId];
     const userText = firstText(userNode?.blocks ?? []) ?? '';
     const baseWire = this.wireBaseFor(userNodeId);
+    // Condensed prior-conversation context for the planning roles (Scout/Foreman),
+    // so a terse follow-up or a clarification reply is judged against the real goal.
+    const contextDigest = this.digestFor(userNodeId);
 
     // Surface the user's message (and any new branch) before streaming begins,
     // so the prompt is visible for the whole turn and the streaming assistant
@@ -711,15 +718,15 @@ export class SessionCore {
     let usage: TokenUsage = emptyUsage();
     try {
       if (opts.prd) {
-        const out = await this.runPrd(userText, imageParts, baseWire, resolved, settings.harness, signal);
+        const out = await this.runPrd(userText, imageParts, baseWire, resolved, settings.harness, signal, contextDigest);
         blocks = out.blocks;
         usage = out.usage;
       } else if (opts.storyIndex !== undefined) {
-        const out = await this.runStory(opts.storyIndex, baseWire, resolved, settings.harness, signal);
+        const out = await this.runStory(opts.storyIndex, baseWire, resolved, settings.harness, signal, contextDigest);
         blocks = out.blocks;
         usage = out.usage;
       } else if (this.conv.harnessMode === 'coop') {
-        const out = await this.runCoop(userText, imageParts, baseWire, resolved, settings.harness, signal);
+        const out = await this.runCoop(userText, imageParts, baseWire, resolved, settings.harness, signal, contextDigest);
         blocks = out.blocks;
         usage = out.usage;
       } else {
@@ -807,9 +814,10 @@ export class SessionCore {
     resolved: ResolvedModel,
     harness: HarnessSettings,
     signal: AbortSignal,
+    contextDigest?: string,
   ): Promise<{ blocks: ContentBlock[]; usage: TokenUsage }> {
     const cards: GateCard[] = [];
-    const result = await this.runCoopCore(userText, imageParts, baseWire, resolved, harness, signal, cards);
+    const result = await this.runCoopCore(userText, imageParts, baseWire, resolved, harness, signal, cards, contextDigest);
 
     const blocks: ContentBlock[] = cards.map((card) => ({ type: 'gate', card }));
     const text = this.coopOutcomeText(result);
@@ -831,6 +839,7 @@ export class SessionCore {
     harness: HarnessSettings,
     signal: AbortSignal,
     cards: GateCard[],
+    contextDigest?: string,
   ): Promise<CoopResult> {
     const settings = await this.ensureSettings();
     const runner: RoleRunner = {
@@ -910,6 +919,7 @@ export class SessionCore {
 
     return runCoopPipeline({
       userPrompt,
+      contextDigest,
       runner,
       inspector,
       buildStage,
@@ -959,6 +969,7 @@ export class SessionCore {
     resolved: ResolvedModel,
     harness: HarnessSettings,
     signal: AbortSignal,
+    contextDigest?: string,
   ): Promise<{ blocks: ContentBlock[]; usage: TokenUsage }> {
     const settings = await this.ensureSettings();
     const usage: TokenUsage = emptyUsage();
@@ -991,7 +1002,7 @@ export class SessionCore {
       apiKey: rm.apiKey,
       modelId: rm.modelId,
       system: FOREMAN_SYSTEM,
-      history: [{ role: 'user', content: [{ type: 'text', text: userText }, ...imageParts] }],
+      history: [{ role: 'user', content: [{ type: 'text', text: composeForemanPrompt(contextDigest, userText) }, ...imageParts] }],
       tools: this.readOnlyTools,
       toolHost: this.toolHost(),
       onEvent: () => {},
@@ -1046,7 +1057,7 @@ export class SessionCore {
     );
 
     // --- Build story 1 immediately, within this same turn ---
-    const story1 = await this.runStory(0, baseWire, resolved, harness, signal);
+    const story1 = await this.runStory(0, baseWire, resolved, harness, signal, contextDigest);
     addUsageInPlace(usage, story1.usage);
 
     // Blocks: Foreman gate, the plan marker (renders live), then story 1's cards + outcome.
@@ -1064,6 +1075,7 @@ export class SessionCore {
     resolved: ResolvedModel,
     harness: HarnessSettings,
     signal: AbortSignal,
+    contextDigest?: string,
   ): Promise<{ blocks: ContentBlock[]; usage: TokenUsage }> {
     const plan = this.conv.prdPlan;
     const story = plan?.stories[storyIndex];
@@ -1079,7 +1091,7 @@ export class SessionCore {
     const userPrompt = composeStoryPrompt(specMarkdown, storyIndex + 1, total);
 
     const cards: GateCard[] = [];
-    const result = await this.runCoopCore(userPrompt, [], baseWire, resolved, harness, signal, cards);
+    const result = await this.runCoopCore(userPrompt, [], baseWire, resolved, harness, signal, cards, contextDigest);
 
     const status: PrdStory['status'] =
       result.outcome === 'ready-for-review' ? 'awaiting-review' : result.outcome === 'cancelled' ? 'pending' : 'failed';
@@ -1111,11 +1123,7 @@ export class SessionCore {
     // A pending cursor story was cancelled (or never started): Continue means
     // RETRY it, not mark it done and skip past work that never happened.
     if (current.status === 'pending') {
-      const { conv, nodeId } = appendUser(this.conv, [
-        { type: 'text', text: `Resume story ${i + 1}: ${current.title}` },
-      ]);
-      this.conv = conv;
-      await this.runAssistantTurn(nodeId, [], { storyIndex: i });
+      await this.rerunCursorStory('Resume');
       return;
     }
 
@@ -1146,6 +1154,60 @@ export class SessionCore {
     ]);
     this.conv = conv;
     await this.runAssistantTurn(nodeId, [], { storyIndex: nextCursor });
+  }
+
+  /**
+   * Re-run the plan's cursor story as a fresh turn — the single code path behind both the
+   * `retryStory` message (a failed story) and the pending-resume branch of the Continue
+   * button (a cancelled/never-started story). Ignored while a turn is streaming; acts only
+   * when the cursor story is `failed` or `pending`. `verb` labels the synthetic user node
+   * ("Retry story N" / "Resume story N") so rewind/branching stay coherent.
+   */
+  private async rerunCursorStory(verb: 'Retry' | 'Resume'): Promise<void> {
+    if (this.abort) return; // a turn is in flight — ignore
+    const plan = this.conv.prdPlan;
+    if (!plan) return;
+    const i = plan.cursor;
+    const current = plan.stories[i];
+    if (!current) return;
+    if (current.status !== 'failed' && current.status !== 'pending') return;
+    const { conv, nodeId } = appendUser(this.conv, [
+      { type: 'text', text: `${verb} story ${i + 1}: ${current.title}` },
+    ]);
+    this.conv = conv;
+    await this.runAssistantTurn(nodeId, [], { storyIndex: i });
+  }
+
+  /**
+   * A condensed digest of the conversation preceding `userNodeId`, for the planning roles.
+   * Walks the active path up to (but excluding) the current user node, takes the last 6
+   * user/assistant nodes' TEXT blocks only (gate/tool/plan/commit blocks are skipped),
+   * truncates each message to ~600 chars, and joins them as `user:`/`assistant:` lines,
+   * capping the whole digest at ~2000 chars (oldest dropped first). Empty history → undefined.
+   */
+  private digestFor(userNodeId: string): string | undefined {
+    const MAX_PER = 600;
+    const MAX_TOTAL = 2000;
+    const parentId = this.conv.nodes[userNodeId]?.parentId ?? null;
+    if (!parentId) return undefined;
+
+    const relevant = this.chainTo(parentId).filter((n) => n.role === 'user' || n.role === 'assistant');
+    const entries: string[] = [];
+    for (const n of relevant.slice(-6)) {
+      const text = n.blocks
+        .filter((b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text')
+        .map((b) => b.text.trim())
+        .filter(Boolean)
+        .join('\n');
+      if (!text) continue;
+      const clipped = text.length > MAX_PER ? `${text.slice(0, MAX_PER)} […]` : text;
+      entries.push(`${n.role}: ${clipped}`);
+    }
+    if (entries.length === 0) return undefined;
+
+    // Cap the whole digest, dropping the oldest entries first.
+    while (entries.length > 1 && entries.join('\n').length > MAX_TOTAL) entries.shift();
+    return entries.join('\n');
   }
 
   /** Set a story's status immutably on the conversation's plan (no-op if the plan is gone). */

--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -498,8 +498,14 @@ export class SessionCore {
 
     // A new prompt supersedes any prompt still held behind an unanswered
     // disambiguation — otherwise answering the stale picker later would
-    // release (and run) the abandoned message.
-    this.heldMention = null;
+    // release (and run) the abandoned message. Never silently: the held
+    // message's unresolved (and even applied) assignments die with it, so the
+    // user must know their directive did not take effect.
+    if (this.heldMention) {
+      const dropped = this.heldMention.queue.map((q) => `"${q.query}"`).join(', ');
+      this.heldMention = null;
+      this.toast('warn', `Dropped the unanswered model choice for ${dropped} — that directive was not applied.`);
+    }
 
     const settings = await this.ensureSettings();
     const mentions = parseModelMentions(text);

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -74,7 +74,9 @@ export type WebviewToHost =
   | { type: 'addProvider'; provider: ProviderConfig; apiKey?: string }
   | { type: 'updateProvider'; provider: ProviderConfig; apiKey?: string }
   | { type: 'deleteProvider'; providerId: string }
-  | { type: 'fetchModels'; providerId: string };
+  | { type: 'fetchModels'; providerId: string }
+  // composer `@` autocomplete: list workspace files (optionally filtered by query)
+  | { type: 'listFiles'; query?: string };
 
 export interface Attachment {
   name: string;
@@ -116,6 +118,8 @@ export type HostToWebview =
       query: string;
       candidates: { providerId: string; modelId: string; label: string }[];
     }
+  // composer `@` autocomplete: workspace file paths matching the current query
+  | { type: 'fileList'; paths: string[] }
   // misc
   | { type: 'showView'; view: 'chat' | 'diff' | 'settings' | 'history' }
   | { type: 'toast'; level: 'info' | 'warn' | 'error'; message: string };

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -35,6 +35,8 @@ export type WebviewToHost =
   | { type: 'cancelResponse' }
   // Advance a PRD build to the next story (marks the cursor story done, runs the next).
   | { type: 'continueStoryLoop' }
+  // Re-run the cursor story of a PRD build (a failed — or pending — story).
+  | { type: 'retryStory' }
   | { type: 'clearSelection' }                                    // dismiss the pinned selection chip
   | { type: 'editMessage'; nodeId: string; text: string }        // branches
   | { type: 'rerunMessage'; nodeId: string }                      // sibling response

--- a/src/webview/components/Chat.tsx
+++ b/src/webview/components/Chat.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'preact/hooks';
 import type { Conversation, FowlPlaySettings } from '../../shared/types';
 import { activePath, post, store } from './store';
 import { Message } from './Message';
+import { PlanBar } from './blocks';
 import { Composer } from './Composer';
 import { StatusLine } from './StatusLine';
 import { IconHistory, IconPlus, IconGear, IconDiff } from './icons';
@@ -101,6 +102,7 @@ export function Chat({
           ))}
         </div>
       </div>
+      <PlanBar />
       <Composer streaming={streaming} />
       {conv && <StatusLine conv={conv} settings={settings} />}
     </div>

--- a/src/webview/components/Composer.tsx
+++ b/src/webview/components/Composer.tsx
@@ -7,7 +7,28 @@ import { filterCommands, type SlashCommand } from '../slashCommands';
 import { SlashMenu, type SlashItem } from './SlashMenu';
 import { IconPaperclip, IconArrowUp, IconStop, IconX } from './icons';
 
-type MenuMode = 'closed' | 'commands' | 'model' | 'export' | 'skills';
+type MenuMode = 'closed' | 'commands' | 'model' | 'export' | 'skills' | 'files';
+
+/**
+ * Locate an `@`-file token being typed at the caret. Returns the `@`'s index and the
+ * query typed after it, or null. The `@` must sit at a token start (string start or
+ * after whitespace / an open bracket) and the run up to the caret must be path-ish.
+ */
+function detectAtToken(value: string, caret: number): { at: number; query: string } | null {
+  for (let i = caret - 1; i >= 0; i -= 1) {
+    const ch = value[i];
+    if (ch === '@') {
+      const before = i === 0 ? '' : value[i - 1];
+      if (i === 0 || /[\s([{'"`]/.test(before)) {
+        const query = value.slice(i + 1, caret);
+        if (/^[\w./-]*$/.test(query)) return { at: i, query };
+      }
+      return null;
+    }
+    if (/\s/.test(ch)) return null; // hit whitespace before an @ → not in an @token
+  }
+  return null;
+}
 
 /** A rendered menu row plus the action to run when it is chosen. */
 interface MenuEntry extends SlashItem {
@@ -39,9 +60,12 @@ export function Composer({ streaming }: { streaming: boolean }) {
   const [menuMode, setMenuMode] = useState<MenuMode>('closed');
   const [highlight, setHighlight] = useState(0);
   const [showStatus, setShowStatus] = useState(false);
+  // The `@`-file token being typed (its position + query), driving the files popup.
+  const [atToken, setAtToken] = useState<{ at: number; query: string } | null>(null);
   const selection = useStore((s) => s.selectionContext);
   const settings = useStore((s) => s.settings);
   const conv = useStore((s) => s.conversation);
+  const fileList = useStore((s) => s.fileList);
   const taRef = useRef<HTMLTextAreaElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
 
@@ -50,6 +74,38 @@ export function Composer({ streaming }: { streaming: boolean }) {
   useEffect(() => {
     if (selection) taRef.current?.focus();
   }, [selection]);
+
+  // While the `@`-file popup is open, (re)request the workspace file list for the
+  // current query, debounced so each keystroke does not round-trip to the host.
+  const fileQuery = atToken?.query ?? null;
+  useEffect(() => {
+    if (menuMode !== 'files') return;
+    const q = fileQuery ?? '';
+    const t = setTimeout(() => post({ type: 'listFiles', query: q || undefined }), 150);
+    return () => clearTimeout(t);
+  }, [menuMode, fileQuery]);
+
+  /** Insert `@<path> ` in place of the `@`-token being typed and hand focus back. */
+  const insertFileMention = (path: string) => {
+    const ta = taRef.current;
+    const at = atToken?.at ?? -1;
+    if (!ta || at < 0) return;
+    const caret = ta.selectionStart ?? text.length;
+    const before = text.slice(0, at);
+    const after = text.slice(caret);
+    const insertion = `@${path} `;
+    const next = `${before}${insertion}${after}`;
+    setText(next);
+    setMenuMode('closed');
+    setAtToken(null);
+    setHighlight(0);
+    requestAnimationFrame(() => {
+      ta.focus();
+      const pos = before.length + insertion.length;
+      ta.setSelectionRange(pos, pos);
+      grow();
+    });
+  };
 
   const grow = () => {
     const ta = taRef.current;
@@ -82,6 +138,7 @@ export function Composer({ streaming }: { streaming: boolean }) {
     setAttachments([]);
     setPrdArmed(false);
     setMenuMode('closed');
+    setAtToken(null);
     resetHeight();
   };
 
@@ -180,6 +237,17 @@ export function Composer({ streaming }: { streaming: boolean }) {
         run: () => runCommand(cmd),
       }));
     }
+    if (menuMode === 'files') {
+      const fq = (atToken?.query ?? '').toLowerCase();
+      const filtered = (fq ? fileList.filter((p) => p.toLowerCase().includes(fq)) : fileList).slice(0, 50);
+      if (filtered.length === 0) {
+        return [{ row: { key: 'none', title: fq ? 'No matching files' : 'No files' }, disabled: true, run: () => {} }];
+      }
+      return filtered.map((p) => ({
+        row: { key: p, title: p },
+        run: () => insertFileMention(p),
+      }));
+    }
     const q = text.trim().toLowerCase();
     if (menuMode === 'model') {
       const providers = settings?.providers ?? [];
@@ -273,9 +341,12 @@ export function Composer({ streaming }: { streaming: boolean }) {
         return;
       }
       if (e.key === 'Enter' || e.key === 'Tab') {
-        // Leading '/' but no command matched → close menu, treat as a prompt.
-        if (menuMode === 'commands' && menu.length === 0) {
+        // Leading '/' with no command, or '@' with no file match → close and treat
+        // the text as an ordinary prompt rather than trapping Enter on a dead menu.
+        const allDisabled = menu.length === 0 || menu.every((it) => it.disabled);
+        if ((menuMode === 'commands' || menuMode === 'files') && allDisabled) {
           setMenuMode('closed');
+          if (menuMode === 'files') setAtToken(null);
           if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
             if (!streaming) send();
@@ -288,8 +359,9 @@ export function Composer({ streaming }: { streaming: boolean }) {
       }
       if (e.key === 'Escape') {
         e.preventDefault();
-        if (menuMode === 'commands') {
+        if (menuMode === 'commands' || menuMode === 'files') {
           setMenuMode('closed');
+          if (menuMode === 'files') setAtToken(null);
         } else {
           // Second-level → back to the command list.
           setMenuMode('commands');
@@ -312,12 +384,28 @@ export function Composer({ streaming }: { streaming: boolean }) {
   };
 
   const onInput = (e: Event) => {
-    const value = (e.target as HTMLTextAreaElement).value;
+    const ta = e.target as HTMLTextAreaElement;
+    const value = ta.value;
     setText(value);
     grow();
     setHighlight(0);
     if (menuMode === 'model' || menuMode === 'export' || menuMode === 'skills') return; // keep filtering the submenu
-    setMenuMode(value.startsWith('/') ? 'commands' : 'closed');
+    // '/' only opens commands at position 0; '@' opens the file picker wherever a
+    // token starts (start-of-line or after whitespace).
+    if (value.startsWith('/')) {
+      setMenuMode('commands');
+      setAtToken(null);
+      return;
+    }
+    const caret = ta.selectionStart ?? value.length;
+    const tok = detectAtToken(value, caret);
+    if (tok) {
+      setAtToken(tok);
+      setMenuMode('files');
+    } else {
+      setAtToken(null);
+      setMenuMode('closed');
+    }
   };
 
   const onFiles = (e: Event) => {

--- a/src/webview/components/blocks.tsx
+++ b/src/webview/components/blocks.tsx
@@ -1,6 +1,7 @@
 /** Assistant content-block renderers. */
 import type { JSX } from 'preact';
-import type { ContentBlock, ToolCallRecord, GateCard, CoopRole, GateStatus, PrdStoryStatus } from '../../shared/types';
+import type { ContentBlock, ToolCallRecord, GateCard, CoopRole, GateStatus, PrdPlan, PrdStoryStatus } from '../../shared/types';
+import type { WebviewToHost } from '../../shared/protocol';
 import { Markdown, Collapsible } from './common';
 import {
   IconCheck, IconX, IconWrench, IconCompass, IconHammer, IconEye, IconShield,
@@ -241,12 +242,72 @@ const PLAN_GLYPH: Record<PrdStoryStatus, JSX.Element> = {
   failed: <span class="fp-plan-glyph fp-plan-failed">✕</span>,
 };
 
+/** A PRD-plan action button descriptor (label + the message it posts). */
+export interface PlanAction {
+  label: string;
+  message: WebviewToHost;
+  variant: 'primary' | 'secondary';
+}
+
+/** Human status word for the cursor story, shown in the pinned bar. */
+const STORY_STATUS_WORD: Record<PrdStoryStatus, string> = {
+  pending: 'pending',
+  building: 'building',
+  'awaiting-review': 'awaiting review',
+  done: 'done',
+  failed: 'failed',
+};
+
+/**
+ * The actions offered for a plan's cursor story — the single source of truth shared by the
+ * plan block and the pinned bar so their buttons can't drift. Empty while streaming or when
+ * the cursor story is not actionable (building/done). A failed story offers Retry (primary) +
+ * Skip (secondary); pending offers Resume; awaiting-review offers Continue. Retry and Resume
+ * both post `retryStory` — one host code path re-runs the cursor story.
+ */
+export function planActions(plan: PrdPlan, streaming: boolean): PlanAction[] {
+  if (streaming) return [];
+  const cursorStory = plan.stories[plan.cursor];
+  if (!cursorStory) return [];
+  switch (cursorStory.status) {
+    case 'failed':
+      return [
+        { label: 'Retry story', message: { type: 'retryStory' }, variant: 'primary' },
+        { label: 'Skip story', message: { type: 'continueStoryLoop' }, variant: 'secondary' },
+      ];
+    case 'pending':
+      return [{ label: `Resume story ${plan.cursor + 1}`, message: { type: 'retryStory' }, variant: 'primary' }];
+    case 'awaiting-review':
+      return [{ label: 'Continue — next story', message: { type: 'continueStoryLoop' }, variant: 'primary' }];
+    default:
+      return [];
+  }
+}
+
+function PlanActionButtons({ plan, streaming }: { plan: PrdPlan; streaming: boolean }) {
+  const actions = planActions(plan, streaming);
+  if (actions.length === 0) return null;
+  return (
+    <>
+      {actions.map((a) => (
+        <button
+          key={a.label}
+          type="button"
+          class={`fp-btn fp-btn-sm ${a.variant === 'primary' ? 'fp-btn-primary' : 'fp-btn-secondary'}`}
+          onClick={() => post(a.message)}
+        >
+          {a.variant === 'primary' && <IconArrowRight size={15} />} {a.label}
+        </button>
+      ))}
+    </>
+  );
+}
+
 /**
  * PRD build plan — a marker block that renders LIVE from the conversation's `prdPlan`
  * (statuses advance across turns; the block itself is only a snapshot placeholder). Shows a
- * story checklist with status glyphs, an "N of M done" header, and — when not streaming and
- * the cursor story is awaiting review or failed — a primary button to continue to the next
- * story.
+ * story checklist with status glyphs, an "N of M done" header, and — via {@link planActions}
+ * — the cursor story's action buttons (Retry/Skip, Resume, or Continue) when not streaming.
  */
 export function PlanBlock() {
   const conv = useStore((s) => s.conversation);
@@ -255,17 +316,7 @@ export function PlanBlock() {
   if (!plan || plan.stories.length === 0) return null;
 
   const done = plan.stories.filter((s) => s.status === 'done').length;
-  const cursorStory = plan.stories[plan.cursor];
-  const canContinue =
-    !streaming &&
-    cursorStory &&
-    (cursorStory.status === 'awaiting-review' || cursorStory.status === 'failed' || cursorStory.status === 'pending');
-  const continueLabel =
-    cursorStory?.status === 'failed'
-      ? 'Continue anyway'
-      : cursorStory?.status === 'pending'
-        ? `Resume story ${plan.cursor + 1}`
-        : 'Continue — next story';
+  const actions = planActions(plan, streaming);
 
   return (
     <div class="fp-plan">
@@ -282,16 +333,48 @@ export function PlanBlock() {
           </li>
         ))}
       </ol>
-      {canContinue && (
-        <button
-          type="button"
-          class="fp-btn fp-btn-primary fp-btn-sm"
-          style={{ alignSelf: 'flex-start' }}
-          onClick={() => post({ type: 'continueStoryLoop' })}
-        >
-          <IconArrowRight size={15} /> {continueLabel}
-        </button>
+      {actions.length > 0 && (
+        <div class="fp-plan-actions">
+          <PlanActionButtons plan={plan} streaming={streaming} />
+        </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * A pinned, one-line PRD status bar rendered between the transcript and the composer whenever
+ * a PRD build is active (a plan exists with a story not yet done). It surfaces "N of M done ·
+ * story K <status>" plus the cursor story's action buttons — so the human can retry/skip/
+ * continue without scrolling back up to the plan block that streamed a screen ago. During
+ * streaming it shows a subtle "building story K…" and no buttons.
+ */
+export function PlanBar() {
+  const conv = useStore((s) => s.conversation);
+  const streaming = useStore((s) => s.streaming);
+  const plan = conv?.prdPlan;
+  if (!plan || plan.stories.length === 0) return null;
+  // Only while the build is still active — a fully-done plan is finished.
+  if (plan.stories.every((s) => s.status === 'done')) return null;
+
+  const done = plan.stories.filter((s) => s.status === 'done').length;
+  const total = plan.stories.length;
+  const k = plan.cursor + 1;
+  const cursorStory = plan.stories[plan.cursor];
+  const statusWord = STORY_STATUS_WORD[cursorStory?.status ?? 'pending'];
+
+  return (
+    <div class="fp-plan-bar">
+      <span class="fp-plan-bar-label">
+        <IconFile size={14} />
+        <span>
+          PRD build · {done} of {total} done ·{' '}
+          {streaming ? <em class="fp-plan-bar-building">building story {k}…</em> : <>story {k} {statusWord}</>}
+        </span>
+      </span>
+      <span class="fp-plan-bar-actions">
+        <PlanActionButtons plan={plan} streaming={streaming} />
+      </span>
     </div>
   );
 }

--- a/src/webview/components/store.tsx
+++ b/src/webview/components/store.tsx
@@ -51,6 +51,8 @@ export interface AppState {
   historyItems: ConversationSummary[];
   modelsFetched: Record<string, { id: string; contextWindow?: number }[]>;
   modelsError: Record<string, string | undefined>;
+  /** Workspace file paths for the composer's `@` autocomplete (latest listFiles result). */
+  fileList: string[];
   toasts: Toast[];
   bootstrapped: boolean;
 }
@@ -72,6 +74,7 @@ const initialState: AppState = {
   historyItems: [],
   modelsFetched: {},
   modelsError: {},
+  fileList: [],
   toasts: [],
   bootstrapped: false,
 };
@@ -199,6 +202,9 @@ class Store {
         this.patch({
           modelMentionChoice: { role: msg.role, query: msg.query, candidates: msg.candidates },
         });
+        break;
+      case 'fileList':
+        this.patch({ fileList: msg.paths });
         break;
       case 'showView':
         this.setView(msg.view);

--- a/src/webview/theme.css
+++ b/src/webview/theme.css
@@ -417,6 +417,21 @@ a:hover { text-decoration: underline; }
 .fp-plan-done { color: var(--fp-ok); }
 .fp-plan-failed { color: var(--fp-block); }
 .fp-plan-building { align-self: center; margin-top: 6px; background: var(--fp-accent); animation: fp-pulse 1.2s ease-in-out infinite; }
+.fp-plan-actions { display: flex; flex-wrap: wrap; gap: 8px; }
+
+/* Pinned PRD status bar (between the transcript and the composer) */
+.fp-plan-bar {
+  display: flex; align-items: center; gap: 12px;
+  max-width: 820px; margin: 0 auto; width: 100%;
+  padding: 7px 24px; box-sizing: border-box;
+  border-top: 1px solid var(--fp-border);
+  background: var(--fp-surface);
+  font-size: calc(12px * var(--fp-scale));
+}
+.fp-plan-bar-label { display: inline-flex; align-items: center; gap: 8px; flex: 1; min-width: 0; color: var(--fp-fg-muted); }
+.fp-plan-bar-label > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.fp-plan-bar-building { color: var(--fp-accent); font-style: italic; }
+.fp-plan-bar-actions { display: inline-flex; flex-wrap: wrap; gap: 8px; flex-shrink: 0; }
 
 /* PRD-build armed chip (composer) */
 .fp-prd-chip { color: var(--fp-accent); border-color: var(--fp-accent); background: var(--fp-accent-soft); font-weight: 700; }

--- a/test/extension-session.test.ts
+++ b/test/extension-session.test.ts
@@ -1455,3 +1455,236 @@ describe('PRD plan history round-trip', () => {
     expect(roundTripped.prdPlan?.cursor).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Conversation context digest for the planning roles (Scout)
+// ---------------------------------------------------------------------------
+
+/** The user prompt text of the SCOUT request(s) in a request list, oldest → newest. */
+function scoutPrompts(requests: ChatRequest[]): string[] {
+  return requests.filter((r) => r.system.includes('SCOUT')).map((r) => userWireText(r));
+}
+
+describe('coop context digest', () => {
+  it("carries prior conversation text into a follow-up coop turn's Scout prompt", async () => {
+    const { session, requests } = makeSession({ mode: 'coop', path: 'foo.txt', content: 'x\n' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'FIRSTASK build the login form' });
+
+    const idx = requests.length;
+    await session.handle({ type: 'sendPrompt', text: 'SECONDASK now add validation' });
+
+    const scout = scoutPrompts(requests.slice(idx))[0];
+    expect(scout).toContain('CONVERSATION SO FAR (condensed):');
+    expect(scout).toContain('FIRSTASK build the login form'); // prior turn in the digest
+    expect(scout).toContain('CURRENT REQUEST:');
+    expect(scout).toContain('SECONDASK now add validation'); // the new turn
+  });
+
+  it("first turn has no digest — the Scout prompt is the bare request", async () => {
+    const { session, requests } = makeSession({ mode: 'coop', path: 'foo.txt', content: 'x\n' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'add a feature' });
+
+    const scout = scoutPrompts(requests)[0];
+    expect(scout).not.toContain('CONVERSATION SO FAR');
+    expect(scout.trim()).toBe('add a feature');
+  });
+
+  it('clarification flow: the second Scout prompt carries BOTH the original request and the reply', async () => {
+    const io = new FakeIo();
+    const posted: HostToWebview[] = [];
+    const requests: ChatRequest[] = [];
+    let scoutCalls = 0;
+    // First Scout call is ambiguous (blocks the line); later ones return criteria.
+    const adapter: ProviderAdapter = {
+      chat(request: ChatRequest) {
+        requests.push(request);
+        let events: StreamEvent[];
+        if (request.system.includes('SCOUT')) {
+          scoutCalls += 1;
+          events =
+            scoutCalls === 1
+              ? textEvents(JSON.stringify({ criteria: [], plan: [], ambiguous: true, question: 'Which cache backend?' }))
+              : textEvents(JSON.stringify({ criteria: ['C1'], plan: ['p'], ambiguous: false }));
+        } else if (request.system.includes('INSPECTOR') || request.system.includes('SENTRY')) {
+          events = textEvents(JSON.stringify({ verdict: 'approve', findings: [] }));
+        } else {
+          const hasToolResult = request.messages.some((m) => m.role === 'tool');
+          events = hasToolResult ? textEvents('done') : editEvents('foo.txt', 'x\n');
+        }
+        return (async function* () {
+          for (const e of events) yield e;
+        })();
+      },
+    };
+    const deps: SessionDeps = {
+      io,
+      secrets: new FakeSecrets(),
+      settings: new FakeSettings('coop'),
+      history: new FakeHistory(),
+      git: fakeGit,
+      post: (m) => posted.push(m),
+      createAdapter: () => adapter,
+      fetchModels: async () => [{ id: 'm1' }],
+      clock: () => Date.now(),
+    };
+    const session = createSessionCore(deps);
+
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'ORIGINALASK add a cache layer' });
+    // First turn blocked on the clarifying question (no build ran).
+    const firstConv = lastConversation(posted)!;
+    const firstLeaf = assistantLeaf(firstConv)!;
+    expect(firstLeaf.blocks.some((b) => b.type === 'text' && b.text.includes('Which cache backend?'))).toBe(true);
+
+    const idx = requests.length;
+    await session.handle({ type: 'sendPrompt', text: 'REPLYTEXT use redis with a 60s TTL' });
+
+    const secondScout = scoutPrompts(requests.slice(idx))[0];
+    expect(secondScout).toContain('ORIGINALASK add a cache layer'); // original request survives via the digest
+    expect(secondScout).toContain('Which cache backend?'); // the assistant's question too
+    expect(secondScout).toContain('REPLYTEXT use redis with a 60s TTL'); // the new reply
+  });
+
+  it('bounds the digest for a long history (per-message + total caps respected)', async () => {
+    const { session, requests } = makeSession({ mode: 'coop', path: 'foo.txt', content: 'x\n' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: `HEADMARK ${'L'.repeat(5000)}` });
+
+    const idx = requests.length;
+    await session.handle({ type: 'sendPrompt', text: 'follow up' });
+
+    const scout = scoutPrompts(requests.slice(idx))[0];
+    const digest = scout.split('CURRENT REQUEST:')[0];
+    // The long prior message was truncated with the ellipsis marker…
+    expect(digest).toContain('HEADMARK');
+    expect(digest).toContain('[…]');
+    // …and the digest is bounded (per-message ~600 chars, total ~2000).
+    expect(digest.length).toBeLessThan(2200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Retry a failed PRD story
+// ---------------------------------------------------------------------------
+
+describe('retryStory', () => {
+  it('re-runs a failed cursor story (failed → building → awaiting-review) via a "Retry story" node', async () => {
+    const io = new FakeIo();
+    const posted: HostToWebview[] = [];
+    let approveInspector = false; // story 1 fails first (inspector rejects), then a retry approves
+    const adapter: ProviderAdapter = {
+      chat(request: ChatRequest) {
+        let events: StreamEvent[];
+        if (request.system.includes('FOREMAN')) events = textEvents(TWO_STORY_JSON);
+        else if (request.system.includes('SCOUT')) events = textEvents(JSON.stringify({ criteria: ['x'], plan: [], ambiguous: false }));
+        else if (request.system.includes('SENTRY')) events = textEvents(JSON.stringify({ verdict: 'approve', findings: [] }));
+        else if (request.system.includes('INSPECTOR'))
+          events = textEvents(JSON.stringify({ verdict: approveInspector ? 'approve' : 'reject', findings: approveInspector ? [] : ['not yet'] }));
+        else {
+          const hasToolResult = request.messages.some((m) => m.role === 'tool');
+          events = hasToolResult ? textEvents('done') : editEvents('foo.txt', 'x\n');
+        }
+        return (async function* () {
+          for (const e of events) yield e;
+        })();
+      },
+    };
+    const deps: SessionDeps = {
+      io,
+      secrets: new FakeSecrets(),
+      settings: new FakeSettings('coop'),
+      history: new FakeHistory(),
+      git: fakeGit,
+      post: (m) => posted.push(m),
+      createAdapter: () => adapter,
+      fetchModels: async () => [{ id: 'm1' }],
+      clock: () => Date.now(),
+    };
+    const session = createSessionCore(deps);
+
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'PRD text', prd: true });
+
+    // Story 1 exhausted its retry budget → failed, cursor still on it.
+    let conv = lastConversation(posted)!;
+    expect(conv.prdPlan?.cursor).toBe(0);
+    expect(conv.prdPlan?.stories[0].status).toBe('failed');
+
+    // Now the inspector approves; retryStory re-runs the cursor story to awaiting-review.
+    approveInspector = true;
+    const before = posted.length;
+    await session.handle({ type: 'retryStory' });
+
+    conv = lastConversation(posted)!;
+    expect(conv.prdPlan?.cursor).toBe(0); // cursor did NOT advance
+    expect(conv.prdPlan?.stories[0].status).toBe('awaiting-review'); // failed → awaiting-review
+    expect(conv.prdPlan?.stories[1].status).toBe('pending');
+    // A synthetic "Retry story 1" user node parented the re-run, and a turn ran.
+    expect(
+      Object.values(conv.nodes).some(
+        (n) => n.role === 'user' && n.blocks.some((b) => b.type === 'text' && b.text.startsWith('Retry story 1:')),
+      ),
+    ).toBe(true);
+    expect(posted.slice(before).some((m) => m.type === 'turnStarted')).toBe(true);
+  });
+
+  it('ignores retryStory while a turn is streaming', async () => {
+    const io = new FakeIo();
+    const posted: HostToWebview[] = [];
+    let unblock: () => void = () => {};
+    const blocker = new Promise<void>((res) => {
+      unblock = res;
+    });
+    // Hang the story-1 Sentry call so a turn is in flight when retryStory arrives.
+    const adapter: ProviderAdapter = {
+      chat(request: ChatRequest) {
+        let events: StreamEvent[];
+        let block = false;
+        if (request.system.includes('FOREMAN')) events = textEvents(TWO_STORY_JSON);
+        else if (request.system.includes('SCOUT')) events = textEvents(JSON.stringify({ criteria: ['x'], plan: [], ambiguous: false }));
+        else if (request.system.includes('SENTRY')) {
+          events = textEvents(JSON.stringify({ verdict: 'approve', findings: [] }));
+          block = true;
+        } else if (request.system.includes('INSPECTOR')) {
+          events = textEvents(JSON.stringify({ verdict: 'approve', findings: [] }));
+        } else {
+          const hasToolResult = request.messages.some((m) => m.role === 'tool');
+          events = hasToolResult ? textEvents('done') : editEvents('foo.txt', 'x\n');
+        }
+        return (async function* () {
+          if (block) await blocker;
+          for (const e of events) yield e;
+        })();
+      },
+    };
+    const deps: SessionDeps = {
+      io,
+      secrets: new FakeSecrets(),
+      settings: new FakeSettings('coop'),
+      history: new FakeHistory(),
+      git: fakeGit,
+      post: (m) => posted.push(m),
+      createAdapter: () => adapter,
+      fetchModels: async () => [{ id: 'm1' }],
+      clock: () => Date.now(),
+    };
+    const session = createSessionCore(deps);
+    await session.handle({ type: 'ready' });
+
+    const turn = session.handle({ type: 'sendPrompt', text: 'PRD text', prd: true });
+    for (let i = 0; i < 100; i += 1) {
+      if (posted.some((m) => m.type === 'gateUpdate' && m.card.role === 'sentry')) break;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    expect(posted.some((m) => m.type === 'gateUpdate' && m.card.role === 'sentry')).toBe(true);
+
+    const before = posted.length;
+    await session.handle({ type: 'retryStory' });
+    expect(posted.length).toBe(before); // ignored while a turn is in flight
+
+    unblock();
+    await turn;
+  });
+});

--- a/test/extension-session.test.ts
+++ b/test/extension-session.test.ts
@@ -1688,3 +1688,190 @@ describe('retryStory', () => {
     await turn;
   });
 });
+
+// ---------------------------------------------------------------------------
+// Deterministic file references in prompts (@file + bare-path auto-include)
+// ---------------------------------------------------------------------------
+
+/** The system prompt of a request is a Coop role prompt (Scout/Inspector/Sentry/Foreman). */
+function isRolePrompt(sys: string): boolean {
+  return /(SCOUT|INSPECTOR|SENTRY|FOREMAN)/.test(sys);
+}
+
+describe('deterministic file references in prompts', () => {
+  it('inlines a bare file reference into the coop Scout and Builder prompts, and toasts once', async () => {
+    const { session, requests, io, posted } = makeSession({ mode: 'coop', path: 'x.txt', content: 'x\n' });
+    io.files.set('auraringprd.md', 'AURA-PRD-BODY: build the ring app');
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'implement auraringprd.md' });
+
+    const scout = requests.find((r) => r.system.includes('SCOUT'));
+    expect(scout).toBeDefined();
+    const scoutText = userWireText(scout!);
+    expect(scoutText).toContain('Referenced file auraringprd.md:');
+    expect(scoutText).toContain('AURA-PRD-BODY: build the ring app');
+
+    // The Builder (solo-style system, not a role prompt) receives the content too.
+    const builder = requests.find((r) => !isRolePrompt(r.system));
+    expect(builder).toBeDefined();
+    expect(allWireText(builder!)).toContain('AURA-PRD-BODY');
+
+    // Exactly one success toast, listing the included file.
+    const included = posted.filter(
+      (m) => m.type === 'toast' && m.level === 'info' && m.message.startsWith('Included'),
+    );
+    expect(included).toHaveLength(1);
+    expect((included[0] as Extract<HostToWebview, { type: 'toast' }>).message).toContain('auraringprd.md');
+  });
+
+  it('keeps the stored user message compact — expansion is wire-only', async () => {
+    const { session, posted, io } = makeSession({ mode: 'coop', path: 'x.txt', content: 'x\n' });
+    io.files.set('auraringprd.md', 'AURA-PRD-BODY');
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'implement auraringprd.md' });
+
+    const conv = lastConversation(posted)!;
+    const userNode = Object.values(conv.nodes).find((n) => n.role === 'user');
+    const stored = userNode?.blocks.map((b) => (b.type === 'text' ? b.text : '')).join('') ?? '';
+    expect(stored).toBe('implement auraringprd.md'); // no inlined body in the transcript
+    expect(stored).not.toContain('AURA-PRD-BODY');
+  });
+
+  it('a staged edit of the referenced file wins over the disk copy', async () => {
+    const io = new FakeIo();
+    io.files.set('spec.md', 'DISK-BODY');
+    const posted: HostToWebview[] = [];
+    const requests: ChatRequest[] = [];
+    const adapter: ProviderAdapter = {
+      chat(request: ChatRequest) {
+        requests.push(request);
+        let events: StreamEvent[];
+        if (request.system.includes('SCOUT')) events = textEvents(JSON.stringify({ criteria: ['c'], plan: [], ambiguous: false }));
+        else if (request.system.includes('INSPECTOR') || request.system.includes('SENTRY')) events = textEvents(JSON.stringify({ verdict: 'approve', findings: [] }));
+        else {
+          const hasToolResult = request.messages.some((m) => m.role === 'tool');
+          events = hasToolResult
+            ? textEvents('done')
+            : [
+                { type: 'tool_call_start', id: 't1', name: 'edit_files' },
+                { type: 'tool_call_args', id: 't1', delta: JSON.stringify({ edits: [{ path: 'spec.md', find: 'DISK-BODY', replace: 'STAGED-BODY' }] }) },
+                { type: 'tool_call_end', id: 't1' },
+                USAGE,
+                { type: 'done', stopReason: 'tool_use' },
+              ];
+        }
+        return (async function* () {
+          for (const e of events) yield e;
+        })();
+      },
+    };
+    const deps: SessionDeps = {
+      io,
+      secrets: new FakeSecrets(),
+      settings: new FakeSettings('coop'),
+      history: new FakeHistory(),
+      git: fakeGit,
+      post: (m) => posted.push(m),
+      createAdapter: () => adapter,
+      fetchModels: async () => [{ id: 'm1' }],
+      clock: () => Date.now(),
+    };
+    const session = createSessionCore(deps);
+
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'edit the spec' }); // stages spec.md → STAGED-BODY
+
+    const idx = requests.length;
+    await session.handle({ type: 'sendPrompt', text: 'now summarize spec.md' }); // references the file
+
+    const scout = requests.slice(idx).find((r) => r.system.includes('SCOUT'));
+    expect(scout).toBeDefined();
+    const t = userWireText(scout!);
+    expect(t).toContain('STAGED-BODY');
+    expect(t).not.toContain('DISK-BODY'); // the staged overlay copy wins
+  });
+
+  it('warns on a missing @-mention but still runs the turn', async () => {
+    const { session, posted } = makeSession({ mode: 'solo', path: 'x.txt', content: 'x\n' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'read @missing.md and continue' });
+
+    expect(
+      posted.some((m) => m.type === 'toast' && m.level === 'warn' && m.message === '@missing.md not found in the workspace'),
+    ).toBe(true);
+    // The prompt still ran as an ordinary turn.
+    expect(posted.some((m) => m.type === 'turnStarted')).toBe(true);
+  });
+
+  it("a PRD turn inlines the referenced file into the Foreman's prompt", async () => {
+    const { session, requests, io } = makeSession({ mode: 'coop', path: 'x.txt', content: 'x\n' });
+    io.files.set('auraringprd.md', 'AURA-PRD-BODY: the ring spec');
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'implement auraringprd.md', prd: true });
+
+    const foreman = requests.find((r) => r.system.includes('FOREMAN'));
+    expect(foreman).toBeDefined();
+    const t = userWireText(foreman!);
+    expect(t).toContain('Referenced file auraringprd.md:');
+    expect(t).toContain('AURA-PRD-BODY: the ring spec');
+  });
+
+  it('does NOT expand file references on synthetic "Continue story" turns', async () => {
+    const io = new FakeIo();
+    io.files.set('notes.md', 'NOTES-BODY-SHOULD-NOT-INLINE');
+    const posted: HostToWebview[] = [];
+    const requests: ChatRequest[] = [];
+    // A decomposition whose second story TITLE contains a resolvable path — if the
+    // synthetic "Continue to story 2: …" node were expanded, notes.md would inline.
+    const twoStories = JSON.stringify({
+      stories: [
+        { title: 'First slice', summary: 's1', criteria: ['a'] },
+        { title: 'Configure notes.md', summary: 's2', criteria: ['b'] },
+      ],
+    });
+    const adapter: ProviderAdapter = {
+      chat(request: ChatRequest) {
+        requests.push(request);
+        let events: StreamEvent[];
+        if (request.system.includes('FOREMAN')) events = textEvents(twoStories);
+        else if (request.system.includes('SCOUT')) events = textEvents(JSON.stringify({ criteria: ['c'], plan: [], ambiguous: false }));
+        else if (request.system.includes('INSPECTOR') || request.system.includes('SENTRY')) events = textEvents(JSON.stringify({ verdict: 'approve', findings: [] }));
+        else {
+          const hasToolResult = request.messages.some((m) => m.role === 'tool');
+          events = hasToolResult ? textEvents('done') : editEvents('foo.txt', 'x\n');
+        }
+        return (async function* () {
+          for (const e of events) yield e;
+        })();
+      },
+    };
+    const deps: SessionDeps = {
+      io,
+      secrets: new FakeSecrets(),
+      settings: new FakeSettings('coop'),
+      history: new FakeHistory(),
+      git: fakeGit,
+      post: (m) => posted.push(m),
+      createAdapter: () => adapter,
+      fetchModels: async () => [{ id: 'm1' }],
+      clock: () => Date.now(),
+    };
+    const session = createSessionCore(deps);
+
+    await session.handle({ type: 'ready' });
+    // Turn-1 PRD prompt references NO file, so no expansion happens on it either.
+    await session.handle({ type: 'sendPrompt', text: 'build the whole thing', prd: true });
+
+    const idx = requests.length;
+    await session.handle({ type: 'continueStoryLoop' }); // synthetic "Continue to story 2: Configure notes.md"
+
+    // The continue turn's requests carry the spec (title text) but NOT an inlined file.
+    for (const r of requests.slice(idx)) {
+      const text = allWireText(r);
+      expect(text).not.toContain('Referenced file notes.md:');
+      expect(text).not.toContain('NOTES-BODY-SHOULD-NOT-INLINE');
+    }
+    // No "Included …" toast fired for the synthetic advance.
+    expect(posted.some((m) => m.type === 'toast' && m.level === 'info' && m.message.startsWith('Included'))).toBe(false);
+  });
+});

--- a/test/fileMentions.test.ts
+++ b/test/fileMentions.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for deterministic file-reference extraction/expansion (src/core/agent/fileMentions).
+ * Pure module — no host, no fs — so these pin the detection grammar and the fencing.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  capFileContent,
+  expandFileMentions,
+  extractFileMentions,
+  FILE_TRUNCATION_MARKER,
+} from '../src/core/agent/fileMentions';
+
+describe('extractFileMentions — explicit @ mentions', () => {
+  it('captures @<path> tokens and strips the marker', () => {
+    const { explicit } = extractFileMentions('please read @src/auth/login.ts and @notes.md');
+    expect(explicit).toEqual(['src/auth/login.ts', 'notes.md']);
+  });
+
+  it('requires a . or / in the path (bare @word is not a file)', () => {
+    const { explicit } = extractFileMentions('@here @team look at @docs/spec.md');
+    expect(explicit).toEqual(['docs/spec.md']);
+  });
+
+  it('strips trailing sentence punctuation from the capture', () => {
+    const { explicit } = extractFileMentions('open @auraringprd.md.');
+    expect(explicit).toEqual(['auraringprd.md']);
+  });
+
+  it('does not fire on an email address mid-token', () => {
+    const { explicit, bare } = extractFileMentions('mail me at pranav@example.com about it');
+    expect(explicit).toEqual([]);
+    // "pranav@example.com" contains '@' so it is not a bare candidate either.
+    expect(bare).toEqual([]);
+  });
+
+  it('dedupes explicit mentions, preserving first-seen order', () => {
+    const { explicit } = extractFileMentions('@a.md then @b.ts then @a.md again');
+    expect(explicit).toEqual(['a.md', 'b.ts']);
+  });
+});
+
+describe('extractFileMentions — bare detection positives', () => {
+  it('detects a bare filename with a known text extension', () => {
+    expect(extractFileMentions('implement auraringprd.md').bare).toEqual(['auraringprd.md']);
+  });
+
+  it('detects a slash path even without an extension', () => {
+    expect(extractFileMentions('look in src/foo.ts and lib/util').bare).toEqual(['src/foo.ts', 'lib/util']);
+  });
+
+  it('detects an uppercase doc path', () => {
+    expect(extractFileMentions('see docs/USER_MANUAL.md for details').bare).toEqual(['docs/USER_MANUAL.md']);
+  });
+});
+
+describe('extractFileMentions — bare detection negatives', () => {
+  it('does not match a plain decimal number', () => {
+    expect(extractFileMentions('bump to 3.6 today').bare).toEqual([]);
+  });
+
+  it('does not match a semver-ish version', () => {
+    expect(extractFileMentions('upgrade to v1.2.3 please').bare).toEqual([]);
+  });
+
+  it('does not match a model name with a dot but no known extension', () => {
+    expect(extractFileMentions('run Qwen3.6-35B-MoE on it').bare).toEqual([]);
+  });
+
+  it('does not match a URL (scheme skipped even though it ends in .md)', () => {
+    expect(extractFileMentions('fetch https://x.com/a.md now').bare).toEqual([]);
+  });
+
+  it('does not match "e.g." prose abbreviations', () => {
+    expect(extractFileMentions('e.g. do the thing').bare).toEqual([]);
+  });
+
+  it('excludes a bare token that is already an explicit mention', () => {
+    const { explicit, bare } = extractFileMentions('@foo.md and foo.md');
+    expect(explicit).toEqual(['foo.md']);
+    expect(bare).toEqual([]);
+  });
+});
+
+describe('expandFileMentions — backtick-safe fencing', () => {
+  it('appends a labelled fenced block per file', () => {
+    const out = expandFileMentions('do it', [{ path: 'a.md', content: 'hello' }]);
+    expect(out).toContain('do it');
+    expect(out).toContain('Referenced file a.md:');
+    expect(out).toContain('```\nhello\n```');
+  });
+
+  it('content containing ``` cannot break out of the fence', () => {
+    const content = 'text\n```ts\nconst x = 1;\n```\nmore';
+    const out = expandFileMentions('please', [{ path: 'r.md', content }]);
+    // The wrapper fence must be longer than the inner triple-fence.
+    expect(out).toContain('````');
+    const first = out.indexOf('````');
+    const last = out.lastIndexOf('````');
+    expect(last).toBeGreaterThan(first);
+    // The inner triple-fence and the file body sit between the outer 4-backtick runs.
+    expect(out.slice(first, last)).toContain('```ts');
+    expect(out.slice(first, last)).toContain('const x = 1;');
+  });
+
+  it('returns the text unchanged when there are no files', () => {
+    expect(expandFileMentions('nothing here', [])).toBe('nothing here');
+  });
+});
+
+describe('capFileContent', () => {
+  it('leaves content under the cap untouched', () => {
+    const r = capFileContent('short', 100);
+    expect(r).toEqual({ content: 'short', truncated: false });
+  });
+
+  it('truncates to the head plus a marker when over the cap', () => {
+    const r = capFileContent('x'.repeat(50), 10);
+    expect(r.truncated).toBe(true);
+    expect(r.content.startsWith('x'.repeat(10))).toBe(true);
+    expect(r.content).toContain(FILE_TRUNCATION_MARKER.trim());
+    expect(r.content).not.toContain('x'.repeat(11));
+  });
+});

--- a/test/harness.test.ts
+++ b/test/harness.test.ts
@@ -198,6 +198,57 @@ describe('runCoopPipeline — modelLabelFor', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Context digest → Scout prompt composition
+// ---------------------------------------------------------------------------
+
+describe('runCoopPipeline — contextDigest', () => {
+  it('prepends the condensed conversation to the Scout prompt when a digest is provided', async () => {
+    const { runner, calls } = scriptedRunner({
+      scout: [scoutOk(['C1'])],
+      inspector: [approve],
+      sentry: [approve],
+    });
+
+    await runCoopPipeline({
+      userPrompt: 'use those 7 criteria',
+      contextDigest: 'user: build the auth flow\nassistant: which provider?',
+      runner,
+      inspector: fakeInspector(),
+      buildStage: vi.fn(async () => BUILDER_USAGE),
+      settings: settings(),
+      onGate: () => {},
+    });
+
+    const scoutPrompt = calls.find((c) => c.role === 'scout')!.userPrompt;
+    expect(scoutPrompt).toContain('CONVERSATION SO FAR (condensed):');
+    expect(scoutPrompt).toContain('build the auth flow');
+    expect(scoutPrompt).toContain('CURRENT REQUEST:');
+    expect(scoutPrompt).toContain('use those 7 criteria');
+    // The digest precedes the current request.
+    expect(scoutPrompt.indexOf('CONVERSATION SO FAR')).toBeLessThan(scoutPrompt.indexOf('CURRENT REQUEST'));
+  });
+
+  it('passes the bare request as the Scout prompt when no digest is given', async () => {
+    const { runner, calls } = scriptedRunner({
+      scout: [scoutOk(['C1'])],
+      inspector: [approve],
+      sentry: [approve],
+    });
+
+    await runCoopPipeline({
+      userPrompt: 'add feature X',
+      runner,
+      inspector: fakeInspector(),
+      buildStage: vi.fn(async () => BUILDER_USAGE),
+      settings: settings(),
+      onGate: () => {},
+    });
+
+    expect(calls.find((c) => c.role === 'scout')!.userPrompt).toBe('add feature X');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Ambiguous scout → blocked
 // ---------------------------------------------------------------------------
 
@@ -226,6 +277,9 @@ describe('runCoopPipeline — ambiguous scout', () => {
     expect(result.outcome).toBe('blocked');
     expect(result.question).toBe(question);
     expect(buildStage).not.toHaveBeenCalled();
+
+    // The Scout card itself reads as blocked (not a green "passed") on an ambiguous result.
+    expect(result.cards.find((c) => c.role === 'scout')?.status).toBe('blocked');
 
     const stl = result.cards.find((c) => c.role === 'stop-the-line');
     expect(stl?.status).toBe('blocked');
@@ -570,5 +624,14 @@ describe('parseScout', () => {
   it('treats an empty-criteria non-ambiguous response as ambiguous (fail-safe)', () => {
     const s = parseScout('{"criteria":[],"plan":["do it"],"ambiguous":false}');
     expect(s.ambiguous).toBe(true);
+  });
+
+  it('extracts a JSON object embedded after a sentence of prose', () => {
+    const s = parseScout(
+      'Sure — here is the contract for the request. {"criteria":["C1: does X"],"plan":["step"],"ambiguous":false}',
+    );
+    expect(s.ambiguous).toBe(false);
+    expect(s.criteria).toEqual(['C1: does X']);
+    expect(s.plan).toEqual(['step']);
   });
 });

--- a/test/modelMentions.test.ts
+++ b/test/modelMentions.test.ts
@@ -102,6 +102,41 @@ describe('parseModelMentions — role directives', () => {
       { role: 'builder', query: 'glm' },
     ]);
   });
+
+  it('chains "and"-joined verbs: one model, several roles', () => {
+    expect(parseModelMentions('qwen to orchestrate and build, gemma to review and audit')).toEqual([
+      { role: 'scout', query: 'qwen' },
+      { role: 'builder', query: 'qwen' },
+      { role: 'inspector', query: 'gemma' },
+      { role: 'sentry', query: 'gemma' },
+    ]);
+  });
+
+  it('chains in the "with" and "for" forms too', () => {
+    expect(parseModelMentions('review and audit with gemma')).toEqual([
+      { role: 'inspector', query: 'gemma' },
+      { role: 'sentry', query: 'gemma' },
+    ]);
+    expect(parseModelMentions('qwen for review and security')).toEqual([
+      { role: 'inspector', query: 'qwen' },
+      { role: 'sentry', query: 'qwen' },
+    ]);
+    expect(parseModelMentions('use fable to plan and audit')).toEqual([
+      { role: 'scout', query: 'fable' },
+      { role: 'sentry', query: 'fable' },
+    ]);
+  });
+
+  it('a chain stops at a non-verb: "and <name>" starts a new clause, not a chain', () => {
+    expect(parseModelMentions('qwen to build and glm to review')).toEqual([
+      { role: 'builder', query: 'qwen' },
+      { role: 'inspector', query: 'glm' },
+    ]);
+  });
+
+  it('chained directives are still directive-only messages', () => {
+    expect(isDirectiveOnly('qwen to orchestrate and build, gemma to review and audit')).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Six commits of fixes from live Coop-mode testing:

**Mention grammar chains** — "qwen to orchestrate and build, gemma to review and audit" now assigns all four roles (previously only the first verb per clause applied, leaving Builder/Sentry silently on the conversation model).

**Supersede warning** — a new prompt that drops an unanswered model-disambiguation picker now warns instead of silently discarding the directive.

**Scout/Foreman conversation context** — role prompts carry a condensed digest of recent turns, so a clarification reply arrives attached to the original request (fixes the restate loop). The Scout adopts explicit user-supplied acceptance criteria, opens referenced files before judging ambiguity, answers JSON-only, and its card shows Blocked (not Passed) when it raises the clarifying question.

**Pinned PRD bar + story retry** — live plan progress with Continue / Retry story / Skip story actions always visible above the composer; failed stories can be retried with new context instead of only skipped; retry/resume share one host code path.

**Host-side file references** — `@path` autocomplete in the composer plus conservative bare-path auto-include ("implement auraringprd.md" just works): content is read through the staging overlay at wire-composition time, fenced tamper-safe, capped to the role's context budget, with an inclusion toast; transcript keeps the compact reference.

**e2e expansion** — Playwright assertions 54 → 100 covering the slash menu, context bar, mention picker, plan-block states, PRD chip, file picker, gate-card labels, and in-DOM markdown regressions.

Verification: `tsc --noEmit` clean, 286 unit tests, 100 e2e assertions, `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG)_