### PR TITLE
Bound runaway generation, fresh-context story retries, PRD bar stop

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -220,6 +220,25 @@ Each stage emits an **evidence gate card** in the chat so you can see what was c
 why it passed. QA and Security gates can't be bypassed. Coop is what makes local models
 reliable: their output is verified before it reaches you.
 
+### Guardrails: token caps and runaway protection
+
+Local servers (LM Studio, llama.cpp, …) default to *unlimited* output, so a model that
+falls into an endless "thinking" loop can silently exhaust its whole context window. FowlPlay
+prevents that on two levels:
+
+- **Every model call is capped.** FowlPlay always sends a `max_tokens` limit — the response
+  reserve for the model's known context window (a quarter of it, at least 1.5k), or a fixed
+  **8192-token** safety net when the window is unknown. No single response can grow unbounded.
+- **A client-side failsafe halts runaways.** If a server ignores the cap and keeps streaming
+  past ~1.5× the limit, FowlPlay aborts that call locally and marks the step **failed** with
+  evidence like *"Runaway generation halted after ~180k tokens (cap ~8k). Retry the step —
+  consider a larger context window or a different model."* In Coop/PRD the Builder's gate card
+  fails; in Solo you get an error block. Retry, and pick a bigger window or a different model
+  if it recurs.
+
+While any response streams you can stop it at once with **Escape** (or the composer's stop
+button) — and, during a PRD build, the **Stop** button on the pinned PRD bar.
+
 ### PRD builds — long-horizon work
 
 A whole PRD (product requirements doc) is too big to build in one changeset. Run **`/prd`**
@@ -243,14 +262,19 @@ review between each.
    - If a story **failed** its checks, you get two buttons: **Retry story** re-runs that same
      story from scratch (worth a try after you've tweaked its spec, or just to give it
      another pass), and **Skip story** moves on anyway — your call, and the skip is noted in
-     that story's spec file.
+     that story's spec file. Each story — including a retry — runs from its **spec alone in a
+     fresh context window**, not the running chat history, so a retry is a genuine clean
+     restart and no earlier story's transcript pollutes it. Earlier stories' work is already
+     on disk (staged or applied), and the Builder is told to read those files rather than
+     assume.
    - If a story was **cancelled** mid-build (it shows as pending), **Resume story N** re-runs
      it — nothing is skipped that never happened.
 6. A **pinned PRD bar** sits just above the composer for the whole build: it shows
    "N of M done · story K …" and repeats the current story's action buttons, so you can
    retry, skip, or continue without scrolling back up to the plan block after a story has
-   streamed its gate cards. While a story is building it reads "building story K…" with no
-   buttons.
+   streamed its gate cards. While a story is building it reads "building story K…" and shows
+   a **Stop** button — so catching a bad build, stopping it, and retrying is one flow in one
+   place.
 7. When the last story is done, a short **completion summary** lists every story's final
    status.
 

--- a/e2e/run.mjs
+++ b/e2e/run.mjs
@@ -395,6 +395,17 @@ await waitFor(page, () => !!Array.from(document.querySelectorAll('button')).find
 // Retry posts retryStory (one code path re-runs the cursor story).
 await page.getByRole('button', { name: /Retry story/ }).first().click();
 ok((await sent(page, 'retryStory')).length >= 1, 'Retry button posts retryStory');
+// While a story is streaming, the pinned PRD bar swaps its actions for a Stop
+// button that posts cancelResponse (catch→stop→retry in one place). turnStarted
+// (with no matching turnFinished) flips the store into the streaming state.
+await page.evaluate(() => window.__host.emit(window.__fixtures.prdConversation('awaiting-review')));
+await page.evaluate(() => window.__host.emit({ type: 'turnStarted', nodeId: 'a1' }));
+await waitFor(page, () => {
+  const bar = document.querySelector('.fp-plan-bar');
+  return !!bar && /Stop/.test(bar.textContent || '');
+}, 'PRD bar shows a Stop button while streaming');
+await page.locator('.fp-plan-bar').getByRole('button', { name: /Stop/ }).click();
+ok((await sent(page, 'cancelResponse')).length >= 1, 'PRD bar Stop posts cancelResponse');
 
 // ============================== PRD CHIP =====================================
 console.log('\n# prd chip');

--- a/src/core/agent/loop.ts
+++ b/src/core/agent/loop.ts
@@ -18,10 +18,45 @@ import type {
   WireMessage,
   WireToolResult,
 } from '../providers/adapter';
+import { estimateTokens } from './contextBudget';
 import { dispatchToolCall, type ToolHost } from './tools';
 
 const DEFAULT_MAX_ROUNDS = 24;
 const SUMMARY_LIMIT = 400;
+
+/**
+ * Generous fixed output cap (tokens) applied when the model's context window is
+ * unknown, so a single response can never grow unbounded — LM Studio and other
+ * local servers default `max_tokens` to unlimited, which let a runaway thinking
+ * loop exhaust the whole window. No reasonable single role response exceeds this.
+ */
+export const DEFAULT_MAX_OUTPUT_TOKENS = 8192;
+
+/**
+ * Client-side runaway failsafe: if a server ignores `max_tokens` and streams past
+ * this multiple of the effective cap, the call is aborted locally and surfaced as
+ * a {@link RunawayGenerationError} rather than being left to exhaust the window.
+ */
+const RUNAWAY_CAP_MULTIPLE = 1.5;
+
+/** Thrown by {@link runAgentLoop} when a single call's output blows past the cap. */
+export class RunawayGenerationError extends Error {
+  constructor(
+    public readonly estimatedTokens: number,
+    public readonly capTokens: number,
+  ) {
+    super(
+      `Runaway generation halted after ~${fmtK(estimatedTokens)} tokens (cap ~${fmtK(capTokens)}). ` +
+        `Retry the step — consider a larger context window or a different model.`,
+    );
+    this.name = 'RunawayGenerationError';
+  }
+}
+
+function fmtK(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k`;
+  return String(n);
+}
 
 export interface LoopOptions {
   adapter: ProviderAdapter;
@@ -67,6 +102,22 @@ export async function runAgentLoop(opts: LoopOptions): Promise<LoopResult> {
     const callOrder: string[] = [];
     let stopReason: 'end' | 'tool_use' | 'cancelled' | 'error' = 'end';
 
+    // Effective output cap for the runaway failsafe: the supplied cap, or the
+    // fixed default when the caller passed none (unknown context window).
+    const effectiveCap = opts.maxTokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
+    const runawayLimit = Math.floor(effectiveCap * RUNAWAY_CAP_MULTIPLE);
+
+    // A per-call AbortController chained to the outer signal, so the runaway
+    // failsafe can abort THIS call locally without touching the turn's signal
+    // (which the caller may still need for cancellation semantics).
+    const callController = new AbortController();
+    const onOuterAbort = () => callController.abort();
+    if (opts.signal) {
+      if (opts.signal.aborted) callController.abort();
+      else opts.signal.addEventListener('abort', onOuterAbort);
+    }
+    let runawayTokens = 0;
+
     const stream = opts.adapter.chat({
       baseUrl: opts.baseUrl,
       apiKey: opts.apiKey,
@@ -75,51 +126,71 @@ export async function runAgentLoop(opts: LoopOptions): Promise<LoopResult> {
       system: opts.system,
       messages,
       tools: opts.tools,
-      signal: opts.signal,
+      signal: callController.signal,
     });
 
-    for await (const event of stream) {
-      opts.onEvent(event);
-      switch (event.type) {
-        case 'text':
-          text += event.delta;
-          break;
-        case 'thinking':
-          thinking += event.delta;
-          break;
-        case 'tool_call_start': {
-          let call = calls.get(event.id);
-          if (!call) {
-            call = { id: event.id, name: event.name, argsStr: '' };
-            calls.set(event.id, call);
-            callOrder.push(event.id);
-          } else if (event.name) {
-            call.name = event.name;
+    try {
+      for await (const event of stream) {
+        opts.onEvent(event);
+        switch (event.type) {
+          case 'text':
+            text += event.delta;
+            break;
+          case 'thinking':
+            thinking += event.delta;
+            break;
+          case 'tool_call_start': {
+            let call = calls.get(event.id);
+            if (!call) {
+              call = { id: event.id, name: event.name, argsStr: '' };
+              calls.set(event.id, call);
+              callOrder.push(event.id);
+            } else if (event.name) {
+              call.name = event.name;
+            }
+            break;
           }
-          break;
+          case 'tool_call_args': {
+            const call = calls.get(event.id);
+            if (call) call.argsStr += event.delta;
+            break;
+          }
+          case 'tool_call_end':
+            break;
+          case 'usage':
+            usage.inputTokens += event.usage.inputTokens;
+            usage.outputTokens += event.usage.outputTokens;
+            usage.cachedTokens += event.usage.cachedTokens;
+            break;
+          case 'done':
+            stopReason = event.stopReason;
+            break;
+          case 'error':
+            // The error text is forwarded via onEvent; the following `done`
+            // event will carry stopReason 'error'.
+            break;
+          default:
+            break;
         }
-        case 'tool_call_args': {
-          const call = calls.get(event.id);
-          if (call) call.argsStr += event.delta;
-          break;
+
+        // Runaway failsafe: the server ignored max_tokens and the streamed
+        // text+thinking has blown past 1.5× the cap. Abort THIS call and throw a
+        // distinct error so the caller can fail the step with actionable evidence.
+        if (event.type === 'text' || event.type === 'thinking') {
+          const est = estimateTokens(text) + estimateTokens(thinking);
+          if (est > runawayLimit) {
+            runawayTokens = est;
+            callController.abort();
+            break;
+          }
         }
-        case 'tool_call_end':
-          break;
-        case 'usage':
-          usage.inputTokens += event.usage.inputTokens;
-          usage.outputTokens += event.usage.outputTokens;
-          usage.cachedTokens += event.usage.cachedTokens;
-          break;
-        case 'done':
-          stopReason = event.stopReason;
-          break;
-        case 'error':
-          // The error text is forwarded via onEvent; the following `done`
-          // event will carry stopReason 'error'.
-          break;
-        default:
-          break;
       }
+    } finally {
+      if (opts.signal) opts.signal.removeEventListener('abort', onOuterAbort);
+    }
+
+    if (runawayTokens > 0) {
+      throw new RunawayGenerationError(runawayTokens, effectiveCap);
     }
 
     // Render assistant text/thinking blocks (in reading order).

--- a/src/core/harness/coop.ts
+++ b/src/core/harness/coop.ts
@@ -59,6 +59,12 @@ export interface RoleRunner {
     /** Inspector/Sentry get read-only tools; Scout too (it must not edit). */
     readOnly: boolean;
     signal?: AbortSignal;
+    /**
+     * Throttled live progress: an estimate of the role's streamed output tokens
+     * so far, so the pipeline can show a climbing count on the role's RUNNING
+     * gate card. Optional — omitted by fakes and callers that don't stream.
+     */
+    onProgress?: (estOutputTokens: number) => void;
   }): Promise<{ text: string; usage: TokenUsage }>;
 }
 
@@ -89,7 +95,11 @@ export interface CoopPipelineOptions {
    * through `inspector`. Returns the Builder's token usage so it is counted toward the
    * conversation totals (the Builder is usually the dominant cost in a Coop turn).
    */
-  buildStage: (instructions: string, signal?: AbortSignal) => Promise<TokenUsage>;
+  buildStage: (
+    instructions: string,
+    signal?: AbortSignal,
+    onProgress?: (estOutputTokens: number) => void,
+  ) => Promise<TokenUsage>;
   settings: HarnessSettings;
   /** Called on every card transition (create + each status change). */
   onGate: (card: GateCard) => void;
@@ -117,6 +127,7 @@ export type CoopOutcome =
   | 'qas-failed'
   | 'security-blocked'
   | 'context-exceeded'
+  | 'runaway'
   | 'cancelled';
 
 /** Detail behind a `context-exceeded` outcome, for the caller's user-facing message. */
@@ -140,6 +151,21 @@ export class ContextExceededError extends Error {
   constructor(public readonly info: ContextExceededInfo) {
     super('Context window exceeded');
     this.name = 'ContextExceededError';
+  }
+}
+
+/**
+ * Thrown from `buildStage` (via the extension) when the Builder's own call was
+ * halted by the client-side runaway failsafe — it streamed past the safety cap
+ * without stopping. The pipeline catches it, fails the in-flight Builder card
+ * with the runaway evidence, and returns the `runaway` outcome. Mirrors the
+ * {@link ContextExceededError} pattern so the harness stays decoupled from the
+ * agentic loop (the extension translates the loop-level error into this one).
+ */
+export class RunawayError extends Error {
+  constructor(public readonly info: { role: CoopRole; message: string }) {
+    super(info.message);
+    this.name = 'RunawayError';
   }
 }
 
@@ -184,6 +210,16 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
   const aborted = () => Boolean(signal?.aborted);
 
   /**
+   * Live progress on a still-RUNNING role card: re-emit it with a climbing
+   * output-token estimate so the user sees generation accumulating (the card
+   * renders `usage.outputTokens` as a ↓ count). No-op once the card has settled.
+   */
+  const bumpCard = (card: GateCard, estOutputTokens: number): void => {
+    if (card.status !== 'running' || estOutputTokens <= 0) return;
+    emit({ ...card, usage: { inputTokens: 0, outputTokens: estOutputTokens, cachedTokens: 0 } });
+  };
+
+  /**
    * Run a read-only review role (Inspector/Sentry) over the diff, splitting it
    * into budget-sized chunks when a budget is supplied and the diff overflows.
    * Each chunk is reviewed sequentially (abort-aware); the verdicts are then
@@ -196,6 +232,7 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
     system: string,
     buildPrompt: (chunk: string) => string,
     diff: string,
+    onProgress?: (estOutputTokens: number) => void,
   ): Promise<{ verdict: ParsedVerdict; usage: TokenUsage; note: string; aborted: boolean }> => {
     const budget = diffBudgetFor?.(role);
     const fit =
@@ -215,6 +252,7 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
         userPrompt: buildPrompt(fit.chunks[0] ?? diff),
         readOnly: true,
         signal,
+        onProgress,
       });
       spend(run.usage);
       const note = fit.truncated
@@ -236,7 +274,7 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
         };
       }
       const prompt = `(Reviewing part ${i + 1} of ${n} of the changeset — judge only what is present in this part.)\n\n${buildPrompt(fit.chunks[i])}`;
-      const run = await runner.run({ role, system, userPrompt: prompt, readOnly: true, signal });
+      const run = await runner.run({ role, system, userPrompt: prompt, readOnly: true, signal, onProgress });
       spend(run.usage);
       verdicts.push(parseVerdict(run.text));
     }
@@ -293,6 +331,7 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
     userPrompt: composeScoutPrompt(contextDigest, userPrompt),
     readOnly: true,
     signal,
+    onProgress: (t) => bumpCard(scoutCard, t),
   });
   addUsage(scoutRun.usage);
   if (aborted()) return cancel(scoutCard);
@@ -377,7 +416,7 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
 
     let builderUsage: TokenUsage;
     try {
-      builderUsage = await buildStage(instructions, signal);
+      builderUsage = await buildStage(instructions, signal, (t) => bumpCard(builderCard, t));
     } catch (err) {
       if (err instanceof ContextExceededError) {
         // Mark the in-flight Builder card, then emit the Context limit gate.
@@ -388,6 +427,18 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
           }),
         );
         return contextExceeded(err.info);
+      }
+      if (err instanceof RunawayError) {
+        // The Builder's own call ran away (server ignored max_tokens). Fail the
+        // in-flight card with the runaway evidence and end the pipeline; the
+        // outcome maps a story to `failed` so the human can retry from clean context.
+        emit(
+          transition(builderCard, 'failed', {
+            attempt,
+            evidence: joinSections(builderCard.evidence, section('Runaway generation halted', err.info.message)),
+          }),
+        );
+        return { outcome: 'runaway', cards, usage };
       }
       throw err;
     }
@@ -425,6 +476,7 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
       INSPECTOR_SYSTEM,
       (chunk) => composeInspectorPrompt(scout.criteria, chunk),
       diff,
+      (t) => bumpCard(inspectorCard, t),
     );
     addUsage(inspectorReview.usage);
     if (inspectorReview.aborted) return cancel(inspectorCard);
@@ -491,6 +543,7 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
     SENTRY_SYSTEM,
     (chunk) => composeSentryPrompt(chunk),
     inspector.unifiedDiff(),
+    (t) => bumpCard(sentryCard, t),
   );
   addUsage(sentryReview.usage);
   if (sentryReview.aborted) return cancel(sentryCard);

--- a/src/core/harness/prd.ts
+++ b/src/core/harness/prd.ts
@@ -206,7 +206,7 @@ function slug(title: string): string {
  * PRD, then the full spec markdown. `index`/`total` are 1-based.
  */
 export function composeStoryPrompt(specMarkdown: string, index: number, total: number): string {
-  return `Story ${index} of ${total} decomposed from a PRD. Implement ONLY this story; earlier stories are already staged/applied.
+  return `Story ${index} of ${total} decomposed from a PRD. Implement ONLY this story. Earlier stories' work is already staged or applied in the workspace — read the files rather than assuming.
 
 ${specMarkdown.trim()}`;
 }

--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -41,7 +41,7 @@ import type { Attachment, HostToWebview, WebviewToHost } from '../shared/protoco
 
 import { createAdapter as coreCreateAdapter, type ProviderAdapter, type WireAssistantPart, type WireMessage, type WireUserPart } from '../core/providers/adapter';
 import { fetchModels as coreFetchModels, type FetchModelsConfig } from '../core/providers/registry';
-import { runAgentLoop } from '../core/agent/loop';
+import { runAgentLoop, DEFAULT_MAX_OUTPUT_TOKENS, RunawayGenerationError } from '../core/agent/loop';
 import { buildToolSpecs, type DirEntry, type GrepMatch, type GrepOptions, type StageOp, type ToolHost } from '../core/agent/tools';
 import { BUNDLED_SKILLS, formatSkillCatalog, parseSkill } from '../core/agent/skills';
 import { gcHistory } from '../core/agent/contextGc';
@@ -53,6 +53,7 @@ import { detectDrift, rebase as coreRebase } from '../core/staging/rebase';
 import { renderHunkDiff } from '../core/diff/compute';
 import {
   ContextExceededError,
+  RunawayError,
   runCoopPipeline,
   type ChangesetInspector,
   type CoopResult,
@@ -740,11 +741,11 @@ export class SessionCore {
     let usage: TokenUsage = emptyUsage();
     try {
       if (opts.prd) {
-        const out = await this.runPrd(userText, imageParts, baseWire, resolved, settings.harness, signal, contextDigest);
+        const out = await this.runPrd(userText, imageParts, resolved, settings.harness, signal, contextDigest);
         blocks = out.blocks;
         usage = out.usage;
       } else if (opts.storyIndex !== undefined) {
-        const out = await this.runStory(opts.storyIndex, baseWire, resolved, settings.harness, signal, contextDigest);
+        const out = await this.runStory(opts.storyIndex, resolved, settings.harness, signal, contextDigest);
         blocks = out.blocks;
         usage = out.usage;
       } else if (this.conv.harnessMode === 'coop') {
@@ -815,6 +816,7 @@ export class SessionCore {
       baseUrl: resolved.baseUrl,
       apiKey: resolved.apiKey,
       modelId: resolved.modelId,
+      maxTokens: this.maxTokensFor(settings),
       system: this.systemWithSkills(SOLO_SYSTEM),
       history: sent,
       tools: this.toolsWithSkills(),
@@ -865,7 +867,7 @@ export class SessionCore {
   ): Promise<CoopResult> {
     const settings = await this.ensureSettings();
     const runner: RoleRunner = {
-      run: async ({ role, system, userPrompt: rolePrompt, readOnly, signal: s }) => {
+      run: async ({ role, system, userPrompt: rolePrompt, readOnly, signal: s, onProgress }) => {
         // Each role resolves its own model through the override chain, falling
         // back to the turn's conversation model.
         const rm = (await this.resolveModel(role)) ?? resolved;
@@ -874,11 +876,14 @@ export class SessionCore {
           baseUrl: rm.baseUrl,
           apiKey: rm.apiKey,
           modelId: rm.modelId,
+          maxTokens: this.maxTokensFor(settings, role),
           system,
           history: [{ role: 'user', content: [{ type: 'text', text: rolePrompt }] }],
           tools: readOnly ? this.readOnlyTools : this.allTools,
           toolHost: this.toolHost(),
-          onEvent: () => {}, // role calls are summarized as gate cards, not streamed
+          // Role calls aren't streamed to the transcript, but we tally their
+          // output so the RUNNING gate card shows a climbing token count.
+          onEvent: this.progressOnEvent(() => {}, onProgress),
           maxRounds: 8,
           signal: s,
         });
@@ -894,7 +899,11 @@ export class SessionCore {
       },
     };
 
-    const buildStage = async (instructions: string, s?: AbortSignal): Promise<TokenUsage> => {
+    const buildStage = async (
+      instructions: string,
+      s?: AbortSignal,
+      onProgress?: (estOutputTokens: number) => void,
+    ): Promise<TokenUsage> => {
       // The Builder stage uses the `builder` role's resolution.
       const rm = (await this.resolveModel('builder')) ?? resolved;
       const base: WireMessage[] = [
@@ -922,18 +931,29 @@ export class SessionCore {
         }
       }
 
-      const res = await runAgentLoop({
-        adapter: rm.adapter,
-        baseUrl: rm.baseUrl,
-        apiKey: rm.apiKey,
-        modelId: rm.modelId,
-        system: this.systemWithSkills(SOLO_SYSTEM),
-        history,
-        tools: this.toolsWithSkills(),
-        toolHost: this.toolHost(),
-        onEvent: (e) => this.deps.post({ type: 'stream', event: e }),
-        signal: s,
-      });
+      let res;
+      try {
+        res = await runAgentLoop({
+          adapter: rm.adapter,
+          baseUrl: rm.baseUrl,
+          apiKey: rm.apiKey,
+          modelId: rm.modelId,
+          maxTokens: this.maxTokensFor(settings, 'builder'),
+          system: this.systemWithSkills(SOLO_SYSTEM),
+          history,
+          tools: this.toolsWithSkills(),
+          toolHost: this.toolHost(),
+          onEvent: this.progressOnEvent((e) => this.deps.post({ type: 'stream', event: e }), onProgress),
+          signal: s,
+        });
+      } catch (err) {
+        // Translate the loop-level runaway into the harness's RunawayError so the
+        // pipeline (which stays decoupled from the loop) can fail the Builder card.
+        if (err instanceof RunawayGenerationError) {
+          throw new RunawayError({ role: 'builder', message: err.message });
+        }
+        throw err;
+      }
       // Return the Builder's usage so the pipeline counts it — it is usually the
       // dominant cost of a Coop turn.
       return res.usage;
@@ -967,6 +987,8 @@ export class SessionCore {
         return 'Sentry flagged a security concern. The changes remain staged — review carefully before applying.';
       case 'context-exceeded':
         return contextExceededMessage(result.context?.modelLabel ?? 'the selected model', result.context?.windowTokens);
+      case 'runaway':
+        return 'Generation ran away and was halted before it exhausted the context window. The changes (if any) remain staged — retry the step, and consider a larger context window or a different model.';
       case 'cancelled':
         return 'Cancelled.';
       case 'ready-for-review':
@@ -987,7 +1009,6 @@ export class SessionCore {
   private async runPrd(
     userText: string,
     imageParts: WireUserPart[],
-    baseWire: WireMessage[],
     resolved: ResolvedModel,
     harness: HarnessSettings,
     signal: AbortSignal,
@@ -1023,6 +1044,7 @@ export class SessionCore {
       baseUrl: rm.baseUrl,
       apiKey: rm.apiKey,
       modelId: rm.modelId,
+      maxTokens: this.maxTokensFor(settings, 'scout'),
       system: FOREMAN_SYSTEM,
       history: [{ role: 'user', content: [{ type: 'text', text: composeForemanPrompt(contextDigest, userText) }, ...imageParts] }],
       tools: this.readOnlyTools,
@@ -1079,7 +1101,7 @@ export class SessionCore {
     );
 
     // --- Build story 1 immediately, within this same turn ---
-    const story1 = await this.runStory(0, baseWire, resolved, harness, signal, contextDigest);
+    const story1 = await this.runStory(0, resolved, harness, signal, contextDigest);
     addUsageInPlace(usage, story1.usage);
 
     // Blocks: Foreman gate, the plan marker (renders live), then story 1's cards + outcome.
@@ -1093,7 +1115,6 @@ export class SessionCore {
    */
   private async runStory(
     storyIndex: number,
-    baseWire: WireMessage[],
     resolved: ResolvedModel,
     harness: HarnessSettings,
     signal: AbortSignal,
@@ -1112,8 +1133,13 @@ export class SessionCore {
     const specMarkdown = renderSpecMarkdown(this.conv.prdPlan!.stories[storyIndex], storyIndex + 1, total);
     const userPrompt = composeStoryPrompt(specMarkdown, storyIndex + 1, total);
 
+    // Stories run from the spec alone — NOT the conversation's wire history. The
+    // spec prompt is self-contained (and tells the Builder that earlier stories
+    // are already on disk to read), so each story gets a fresh window and a
+    // "Retry story" is mechanically a clean-context restart. The Scout still
+    // receives the cheap contextDigest for user clarifications.
     const cards: GateCard[] = [];
-    const result = await this.runCoopCore(userPrompt, [], baseWire, resolved, harness, signal, cards, contextDigest);
+    const result = await this.runCoopCore(userPrompt, [], [], resolved, harness, signal, cards, contextDigest);
 
     const status: PrdStory['status'] =
       result.outcome === 'ready-for-review' ? 'awaiting-review' : result.outcome === 'cancelled' ? 'pending' : 'failed';
@@ -1813,16 +1839,64 @@ export class SessionCore {
   }
 
   /**
-   * The payload token budget for a role's model: the context window minus a
-   * reserve for the system prompt, instructions, and response headroom
-   * (`max(1500, 25% of window)`). Returns `undefined` when the window is unknown
-   * — no hard budget, preserving today's behavior for such providers.
+   * The response token reserve for a role's model: `max(1500, 25% of window)`.
+   * This is both the headroom kept out of the payload budget AND the `max_tokens`
+   * a single response is capped at. Returns `undefined` when the window is unknown
+   * (the caller falls back to {@link DEFAULT_MAX_OUTPUT_TOKENS} for the cap).
+   */
+  private responseCapFor(settings: FowlPlaySettings, role?: CoopRole): number | undefined {
+    const window = this.roleWindow(settings, role);
+    if (window === undefined) return undefined;
+    return Math.max(1500, Math.floor(window * 0.25));
+  }
+
+  /**
+   * The `max_tokens` to send for a role's model call: the response reserve, or a
+   * generous fixed default when the window is unknown — never unlimited, so a
+   * single response can't exhaust the window (e.g. LM Studio's default).
+   */
+  private maxTokensFor(settings: FowlPlaySettings, role?: CoopRole): number {
+    return this.responseCapFor(settings, role) ?? DEFAULT_MAX_OUTPUT_TOKENS;
+  }
+
+  /**
+   * The payload token budget for a role's model: the context window minus the
+   * response reserve. Returns `undefined` when the window is unknown — no hard
+   * budget, preserving today's behavior for such providers.
    */
   private payloadBudget(settings: FowlPlaySettings, role?: CoopRole): number | undefined {
     const window = this.roleWindow(settings, role);
     if (window === undefined) return undefined;
-    const reserve = Math.max(1500, Math.floor(window * 0.25));
+    const reserve = this.responseCapFor(settings, role)!;
     return Math.max(0, window - reserve);
+  }
+
+  /**
+   * Wrap a base `onEvent` so it tallies streamed text+thinking and reports a
+   * throttled (~1.5s, only when it grew) estimate of output tokens via
+   * `onProgress` — used to show a climbing token count on a running gate card.
+   * Returns the base handler unchanged when no progress sink is supplied.
+   */
+  private progressOnEvent(
+    base: (e: StreamEvent) => void,
+    onProgress?: (estOutputTokens: number) => void,
+  ): (e: StreamEvent) => void {
+    if (!onProgress) return base;
+    let chars = 0;
+    let lastReport = 0;
+    let lastValue = -1;
+    return (e: StreamEvent) => {
+      base(e);
+      if (e.type !== 'text' && e.type !== 'thinking') return;
+      chars += e.delta.length;
+      const est = Math.ceil(chars / 4); // matches estimateTokens(chars-of-text)
+      const now = this.clock();
+      if (now - lastReport >= 1500 && est !== lastValue) {
+        lastReport = now;
+        lastValue = est;
+        onProgress(est);
+      }
+    };
   }
 
   /** Display label for an explicit ModelRef (used in mention confirmations). */

--- a/src/webview/components/blocks.tsx
+++ b/src/webview/components/blocks.tsx
@@ -373,7 +373,18 @@ export function PlanBar() {
         </span>
       </span>
       <span class="fp-plan-bar-actions">
-        <PlanActionButtons plan={plan} streaming={streaming} />
+        {streaming ? (
+          <button
+            type="button"
+            class="fp-btn fp-btn-sm fp-btn-secondary"
+            onClick={() => post({ type: 'cancelResponse' })}
+            title="Stop the current story build"
+          >
+            <IconX size={15} /> Stop
+          </button>
+        ) : (
+          <PlanActionButtons plan={plan} streaming={streaming} />
+        )}
       </span>
     </div>
   );

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { ProviderAdapter, WireMessage } from '../src/core/providers/adapter';
+import type { ChatRequest, ProviderAdapter, WireMessage } from '../src/core/providers/adapter';
 import { applyFindReplace } from '../src/core/agent/edits';
 import { gcHistory } from '../src/core/agent/contextGc';
-import { runAgentLoop } from '../src/core/agent/loop';
+import { runAgentLoop, RunawayGenerationError } from '../src/core/agent/loop';
 import { buildToolSpecs, dispatchToolCall, type ToolHost } from '../src/core/agent/tools';
 import type { StreamEvent } from '../src/shared/types';
 
@@ -315,6 +315,64 @@ describe('runAgentLoop', () => {
     expect(chatSpy).toHaveBeenCalledTimes(1);
     expect(result.wireHistory).toHaveLength(1);
     expect(result.blocks).toEqual([{ type: 'text', text: 'hi' }]);
+  });
+
+  it('forwards maxTokens to the adapter request', async () => {
+    // A recording adapter that captures the ChatRequest and returns a trivial turn.
+    let seen: ChatRequest | undefined;
+    const adapter: ProviderAdapter = {
+      async *chat(request: ChatRequest) {
+        seen = request;
+        yield { type: 'text', delta: 'ok' } as StreamEvent;
+        yield { type: 'done', stopReason: 'end' } as StreamEvent;
+      },
+    };
+    await runAgentLoop({
+      adapter,
+      baseUrl: 'http://x',
+      modelId: 'm',
+      maxTokens: 2048,
+      system: '',
+      history: [],
+      tools: [],
+      toolHost: makeHost({}),
+      onEvent: () => {},
+    });
+    expect(seen?.maxTokens).toBe(2048);
+  });
+
+  it('aborts and throws a distinct RunawayGenerationError past 1.5× the cap', async () => {
+    // A server that ignores max_tokens and streams unbounded text.
+    let aborted = false;
+    const adapter: ProviderAdapter = {
+      async *chat(request: ChatRequest) {
+        request.signal?.addEventListener('abort', () => {
+          aborted = true;
+        });
+        for (let i = 0; i < 10000; i += 1) {
+          yield { type: 'text', delta: 'x'.repeat(20) } as StreamEvent; // 20 chars = 5 tokens
+        }
+        yield { type: 'done', stopReason: 'end' } as StreamEvent;
+      },
+    };
+
+    // cap 200 → runaway limit floor(200 * 1.5) = 300 tokens (~1200 chars).
+    await expect(
+      runAgentLoop({
+        adapter,
+        baseUrl: 'http://x',
+        modelId: 'm',
+        maxTokens: 200,
+        system: '',
+        history: [{ role: 'user', content: [{ type: 'text', text: 'go' }] }],
+        tools: [],
+        toolHost: makeHost({}),
+        onEvent: () => {},
+      }),
+    ).rejects.toThrowError(RunawayGenerationError);
+
+    // The failsafe aborted the underlying call locally.
+    expect(aborted).toBe(true);
   });
 });
 

--- a/test/extension-session.test.ts
+++ b/test/extension-session.test.ts
@@ -801,6 +801,30 @@ describe('context-window management', () => {
 });
 
 // ---------------------------------------------------------------------------
+// max_tokens output cap (never unlimited)
+// ---------------------------------------------------------------------------
+
+describe('max_tokens output cap', () => {
+  it('sends the fixed 8192 default cap when the model context window is unknown', async () => {
+    const { session, requests } = makeSession({ path: 'foo.txt', content: 'x\n' }); // model has no window
+    await session.handle({ type: 'ready' });
+    const idx = requests.length;
+    await session.handle({ type: 'sendPrompt', text: 'create foo.txt' });
+    // Every call this turn carries the safety-net cap (no unlimited generation).
+    expect(requests[idx].maxTokens).toBe(8192);
+  });
+
+  it('caps at the response reserve (max(1500, 25% of window)) when the window is known', async () => {
+    // window 8000 → reserve max(1500, floor(0.25 * 8000)) = 2000.
+    const { session, requests } = makeWindowSession({ window: 8000, path: 'foo.txt', content: 'hi\n' });
+    await session.handle({ type: 'ready' });
+    const idx = requests.length;
+    await session.handle({ type: 'sendPrompt', text: 'create foo.txt' });
+    expect(requests[idx].maxTokens).toBe(2000);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Cross-surface settings sync
 // ---------------------------------------------------------------------------
 
@@ -1562,6 +1586,97 @@ describe('coop context digest', () => {
     expect(digest).toContain('[…]');
     // …and the digest is bounded (per-message ~600 chars, total ~2000).
     expect(digest.length).toBeLessThan(2200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fresh-context story runs (Builder starts from the spec, not the conversation)
+// ---------------------------------------------------------------------------
+
+describe('fresh-context story runs', () => {
+  it('a continued story build carries the spec but NOT the prior conversation wire', async () => {
+    const { session, requests } = makeSession({ mode: 'coop', path: 'foo.txt', content: 'x\n' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'PRDPROMPTMARKER build the whole thing', prd: true });
+
+    const idx = requests.length;
+    await session.handle({ type: 'continueStoryLoop' }); // build story 2 from a fresh window
+
+    const storyBuilders = requests.slice(idx).filter((r) => !isRolePrompt(r.system));
+    expect(storyBuilders.length).toBeGreaterThan(0);
+    // The Builder sees the story's spec (its title)…
+    expect(storyBuilders.some((r) => allWireText(r).includes('Second story'))).toBe(true);
+    // …but never the earlier PRD conversation text.
+    for (const r of storyBuilders) {
+      expect(allWireText(r)).not.toContain('PRDPROMPTMARKER');
+    }
+  });
+
+  it('a normal (non-PRD) coop turn still carries prior conversation history to the Builder', async () => {
+    const { session, requests } = makeSession({ mode: 'coop', path: 'foo.txt', content: 'x\n' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'FIRSTMARK build the login form' });
+
+    const idx = requests.length;
+    await session.handle({ type: 'sendPrompt', text: 'SECONDMARK now add validation' });
+
+    const builder = requests.slice(idx).find((r) => !isRolePrompt(r.system));
+    expect(builder).toBeDefined();
+    // The Builder's wire keeps prior conversation continuity (unlike a story build).
+    expect(allWireText(builder!)).toContain('FIRSTMARK');
+    expect(allWireText(builder!)).toContain('SECONDMARK');
+  });
+
+  it('a retried story starts with only the spec (clean-context restart)', async () => {
+    const io = new FakeIo();
+    const posted: HostToWebview[] = [];
+    const requests: ChatRequest[] = [];
+    let approveInspector = false; // story 1 fails first, then a retry approves
+    const adapter: ProviderAdapter = {
+      chat(request: ChatRequest) {
+        requests.push(request);
+        let events: StreamEvent[];
+        if (request.system.includes('FOREMAN')) events = textEvents(TWO_STORY_JSON);
+        else if (request.system.includes('SCOUT')) events = textEvents(JSON.stringify({ criteria: ['x'], plan: [], ambiguous: false }));
+        else if (request.system.includes('SENTRY')) events = textEvents(JSON.stringify({ verdict: 'approve', findings: [] }));
+        else if (request.system.includes('INSPECTOR'))
+          events = textEvents(JSON.stringify({ verdict: approveInspector ? 'approve' : 'reject', findings: approveInspector ? [] : ['not yet'] }));
+        else {
+          const hasToolResult = request.messages.some((m) => m.role === 'tool');
+          events = hasToolResult ? textEvents('done') : editEvents('foo.txt', 'x\n');
+        }
+        return (async function* () {
+          for (const e of events) yield e;
+        })();
+      },
+    };
+    const deps: SessionDeps = {
+      io,
+      secrets: new FakeSecrets(),
+      settings: new FakeSettings('coop'),
+      history: new FakeHistory(),
+      git: fakeGit,
+      post: (m) => posted.push(m),
+      createAdapter: () => adapter,
+      fetchModels: async () => [{ id: 'm1' }],
+      clock: () => Date.now(),
+    };
+    const session = createSessionCore(deps);
+
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'RETRYPRDMARKER build it', prd: true }); // story 1 fails
+
+    approveInspector = true;
+    const idx = requests.length;
+    await session.handle({ type: 'retryStory' });
+
+    const retryBuilders = requests.slice(idx).filter((r) => !isRolePrompt(r.system));
+    expect(retryBuilders.length).toBeGreaterThan(0);
+    // The retried Builder sees the story spec (title) but not the PRD conversation text.
+    expect(retryBuilders.some((r) => allWireText(r).includes('First story'))).toBe(true);
+    for (const r of retryBuilders) {
+      expect(allWireText(r)).not.toContain('RETRYPRDMARKER');
+    }
   });
 });
 

--- a/test/harness.test.ts
+++ b/test/harness.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { GateCard, HarnessSettings, TokenUsage } from '../src/shared/types';
 import {
   ContextExceededError,
+  RunawayError,
   runCoopPipeline,
   type ChangesetInspector,
   type CoopResult,
@@ -547,6 +548,43 @@ describe('runCoopPipeline — context-exceeded', () => {
     expect(result.cards.find((c) => c.role === 'builder')?.status).toBe('failed');
     expect(result.cards.some((c) => c.role === 'inspector')).toBe(false);
     expect(result.cards.some((c) => c.role === 'sentry')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runaway outcome (Builder's own call streamed past the safety cap)
+// ---------------------------------------------------------------------------
+
+describe('runCoopPipeline — runaway builder', () => {
+  it('fails the Builder card with the runaway evidence and returns the runaway outcome', async () => {
+    const { runner } = scriptedRunner({ scout: [scoutOk(['C1'])] });
+    const message =
+      'Runaway generation halted after ~180k tokens (cap ~8k). Retry the step — consider a larger context window or a different model.';
+    const buildStage = vi.fn(async () => {
+      throw new RunawayError({ role: 'builder', message });
+    });
+
+    const result = await runCoopPipeline({
+      userPrompt: 'implement the thing',
+      runner,
+      inspector: fakeInspector(),
+      buildStage,
+      settings: settings(),
+      onGate: () => {},
+    });
+
+    expect(result.outcome).toBe('runaway');
+
+    // The in-flight Builder card is marked failed and carries the runaway evidence.
+    const builder = result.cards.find((c) => c.role === 'builder');
+    expect(builder?.status).toBe('failed');
+    expect(builder?.evidence).toContain('Runaway generation halted');
+    expect(builder?.evidence).toContain('180k');
+
+    // Nothing after the Builder ran.
+    expect(result.cards.some((c) => c.role === 'inspector')).toBe(false);
+    expect(result.cards.some((c) => c.role === 'sentry')).toBe(false);
+    expect(result.cards.some((c) => c.role === 'hitl')).toBe(false);
   });
 });
 

--- a/test/prd.test.ts
+++ b/test/prd.test.ts
@@ -166,7 +166,7 @@ describe('composeStoryPrompt', () => {
     const prompt = composeStoryPrompt(spec, 2, 5);
     expect(prompt).toContain('Story 2 of 5 decomposed from a PRD');
     expect(prompt).toContain('Implement ONLY this story');
-    expect(prompt).toContain('earlier stories are already staged/applied');
+    expect(prompt).toContain('read the files rather than assuming');
     expect(prompt).toContain('# Add pagination');
     // The spec text follows the preamble.
     expect(prompt.indexOf('Story 2 of 5')).toBeLessThan(prompt.indexOf('# Add pagination'));


### PR DESCRIPTION
Guardrails for the field failure where a local Builder entered an infinite thinking loop and exhausted its context window:

- Every budgeted model call sends `max_tokens` (the role's response reserve; 8192 default when the window is unknown) — thinking loops are cut server-side
- Client-side failsafe aborts any call streaming past 1.5× its cap (per-call abort controller chained to the turn signal) and surfaces a dedicated `runaway` outcome with an actionable gate card
- Running gate cards show a live climbing output-token estimate (~1.5s throttle); the PRD bar gains a Stop button while a story streams
- Story runs (first / continued / retried) build from their spec alone instead of inheriting conversation wire history — "Retry story" is now a clean-context restart; normal coop turns keep history unchanged

Verification: `tsc --noEmit` clean, 297 unit tests, 102 e2e assertions, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG)_