### PR TITLE
Live coop journey harness, modal mention grammar + near-miss warning, stream sanitizer

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -398,6 +398,14 @@ underneath your staged edits. Click **Rebase** to merge onto the new state.
 work), or switch to a stronger model mid-conversation from the status line — your
 conversation and staged edits carry over.
 
+**Stray tokens like `<|channel|>` or `<think>` in a reply.** These are chat-template control
+markers leaking into the response because the local server is using a wrong or missing chat
+template for the model (common with community GGUF/QAT builds on LM Studio and llama.cpp).
+FowlPlay auto-cleans them: recognized markers are stripped and reasoning-channel text is
+folded into the collapsible thinking block. For the best results, still fix the server side —
+select the model's correct prompt template (or update to a build that ships one) so reasoning
+is delivered on its own channel.
+
 ---
 
 <div align="center">

--- a/e2e/coopJourney.mjs
+++ b/e2e/coopJourney.mjs
@@ -1,0 +1,260 @@
+/**
+ * FowlPlay LIVE Coop journey.
+ *
+ * Unlike e2e/run.mjs (which drives the UI against a scripted MockBridge), this
+ * walks a full user journey against the REAL SessionCore: the browser loads
+ * e2e/liveHarness.html, which installs window.__fowlplayBridge backed by
+ * createSessionCore + in-memory ports + a scripted dual-model ProviderAdapter
+ * (see e2e/liveHost.ts), then the real dist/webview.js bundle on top.
+ *
+ * The journey: a directive routes the orchestrator (Gemma) and builder (Qwen),
+ * a PRD is decomposed by the Foreman and built story-by-story through the Coop
+ * pipeline — exercising a clean pass, an Inspector route-back, and a runaway
+ * guard + retry — with a screenshot at each beat.
+ *
+ * Usage: node e2e/coopJourney.mjs   (requires `node esbuild.mjs` first)
+ * Env:   FP_CHROMIUM — chromium executable override.
+ */
+import { createServer } from 'node:http';
+import { readFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { extname, join, normalize } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = normalize(join(fileURLToPath(import.meta.url), '..', '..'));
+const SHOTS = join(ROOT, 'e2e', 'screenshots', 'coop');
+
+const QWEN_LABEL = 'Qwen3.6-35B-MoE';
+const GEMMA_LABEL = 'Gemma 3 26B';
+
+// --- locate playwright + chromium (mirrors run.mjs) --------------------------
+async function loadPlaywright() {
+  try {
+    return await import('playwright');
+  } catch {
+    const { createRequire } = await import('node:module');
+    const req = createRequire(import.meta.url);
+    const g = '/opt/node22/lib/node_modules/playwright/index.mjs';
+    if (existsSync(g)) return await import(g);
+    return req('playwright');
+  }
+}
+
+function chromiumPath() {
+  if (process.env.FP_CHROMIUM) return process.env.FP_CHROMIUM;
+  for (const p of ['/opt/pw-browsers/chromium-1194/chrome-linux/chrome']) {
+    if (existsSync(p)) return p;
+  }
+  return undefined;
+}
+
+// --- tiny static server ------------------------------------------------------
+const MIME = {
+  '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml',
+  '.png': 'image/png', '.map': 'application/json',
+};
+const server = createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url, 'http://x');
+    const path = normalize(join(ROOT, decodeURIComponent(url.pathname)));
+    if (!path.startsWith(ROOT)) throw new Error('traversal');
+    const body = await readFile(path);
+    res.writeHead(200, { 'content-type': MIME[extname(path)] ?? 'application/octet-stream' });
+    res.end(body);
+  } catch {
+    res.writeHead(404);
+    res.end('not found');
+  }
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+const BASE = `http://127.0.0.1:${server.address().port}/e2e/liveHarness.html`;
+
+// --- assertion helpers -------------------------------------------------------
+let passed = 0;
+let failed = 0;
+const failures = [];
+function ok(cond, name) {
+  if (cond) { passed += 1; console.log(`  ✓ ${name}`); }
+  else { failed += 1; failures.push(name); console.log(`  ✗ ${name}`); }
+}
+async function waitFor(page, fn, name, timeout = 20000) {
+  try {
+    await page.waitForFunction(fn, undefined, { timeout });
+    ok(true, name);
+  } catch {
+    ok(false, name);
+  }
+}
+async function shot(page, name) {
+  await page.screenshot({ path: join(SHOTS, `${name}.png`), fullPage: false });
+}
+/** Model label shown on the gate card whose title contains `titleSubstr`. */
+const gateModel = (page, titleSubstr) =>
+  page.evaluate((t) => {
+    const cards = Array.from(document.querySelectorAll('.fp-gate'));
+    const card = cards.find((c) => (c.querySelector('.fp-gate-title')?.textContent || '').includes(t));
+    return card?.querySelector('.fp-gate-model')?.textContent ?? null;
+  }, titleSubstr);
+/** All gate model labels grouped by the role word in their title. */
+const allGateModels = (page) =>
+  page.evaluate(() =>
+    Array.from(document.querySelectorAll('.fp-gate')).map((c) => ({
+      title: c.querySelector('.fp-gate-title')?.textContent || '',
+      model: c.querySelector('.fp-gate-model')?.textContent || '',
+    })),
+  );
+const planBarText = (page) => page.evaluate(() => document.querySelector('.fp-plan-bar')?.textContent ?? '');
+
+// --- run ----------------------------------------------------------------------
+await mkdir(SHOTS, { recursive: true });
+const { chromium } = await loadPlaywright();
+const browser = await chromium.launch({ executablePath: chromiumPath() });
+const page = await browser.newPage({ viewport: { width: 1200, height: 900 } });
+page.on('pageerror', (e) => console.log('  [pageerror]', String(e).slice(0, 300)));
+page.on('console', (m) => { if (m.type() === 'error') console.log('  [console.error]', m.text().slice(0, 200)); });
+
+await page.goto(BASE, { waitUntil: 'load' });
+const composer = () => page.locator('.fp-composer-textarea');
+
+// ============================== 1. DIRECTIVE =================================
+console.log('\n# 1. directive routes orchestrator + builder');
+await waitFor(page, () => !!document.querySelector('.fp-composer-textarea'), 'chat mounted (real SessionCore)');
+await composer().fill('gemma is the orchestrator, qwen is the builder');
+await composer().press('Enter');
+await waitFor(
+  page,
+  () => Array.from(document.querySelectorAll('.fp-toast')).some((t) => /Scout → Gemma/.test(t.textContent || '') && /Builder → Qwen/.test(t.textContent || '')),
+  'directive confirmation toast names Scout→Gemma and Builder→Qwen',
+);
+await shot(page, '01-directive-toast');
+
+// ============================== 2. /status ===================================
+console.log('\n# 2. /status shows the routed roles');
+await composer().fill('/status');
+await composer().press('Enter');
+await waitFor(page, () => !!document.querySelector('.fp-status-card'), '/status renders the status card');
+await waitFor(
+  page,
+  () => {
+    const t = document.querySelector('.fp-status-card')?.textContent || '';
+    return t.includes('Scout → Gemma 3 26B') && t.includes('Builder → Qwen3.6-35B-MoE');
+  },
+  'status Roles line shows both routed models',
+);
+await shot(page, '02-status-roles');
+await page.locator('.fp-status-card button[aria-label="Dismiss status"]').click();
+
+// ============================== 3. /prd → Foreman ============================
+console.log('\n# 3. /prd build of @pomodoro-prd.md');
+await composer().fill('/prd');
+await composer().press('Enter');
+await waitFor(page, () => !!document.querySelector('.fp-prd-chip'), '/prd arms the PRD build chip');
+await composer().fill('implement @pomodoro-prd.md');
+await shot(page, '03-prd-armed');
+// Escape closes the @-file popup (keeping the text), then Enter sends.
+await composer().press('Escape');
+await composer().press('Enter');
+await waitFor(
+  page,
+  () => Array.from(document.querySelectorAll('.fp-toast')).some((t) => /Included/.test(t.textContent || '') && /pomodoro-prd\.md/.test(t.textContent || '')),
+  'file-inclusion toast lists pomodoro-prd.md',
+);
+await waitFor(page, () => document.body.innerText.includes('Decomposed into 3 stories'), 'Foreman decomposed the PRD into 3 stories');
+await waitFor(
+  page,
+  () => {
+    const titles = Array.from(document.querySelectorAll('.fp-plan-story-title')).map((n) => n.textContent);
+    return titles.length === 3;
+  },
+  'plan block lists all 3 stories',
+);
+ok((await gateModel(page, 'Foreman')) === GEMMA_LABEL, `Foreman card ran on ${GEMMA_LABEL} (orchestrator)`);
+await shot(page, '04-foreman');
+
+// ============================== 4. STORY 1 CARDS + DIFF ======================
+console.log('\n# 4. story 1 pipeline + diff review');
+await waitFor(page, () => document.body.innerText.includes('Human review'), 'story 1 reached the HITL gate');
+await waitFor(page, () => document.body.innerText.includes('Awaiting your diff review'), 'HITL card awaits diff review');
+ok((await gateModel(page, 'Builder')) === QWEN_LABEL, `Builder card ran on ${QWEN_LABEL}`);
+ok((await gateModel(page, 'Inspector')) === QWEN_LABEL, `Inspector ran on the conversation/default model (${QWEN_LABEL})`);
+ok((await gateModel(page, 'Sentry')) === QWEN_LABEL, `Sentry ran on the conversation/default model (${QWEN_LABEL})`);
+await shot(page, '05-story1-cards');
+
+// Open Review Changes (the HITL card's button) → the live diff.
+await page.getByRole('button', { name: /Review Changes/ }).first().click();
+await waitFor(page, () => !!document.querySelector('.fp-diff'), 'diff viewer opens');
+await waitFor(page, () => document.querySelectorAll('.fp-hunk').length >= 1, 'staged hunk(s) render');
+await waitFor(page, () => document.body.innerText.includes('index.html'), 'story 1 staged index.html');
+await shot(page, '06-diff');
+await page.getByRole('button', { name: 'Apply to Disk' }).click();
+await waitFor(page, () => !!document.querySelector('.fp-plan-bar'), 'back to chat with the pinned PRD bar');
+
+// ============================== 5. STORY 2 ROUTE-BACK ========================
+console.log('\n# 5. continue → story 2 (Inspector route-back)');
+await waitFor(
+  page,
+  () => {
+    const t = document.querySelector('.fp-plan-bar')?.textContent || '';
+    return /story 1/.test(t) && /of 3/.test(t);
+  },
+  'PRD bar shows story 1 of 3',
+  8000,
+);
+await page.locator('.fp-plan-bar').getByRole('button', { name: /Continue/ }).click();
+await waitFor(page, () => /story 2 awaiting review/.test(document.querySelector('.fp-plan-bar')?.textContent || ''), 'story 2 finished (awaiting review)');
+await waitFor(page, () => document.body.innerText.includes('Routing back to Builder'), 'Inspector rejected attempt 1 and routed back');
+await waitFor(
+  page,
+  () => {
+    const cards = Array.from(document.querySelectorAll('.fp-gate'));
+    return cards.some((c) => (c.querySelector('.fp-gate-title')?.textContent || '').includes('Inspector') && /attempt 2/.test(c.textContent || ''));
+  },
+  'an Inspector card at attempt 2 exists',
+);
+await shot(page, '07-story2-routeback');
+
+// ============================== 6. STORY 3 RUNAWAY + RETRY ===================
+console.log('\n# 6. continue → story 3 (runaway guard) then retry');
+await page.locator('.fp-plan-bar').getByRole('button', { name: /Continue/ }).click();
+await waitFor(page, () => document.body.innerText.includes('Runaway generation halted'), 'Builder card fails with runaway evidence');
+await waitFor(page, () => /story 3 failed/.test(document.querySelector('.fp-plan-bar')?.textContent || ''), 'story 3 landed failed');
+await shot(page, '08-runaway');
+
+await page.locator('.fp-plan-bar').getByRole('button', { name: /Retry story/ }).click();
+await waitFor(page, () => /story 3 awaiting review/.test(document.querySelector('.fp-plan-bar')?.textContent || ''), 'retry of story 3 passed (awaiting review)');
+await shot(page, '09-retry-pass');
+
+// ============================== 7. COMPLETION ================================
+console.log('\n# 7. final continue → plan complete');
+await page.locator('.fp-plan-bar').getByRole('button', { name: /Continue/ }).click();
+await waitFor(page, () => document.body.innerText.includes('PRD build complete'), 'plan completion summary appears');
+await waitFor(page, () => document.body.innerText.includes('3 of 3 stories done'), 'summary reports 3 of 3 done');
+await shot(page, '10-complete');
+
+// --- call-log assertions -----------------------------------------------------
+console.log('\n# call log (which model served which role)');
+const calls = await page.evaluate(() => (window.__live || []).map((c) => ({ role: c.role, modelId: c.modelId })));
+const byRole = (r) => calls.filter((c) => c.role === r);
+ok(byRole('foreman').length >= 1 && byRole('foreman').every((c) => c.modelId === 'gemma-3-26b'), 'every Foreman call went to gemma-3-26b');
+ok(byRole('scout').length >= 1 && byRole('scout').every((c) => c.modelId === 'gemma-3-26b'), 'every Scout call went to gemma-3-26b');
+ok(byRole('builder').length >= 1 && byRole('builder').every((c) => c.modelId === 'qwen3.6-35b-moe'), 'every Builder call went to qwen3.6-35b-moe');
+ok(byRole('inspector').every((c) => c.modelId === 'qwen3.6-35b-moe'), 'every Inspector call went to the default (qwen3.6-35b-moe)');
+ok(byRole('sentry').every((c) => c.modelId === 'qwen3.6-35b-moe'), 'every Sentry call went to the default (qwen3.6-35b-moe)');
+
+// Cross-check the rendered gate cards agree with the routing.
+const gates = await allGateModels(page);
+const modelForTitle = (t) => gates.filter((g) => g.title.includes(t)).map((g) => g.model);
+ok(modelForTitle('Foreman').every((m) => m === GEMMA_LABEL), 'Foreman gate cards labeled Gemma');
+ok(modelForTitle('Scout').every((m) => m === GEMMA_LABEL), 'Scout gate cards labeled Gemma');
+ok(modelForTitle('Builder').every((m) => m === QWEN_LABEL), 'Builder gate cards labeled Qwen');
+
+await browser.close();
+server.close();
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failures.length) {
+  console.log('Failures:');
+  for (const f of failures) console.log(`  - ${f}`);
+  process.exit(1);
+}

--- a/e2e/liveHarness.html
+++ b/e2e/liveHarness.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>FowlPlay — Live Coop Harness</title>
+    <link rel="stylesheet" href="../dist/webview.css" />
+    <style>
+      html, body { height: 100%; margin: 0; }
+      #root { height: 100vh; }
+    </style>
+    <!-- liveHost installs window.__fowlplayBridge (backed by the REAL SessionCore)
+         BEFORE the webview bundle calls getBridge(). -->
+    <script src="../dist/liveHost.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="../dist/webview.js"></script>
+  </body>
+</html>

--- a/e2e/liveHost.ts
+++ b/e2e/liveHost.ts
@@ -1,0 +1,578 @@
+/**
+ * Live e2e host — the REAL SessionCore, wired to in-memory ports and a scripted
+ * dual-model ProviderAdapter, exposed to the real webview bundle through the same
+ * `window.__fowlplayBridge` seam the MockBridge uses.
+ *
+ * Unlike e2e/mockBridge.js (which fakes the host and scripts UI messages), this
+ * harness runs the production `createSessionCore`: the webview's posts are handed
+ * to `session.handle(msg)`, and the session's `deps.post` is delivered back to the
+ * webview's message handlers. The only fakes are the narrow SessionDeps ports
+ * (disk / secrets / settings / history) and the ProviderAdapter, whose responses
+ * depend on BOTH the modelId and the role system prompt so per-role routing is
+ * genuinely exercised.
+ *
+ * Bundled to dist/liveHost.js by esbuild and loaded by e2e/liveHarness.html BEFORE
+ * dist/webview.js, so the bridge is installed before the webview calls getBridge().
+ *
+ * window.__live      — the scripted adapter's ordered call log (role + modelId).
+ * window.__liveReady  — resolves once the session has been constructed.
+ */
+
+import { createSessionCore, type SessionCore } from '../src/extension/session';
+import type {
+  DiskIo,
+  SecretsPort,
+  SettingsPort,
+  HistoryPort,
+  SessionDeps,
+} from '../src/extension/session';
+import type {
+  Conversation,
+  ConversationSummary,
+  FowlPlaySettings,
+  ModelRef,
+  StreamEvent,
+  ProviderKind,
+  SdkType,
+  AppearanceSettings,
+  HarnessSettings,
+  ProviderConfig,
+} from '../src/shared/types';
+import type { HostToWebview, WebviewToHost, WebviewBridge } from '../src/shared/protocol';
+import type { ProviderAdapter, ChatRequest, WireMessage } from '../src/core/providers/adapter';
+import type { DirEntry, GrepMatch } from '../src/core/agent/tools';
+
+// ===========================================================================
+// Model identity
+// ===========================================================================
+
+const QWEN = 'qwen3.6-35b-moe';
+const QWEN_LABEL = 'Qwen3.6-35B-MoE';
+const GEMMA = 'gemma-3-26b';
+const GEMMA_LABEL = 'Gemma 3 26B';
+const CONTEXT_WINDOW = 32768;
+
+// ===========================================================================
+// Seed PRD (small — 3 features)
+// ===========================================================================
+
+const PRD_PATH = 'pomodoro-prd.md';
+const PRD_MARKDOWN = `# Pomodoro Timer — PRD
+
+A tiny single-page Pomodoro timer app. No build step; plain HTML/CSS/JS.
+
+## Feature 1 — Page scaffold + header
+- A single \`index.html\` that loads the app.
+- A visible header titled "Pomodoro".
+- A container element where the timer will render.
+
+## Feature 2 — Timer logic
+- A 25:00 countdown that renders as MM:SS.
+- Start, Pause, and Reset controls.
+- Pause freezes the remaining time; Reset returns it to 25:00.
+
+## Feature 3 — Styling / dark theme
+- A dark theme (dark background, light foreground).
+- The countdown is the visual focus (large, centered).
+- Controls are clearly tappable buttons.
+`;
+
+// ===========================================================================
+// In-memory ports
+// ===========================================================================
+
+/** Convert a glob pattern to a RegExp anchored to a full workspace-relative path. */
+function globToRegExp(pattern: string): RegExp {
+  let re = '';
+  for (let i = 0; i < pattern.length; i += 1) {
+    const c = pattern[i];
+    if (c === '*') {
+      if (pattern[i + 1] === '*') {
+        // "**/" → any number of leading dirs (incl. none); "**" → anything.
+        if (pattern[i + 2] === '/') {
+          re += '(?:.*/)?';
+          i += 2;
+        } else {
+          re += '.*';
+          i += 1;
+        }
+      } else {
+        re += '[^/]*';
+      }
+    } else if (c === '?') {
+      re += '.';
+    } else {
+      re += c.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+class MemDisk implements DiskIo {
+  readonly files = new Map<string, string>();
+
+  constructor(seed: Record<string, string>) {
+    for (const [k, v] of Object.entries(seed)) this.files.set(k, v);
+  }
+
+  async read(path: string): Promise<string | null> {
+    return this.files.has(path) ? this.files.get(path)! : null;
+  }
+  async exists(path: string): Promise<boolean> {
+    return this.files.has(path);
+  }
+  async listDir(path: string): Promise<DirEntry[]> {
+    const prefix = path === '' || path === '.' ? '' : path.replace(/\/$/, '') + '/';
+    const names = new Set<string>();
+    const entries: DirEntry[] = [];
+    for (const key of this.files.keys()) {
+      if (!key.startsWith(prefix)) continue;
+      const rest = key.slice(prefix.length);
+      const slash = rest.indexOf('/');
+      if (slash === -1) {
+        if (!names.has(rest)) { names.add(rest); entries.push({ name: rest, kind: 'file' }); }
+      } else {
+        const dir = rest.slice(0, slash);
+        if (!names.has(dir)) { names.add(dir); entries.push({ name: dir, kind: 'dir' }); }
+      }
+    }
+    return entries;
+  }
+  async glob(pattern: string): Promise<string[]> {
+    const re = globToRegExp(pattern);
+    return [...this.files.keys()].filter((k) => re.test(k)).sort();
+  }
+  async grep(_pattern: string, _opts: unknown): Promise<GrepMatch[]> {
+    return [];
+  }
+  async write(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+  }
+  async remove(path: string): Promise<void> {
+    this.files.delete(path);
+  }
+}
+
+class MemSecrets implements SecretsPort {
+  private readonly map = new Map<string, string>();
+  async get(id: string): Promise<string | undefined> { return this.map.get(id); }
+  async set(id: string, key: string): Promise<void> { this.map.set(id, key); }
+  async delete(id: string): Promise<void> { this.map.delete(id); }
+}
+
+class MemHistory implements HistoryPort {
+  private readonly map = new Map<string, Conversation>();
+  async list(query?: string): Promise<ConversationSummary[]> {
+    const q = (query ?? '').toLowerCase();
+    return [...this.map.values()]
+      .filter((c) => !q || c.title.toLowerCase().includes(q))
+      .map((c) => ({ id: c.id, title: c.title, updatedAt: c.updatedAt, messageCount: Object.keys(c.nodes).length }));
+  }
+  async load(id: string): Promise<Conversation | null> { return this.map.get(id) ?? null; }
+  async save(conv: Conversation): Promise<void> { this.map.set(conv.id, conv); }
+  async rename(id: string, title: string): Promise<void> {
+    const c = this.map.get(id);
+    if (c) this.map.set(id, { ...c, title });
+  }
+  async remove(id: string): Promise<void> { this.map.delete(id); }
+}
+
+class MemSettings implements SettingsPort {
+  private settings: FowlPlaySettings;
+  constructor(initial: FowlPlaySettings) { this.settings = initial; }
+  async load(): Promise<FowlPlaySettings> { return this.settings; }
+  async saveAppearance(a: AppearanceSettings): Promise<void> {
+    this.settings = { ...this.settings, appearance: a };
+  }
+  async saveHarness(h: HarnessSettings): Promise<void> {
+    this.settings = { ...this.settings, harness: h };
+  }
+  async saveProviders(providers: ProviderConfig[]): Promise<void> {
+    this.settings = { ...this.settings, providers };
+  }
+  async saveDefaultModel(model: ModelRef | null): Promise<void> {
+    this.settings = { ...this.settings, defaultModel: model };
+  }
+}
+
+// ===========================================================================
+// Scripted dual-model adapter
+// ===========================================================================
+
+type RoleGuess = 'foreman' | 'scout' | 'inspector' | 'sentry' | 'builder' | 'commit';
+
+interface CallRecord {
+  seq: number;
+  role: RoleGuess;
+  modelId: string;
+  story: number | null;
+  note: string;
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+function guessRole(system: string): RoleGuess {
+  if (system.includes('You are FOREMAN')) return 'foreman';
+  if (system.includes('You are SCOUT')) return 'scout';
+  if (system.includes('You are INSPECTOR')) return 'inspector';
+  if (system.includes('You are SENTRY')) return 'sentry';
+  // Precise: the commit-message system prompt. A loose "commit message" check
+  // would false-match the Builder, whose skill catalog lists a `commit-message`
+  // skill (its description contains that phrase).
+  if (system.includes('You write concise git commit messages')) return 'commit';
+  return 'builder';
+}
+
+/** Last "Story N of M" in the user turns of a request, or null. */
+function parseStory(messages: WireMessage[]): number | null {
+  let found: number | null = null;
+  for (const m of messages) {
+    if (m.role !== 'user') continue;
+    for (const part of m.content) {
+      if (part.type !== 'text') continue;
+      const re = /Story (\d+) of \d+/g;
+      let mm: RegExpExecArray | null;
+      while ((mm = re.exec(part.text)) !== null) found = Number(mm[1]);
+    }
+  }
+  return found;
+}
+
+function lastIsToolResult(messages: WireMessage[]): boolean {
+  const last = messages[messages.length - 1];
+  return !!last && last.role === 'tool';
+}
+
+function fence(obj: unknown): string {
+  return '```json\n' + JSON.stringify(obj, null, 2) + '\n```';
+}
+
+function chunk(text: string, n: number): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < text.length; i += n) out.push(text.slice(i, i + n));
+  return out;
+}
+
+const STORY_FILES: Record<number, string> = { 1: 'index.html', 2: 'timer.js', 3: 'styles.css' };
+
+function fileContentFor(story: number, fixed: boolean): string {
+  switch (story) {
+    case 1:
+      return `<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Pomodoro</title></head>
+  <body>
+    <header><h1>Pomodoro</h1></header>
+    <main id="app"><div id="timer"></div></main>
+    <script src="timer.js"></script>
+  </body>
+</html>
+`;
+    case 2:
+      // Attempt 1 has two defects the Inspector catches; the fix (fixed=true) repairs them.
+      return fixed
+        ? `let remaining = 25 * 60; // 25:00
+let handle = null;
+function render() {
+  const m = String(Math.floor(remaining / 60)).padStart(2, '0');
+  const s = String(remaining % 60).padStart(2, '0');
+  document.getElementById('timer').textContent = m + ':' + s;
+}
+function start() { if (!handle) handle = setInterval(tick, 1000); }
+function pause() { clearInterval(handle); handle = null; }
+function reset() { pause(); remaining = 25 * 60; render(); }
+function tick() { if (remaining > 0) { remaining -= 1; render(); } else pause(); }
+render();
+`
+        : `let remaining = 1500;
+let handle = null;
+function render() {
+  document.getElementById('timer').textContent = remaining; // BUG: not MM:SS
+}
+function start() { handle = setInterval(tick, 1000); } // BUG: double-start not guarded
+function tick() { remaining -= 1; render(); }
+render();
+`;
+    case 3:
+      return `:root { color-scheme: dark; }
+body { background: #10131a; color: #e6e8ee; font-family: system-ui, sans-serif; }
+header h1 { text-align: center; }
+#timer { font-size: 5rem; text-align: center; margin: 2rem auto; font-variant-numeric: tabular-nums; }
+button { padding: 0.6rem 1.2rem; border-radius: 999px; border: 0; cursor: pointer; }
+`;
+    default:
+      return `/* story ${story} */\n`;
+  }
+}
+
+class ScriptedAdapter implements ProviderAdapter {
+  readonly calls: CallRecord[] = [];
+  private seq = 0;
+  /** Builder ATTEMPTS started per story (round-1 calls only). */
+  private builderAttempts = new Map<number, number>();
+  /** Inspector reviews performed per story. */
+  private inspectorReviews = new Map<number, number>();
+  private currentStory = 0;
+
+  chat(req: ChatRequest): AsyncIterable<StreamEvent> {
+    const role = guessRole(req.system);
+    const story = parseStory(req.messages) ?? this.currentStory;
+    if ((role === 'scout' || role === 'builder') && story) this.currentStory = story;
+    const hasToolResult = lastIsToolResult(req.messages);
+    return this.run(role, story, hasToolResult, req);
+  }
+
+  private record(role: RoleGuess, modelId: string, story: number | null, note: string): void {
+    this.calls.push({ seq: (this.seq += 1), role, modelId, story, note });
+  }
+
+  private async *run(
+    role: RoleGuess,
+    story: number,
+    hasToolResult: boolean,
+    req: ChatRequest,
+  ): AsyncGenerator<StreamEvent> {
+    const D = 18; // inter-event delay so the UI visibly streams
+    const usage = (out: number) => ({ inputTokens: 900, outputTokens: out, cachedTokens: 0 });
+    const who = req.modelId === GEMMA ? GEMMA_LABEL : QWEN_LABEL;
+
+    if (role === 'foreman') {
+      this.record('foreman', req.modelId, null, 'decompose PRD → 3 stories');
+      const stories = {
+        stories: [
+          {
+            title: 'Scaffold the page and header',
+            summary: `[${who}] A single index.html with a "Pomodoro" header and a timer container.`,
+            criteria: [
+              'index.html exists and loads the app',
+              'A header titled "Pomodoro" is visible',
+              'A #timer container element is present',
+            ],
+          },
+          {
+            title: 'Implement the timer logic',
+            summary: `[${who}] A 25:00 countdown with start, pause, and reset.`,
+            criteria: [
+              'A 25:00 countdown renders as MM:SS',
+              'Start, Pause, and Reset controls work',
+              'Reset returns the countdown to 25:00',
+            ],
+          },
+          {
+            title: 'Style the app with a dark theme',
+            summary: `[${who}] A dark theme where the countdown is the visual focus.`,
+            criteria: [
+              'The app uses a dark background with light text',
+              'The countdown is large and centered',
+              'Controls render as tappable buttons',
+            ],
+          },
+        ],
+      };
+      yield* this.stream(fence(stories), D);
+      yield { type: 'usage', usage: usage(320) };
+      yield { type: 'done', stopReason: 'end' };
+      return;
+    }
+
+    if (role === 'scout') {
+      this.record('scout', req.modelId, story, `criteria for story ${story}`);
+      const criteria = SCOUT_CRITERIA[story] ?? [`Story ${story} behaves as specified`];
+      const plan = [`Read the spec for story ${story}`, `Create ${STORY_FILES[story] ?? 'the file'}`, 'Report which criterion each change serves'];
+      yield* this.stream(
+        fence({ criteria: criteria.map((c) => `[${who}] ${c}`), plan, ambiguous: false, question: '' }),
+        D,
+      );
+      yield { type: 'usage', usage: usage(140) };
+      yield { type: 'done', stopReason: 'end' };
+      return;
+    }
+
+    if (role === 'inspector') {
+      const n = (this.inspectorReviews.get(story) ?? 0) + 1;
+      this.inspectorReviews.set(story, n);
+      const reject = story === 2 && n === 1;
+      this.record('inspector', req.modelId, story, reject ? 'reject (attempt 1)' : `approve (review ${n})`);
+      const verdict = reject
+        ? {
+            verdict: 'reject',
+            findings: [
+              'criterion 1: the countdown renders raw seconds, not MM:SS — format as two-digit minutes:seconds',
+              'criterion 2: Start is not guarded, so repeated clicks spawn multiple intervals (add a Pause/Reset and a running guard)',
+            ],
+            evidence: `[${who}] Reviewed timer.js from the diff; two acceptance criteria are unmet.`,
+          }
+        : {
+            verdict: 'approve',
+            findings: [],
+            evidence: `[${who}] Every acceptance criterion for story ${story} is demonstrated by the diff.`,
+          };
+      yield* this.stream(fence(verdict), D);
+      yield { type: 'usage', usage: usage(reject ? 180 : 120) };
+      yield { type: 'done', stopReason: 'end' };
+      return;
+    }
+
+    if (role === 'sentry') {
+      this.record('sentry', req.modelId, story, 'approve (security)');
+      yield* this.stream(
+        fence({ verdict: 'approve', findings: [], evidence: `[${who}] No secrets, injection, or unsafe patterns in the diff.` }),
+        D,
+      );
+      yield { type: 'usage', usage: usage(90) };
+      yield { type: 'done', stopReason: 'end' };
+      return;
+    }
+
+    if (role === 'commit') {
+      this.record('commit', req.modelId, story, 'commit message');
+      yield { type: 'text', delta: 'chore: apply staged changes' };
+      yield { type: 'usage', usage: usage(12) };
+      yield { type: 'done', stopReason: 'end' };
+      return;
+    }
+
+    // --- Builder ---------------------------------------------------------
+    if (hasToolResult) {
+      // Round 2: summarize the edit the tool applied and finish.
+      const file = STORY_FILES[story] ?? 'the file';
+      yield* this.stream(
+        `${who} implemented story ${story}: created \`${file}\` and mapped each change to its acceptance criterion.`,
+        D,
+      );
+      yield { type: 'usage', usage: usage(160) };
+      yield { type: 'done', stopReason: 'end' };
+      return;
+    }
+
+    // Round 1 of a fresh Builder attempt.
+    const attempt = (this.builderAttempts.get(story) ?? 0) + 1;
+    this.builderAttempts.set(story, attempt);
+
+    // Story 3's FIRST builder attempt runs away (unbounded thinking) to trip the
+    // client-side RUNAWAY guard; the retry (attempt 2) builds cleanly.
+    if (story === 3 && attempt === 1) {
+      this.record('builder', req.modelId, story, 'RUNAWAY (unbounded thinking)');
+      const blob = 'Reconsidering the dark-theme palette and re-deriving the contrast ratios once more. '.repeat(90);
+      for (let i = 0; i < 300; i += 1) {
+        if (req.signal?.aborted) return;
+        yield { type: 'thinking', delta: blob };
+        await sleep(12);
+      }
+      return; // never reached in practice — the guard aborts us first
+    }
+
+    // Clean build: stage the story's file via an edit_files tool call.
+    const isFix = req.messages.some(
+      (m) => m.role === 'user' && m.content.some((p) => p.type === 'text' && p.text.includes('The Inspector rejected the previous attempt')),
+    );
+    this.record('builder', req.modelId, story, isFix ? `edits (fix, attempt ${attempt})` : `edits (attempt ${attempt})`);
+    const path = STORY_FILES[story] ?? `story-${story}.txt`;
+    const content = fileContentFor(story, story !== 2 || isFix);
+    const args = JSON.stringify({ edits: [{ path, create: content }] });
+    yield* this.stream(`Creating \`${path}\` for story ${story}. `, D);
+    const id = `call-${this.seq}-${story}-${attempt}`;
+    yield { type: 'tool_call_start', id, name: 'edit_files' };
+    for (const c of chunk(args, 60)) {
+      yield { type: 'tool_call_args', id, delta: c };
+      await sleep(8);
+    }
+    yield { type: 'tool_call_end', id };
+    yield { type: 'usage', usage: usage(220) };
+    yield { type: 'done', stopReason: 'tool_use' };
+  }
+
+  private async *stream(text: string, delay: number): AsyncGenerator<StreamEvent> {
+    for (const c of chunk(text, 48)) {
+      yield { type: 'text', delta: c };
+      await sleep(delay);
+    }
+  }
+}
+
+const SCOUT_CRITERIA: Record<number, string[]> = {
+  1: ['index.html exists and loads the app', 'A header titled "Pomodoro" is visible', 'A #timer container is present'],
+  2: ['A 25:00 countdown renders as MM:SS', 'Start, Pause, and Reset controls work', 'Reset returns the countdown to 25:00'],
+  3: ['The app uses a dark background with light text', 'The countdown is large and centered', 'Controls render as tappable buttons'],
+};
+
+// ===========================================================================
+// Bridge wiring — webview.post → session.handle; deps.post → webview handlers
+// ===========================================================================
+
+function buildSettings(): FowlPlaySettings {
+  const provider = (id: string, name: string, sdkType: SdkType, kind: ProviderKind, modelId: string, label: string): ProviderConfig => ({
+    id,
+    name,
+    kind,
+    sdkType,
+    baseUrl: `http://localhost:1143${id === 'prov-qwen' ? '4' : '5'}/v1`,
+    requiresApiKey: false,
+    models: [{ id: modelId, displayName: label, contextWindow: CONTEXT_WINDOW }],
+  });
+  return {
+    appearance: { fontFamily: 'JetBrains Mono', fontScale: 1, theme: 'fowlplay-light' },
+    harness: { defaultMode: 'coop', qasRetryBudget: 2 },
+    providers: [
+      provider('prov-qwen', 'Local — Qwen', 'openai-completions', 'local', QWEN, QWEN_LABEL),
+      provider('prov-gemma', 'Local — Gemma', 'openai-completions', 'local', GEMMA, GEMMA_LABEL),
+    ],
+    defaultModel: { providerId: 'prov-qwen', modelId: QWEN },
+  };
+}
+
+declare global {
+  interface Window {
+    __live?: CallRecord[];
+    __liveSession?: SessionCore;
+    __liveDisk?: MemDisk;
+  }
+}
+
+function install(): void {
+  const handlers: Array<(msg: HostToWebview) => void> = [];
+  const adapter = new ScriptedAdapter();
+  const disk = new MemDisk({ [PRD_PATH]: PRD_MARKDOWN });
+
+  const deps: SessionDeps = {
+    io: disk,
+    secrets: new MemSecrets(),
+    settings: new MemSettings(buildSettings()),
+    history: new MemHistory(),
+    git: undefined,
+    post(msg: HostToWebview) {
+      for (const h of handlers) {
+        try { h(msg); } catch (e) { console.error('live host: handler error', e); }
+      }
+    },
+    createAdapter: () => adapter,
+    fetchModels: async () => [
+      { id: QWEN, contextWindow: CONTEXT_WINDOW },
+      { id: GEMMA, contextWindow: CONTEXT_WINDOW },
+    ],
+    clock: () => Date.now(),
+  };
+
+  const session = createSessionCore(deps);
+
+  const bridge: WebviewBridge = {
+    post(msg: WebviewToHost) {
+      // Fire-and-forget: the webview does not await the host.
+      void session.handle(msg);
+    },
+    onMessage(handler: (msg: HostToWebview) => void) {
+      handlers.push(handler);
+      return () => {
+        const i = handlers.indexOf(handler);
+        if (i >= 0) handlers.splice(i, 1);
+      };
+    },
+  };
+
+  window.__fowlplayBridge = bridge;
+  window.__live = adapter.calls;
+  window.__liveSession = session;
+  window.__liveDisk = disk;
+}
+
+install();

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -30,10 +30,31 @@ const webviewCtx = {
   logLevel: 'info',
 };
 
+/**
+ * Live e2e harness bundle (browser / IIFE). Runs the REAL SessionCore against
+ * in-memory ports + a scripted dual-model adapter, installed on window before the
+ * webview bundle loads. Built only for the `e2e:coop` journey — not part of the
+ * shipped extension.
+ */
+const liveHostCtx = {
+  entryPoints: ['e2e/liveHost.ts'],
+  bundle: true,
+  outfile: 'dist/liveHost.js',
+  platform: 'browser',
+  format: 'iife',
+  target: 'es2022',
+  sourcemap: true,
+  logLevel: 'info',
+};
+
 if (watch) {
   const [a, b] = await Promise.all([esbuild.context(extensionCtx), esbuild.context(webviewCtx)]);
   await Promise.all([a.watch(), b.watch()]);
   console.log('watching…');
 } else {
-  await Promise.all([esbuild.build(extensionCtx), esbuild.build(webviewCtx)]);
+  await Promise.all([
+    esbuild.build(extensionCtx),
+    esbuild.build(webviewCtx),
+    esbuild.build(liveHostCtx),
+  ]);
 }

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "lint": "tsc --noEmit",
     "test": "vitest run",
     "e2e": "node e2e/run.mjs",
+    "e2e:coop": "node esbuild.mjs && node e2e/coopJourney.mjs",
     "package": "npm run build && vsce package --no-dependencies"
   },
   "devDependencies": {

--- a/src/core/agent/modelMentions.ts
+++ b/src/core/agent/modelMentions.ts
@@ -76,18 +76,33 @@ const PERSON_TO_ROLE: Record<string, CoopRole> = {
  */
 const CONNECTIVES = ['to', 'with', 'for', 'and', 'or', 'use', 'let', 'switch', 'everything', 'all', 'every', 'please'];
 
+/** Verbs that introduce a reversed assignment ("set the builder to qwen", "assign planning to gemma"). */
+const ASSIGN_VERBS = ['set', 'assign'];
+
 /**
  * Copula/modal glue for predicate phrasing, plus pronouns/articles that must
  * never be mistaken for a model name ("it should be the builder" must not
  * produce a mention with query "it").
  */
 const COPULA_WORDS = ['should', 'shall', 'will', 'can', 'must', 'be', 'is', 'as', 'make', 'the', 'our', 'my', 'a', 'an'];
-const NAME_STOPWORDS = ['it', 'this', 'that', 'these', 'those', 'he', 'she', 'they', 'we', 'i', 'you', 'who', 'which', 'what', 'there', 'model', 'models'];
+const NAME_STOPWORDS = ['it', 'this', 'that', 'these', 'those', 'he', 'she', 'they', 'we', 'i', 'you', 'who', 'which', 'what', 'there', 'model', 'models', 'code', 'everything'];
 
 const KEYWORDS = new Set<string>([
   ...CONNECTIVES,
+  ...ASSIGN_VERBS,
   ...COPULA_WORDS,
   ...NAME_STOPWORDS,
+  ...Object.keys(VERB_TO_ROLE),
+  ...Object.keys(NOUN_TO_ROLE),
+  ...Object.keys(PERSON_TO_ROLE),
+]);
+
+/**
+ * Any word that names a role in one of the grammar tables — used by the
+ * near-miss detector to gate at message level ("did the user use role
+ * vocabulary at all?").
+ */
+const ROLE_WORDS = new Set<string>([
   ...Object.keys(VERB_TO_ROLE),
   ...Object.keys(NOUN_TO_ROLE),
   ...Object.keys(PERSON_TO_ROLE),
@@ -110,6 +125,12 @@ const NOUN_ALT = alternation(Object.keys(NOUN_TO_ROLE));
 const PERSON_ALT = alternation(Object.keys(PERSON_TO_ROLE));
 const KW_ALT = alternation([...KEYWORDS]);
 
+// Combined role vocabulary (role-person nouns + role-nouns) for the reversed
+// "set the <role> to <name>" form. Person entries win where the two tables
+// disagree (they don't today — every shared key maps to the same role).
+const ROLE_TABLE: Record<string, CoopRole> = { ...NOUN_TO_ROLE, ...PERSON_TO_ROLE };
+const ROLE_ALT = alternation(Object.keys(ROLE_TABLE));
+
 // Conjunction chains: "orchestrate and build", "review, audit and security".
 // A chain is a first verb/noun plus zero or more ("and"/comma)-joined ones, so
 // "qwen to orchestrate and build" assigns BOTH roles. The joined token must
@@ -119,8 +140,13 @@ const CHAIN_JOIN = `(?:[ \\t]*,[ \\t]*(?:and[ \\t]+)?|[ \\t]+and[ \\t]+)`;
 const VERB_CHAIN = `(${VERB_ALT})((?:${CHAIN_JOIN}(?:${VERB_ALT})\\b)*)`;
 const NOUN_CHAIN = `(${NOUN_ALT})((?:${CHAIN_JOIN}(?:${NOUN_ALT})\\b)*)`;
 const PERSON_CHAIN = `(${PERSON_ALT})((?:${CHAIN_JOIN}(?:the[ \\t]+)?(?:${PERSON_ALT})\\b)*)`;
+// A chain over the combined role vocabulary, for the reversed "set … to <name>" form.
+const ROLE_CHAIN = `(${ROLE_ALT})((?:${CHAIN_JOIN}(?:the[ \\t]+)?(?:${ROLE_ALT})\\b)*)`;
 // Copula glue: "should be the", "will be our", "is the", "as", "as the" …
 const COPULA = `(?:(?:should|shall|will|can|must)[ \\t]+(?:be[ \\t]+)?|is[ \\t]+|as[ \\t]+)(?:the[ \\t]+|our[ \\t]+|my[ \\t]+|a[ \\t]+|an[ \\t]+)?`;
+// Modal + bare verb glue: "should build", "will review and audit", "must also plan".
+// Note "be" is deliberately NOT a verb, so this can never shadow the copula form.
+const MODAL_VERB_GLUE = `(?:should|shall|will|can|must)[ \\t]+(?:also[ \\t]+)?`;
 
 /** Expand a matched chain (first token + joined tail) into its role list, deduped in order. */
 function chainRoles(table: Record<string, CoopRole>, first: string, tail: string): CoopRole[] {
@@ -166,6 +192,11 @@ const chainMentions = (query: string, roles: CoopRole[]): Mention[] | null =>
   query && roles.length > 0 ? roles.map((role) => ({ role, query })) : null;
 
 const PATTERNS: Pattern[] = [
+  // (set|assign) [the] <role>[ and <role>…] to <name>   ("set the orchestrator and planner to gemma")
+  {
+    re: new RegExp(`\\b(?:set|assign)[ \\t]+(?:the[ \\t]+)?${ROLE_CHAIN}[ \\t]+to[ \\t]+${NAME}`, 'gi'),
+    make: (m) => chainMentions(nameQuery(m[3]), chainRoles(ROLE_TABLE, m[1], m[2])),
+  },
   // use <name> to <verb>[ and <verb>…]
   {
     re: new RegExp(`\\buse[ \\t]+${NAME}[ \\t]+to[ \\t]+${VERB_CHAIN}`, 'gi'),
@@ -183,9 +214,17 @@ const PATTERNS: Pattern[] = [
   },
   // <name> should/will/is/as [be] [the] <role-person>[ and <role-person>…]
   // ("gemma should be the builder", "qwen is the orchestrator", "glm as reviewer")
+  // MUST precede the modal + bare-verb pattern so "should be the builder" resolves
+  // as a copula (builder), not as a bare verb.
   {
     re: new RegExp(`${NAME}[ \\t]+${COPULA}${PERSON_CHAIN}`, 'gi'),
     make: (m) => chainMentions(nameQuery(m[1]), chainRoles(PERSON_TO_ROLE, m[2], m[3])),
+  },
+  // <name> (should|shall|will|can|must) [also] <verb>[ and <verb>…]
+  // ("qwen should build", "gemma will review and audit") — closes the modal-verb gap.
+  {
+    re: new RegExp(`${NAME}[ \\t]+${MODAL_VERB_GLUE}${VERB_CHAIN}`, 'gi'),
+    make: (m) => chainMentions(nameQuery(m[1]), chainRoles(VERB_TO_ROLE, m[2], m[3])),
   },
   // make <name> [the] <role-person>[ and <role-person>…]   ("make gemma the reviewer")
   {
@@ -369,4 +408,55 @@ export function matchModels(query: string, providers: ProviderConfig[]): ModelMa
 /** Convenience: a `ModelMatch` as a `ModelRef`. */
 export function toModelRef(match: ModelMatch): ModelRef {
   return { providerId: match.providerId, modelId: match.modelId };
+}
+
+/**
+ * Detect model directives the grammar ALMOST recognized — a near-miss guard so a
+ * mistyped or unsupported phrasing never fails silently.
+ *
+ * Returns the (verbatim, deduped) tokens in `text` that (a) match a configured
+ * model, (b) fall OUTSIDE every recognized directive span, in a message that
+ * (c) uses role vocabulary at all. The host toasts each hint so the user learns
+ * their steering attempt did not take effect and how to phrase it.
+ *
+ * Conservative by construction: a token inside a parsed span (the directive
+ * worked), a message with no role word ("qwen wrote this yesterday"), or a token
+ * that matches nothing all yield nothing. `mentions` is used to belt-and-suspender
+ * the span check — a token equal to a parsed mention's query is never a hint.
+ */
+export function findUnparsedModelHints(
+  text: string,
+  mentions: Mention[],
+  providers: ProviderConfig[],
+): string[] {
+  const src = text ?? '';
+  if (!src.trim()) return [];
+
+  // Message-level gate: only warn when the user reached for role vocabulary.
+  const hasRoleWord = src
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .some((w) => ROLE_WORDS.has(w));
+  if (!hasRoleWord) return [];
+
+  const spans = scan(src);
+  const claimed = (start: number, end: number): boolean =>
+    spans.some((s) => start < s.end && end > s.start);
+  const mentionQueries = new Set(mentions.map((m) => m.query.toLowerCase()));
+
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const re = /[A-Za-z0-9][\w.:/-]*/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(src)) !== null) {
+    const tok = m[0];
+    if (tok.length < 3) continue;
+    const lower = tok.toLowerCase();
+    if (seen.has(lower) || isKeyword(tok) || mentionQueries.has(lower)) continue;
+    if (claimed(m.index, m.index + tok.length)) continue;
+    if (matchModels(tok, providers).length === 0) continue;
+    seen.add(lower);
+    out.push(tok);
+  }
+  return out;
 }

--- a/src/core/providers/openaiCompletions.ts
+++ b/src/core/providers/openaiCompletions.ts
@@ -20,6 +20,7 @@ import {
   readErrorSnippet,
   readSse,
 } from './adapter';
+import { StreamSanitizer } from './streamSanitizer';
 
 // --- OpenAI wire shapes (only the fields we read) --------------------------
 
@@ -99,6 +100,12 @@ export class OpenAiCompletionsAdapter implements ProviderAdapter {
     let stopReason: 'end' | 'tool_use' = 'end';
     let sawToolCalls = false;
 
+    // Misconfigured local servers (wrong/missing chat template) leak raw channel
+    // markers into `content` as plain text. One sanitizer per request strips them
+    // and routes reasoning-channel text to 'thinking'. `reasoning_content` is a
+    // separate, already-clean channel and bypasses this.
+    const sanitizer = new StreamSanitizer();
+
     try {
       for await (const evt of readSse(response, request.signal)) {
         const data = evt.data.trim();
@@ -126,7 +133,11 @@ export class OpenAiCompletionsAdapter implements ProviderAdapter {
         const delta = choice.delta;
         if (delta) {
           if (typeof delta.content === 'string' && delta.content.length > 0) {
-            yield { type: 'text', delta: delta.content };
+            for (const part of sanitizer.pushText(delta.content)) {
+              yield part.kind === 'thinking'
+                ? { type: 'thinking', delta: part.delta }
+                : { type: 'text', delta: part.delta };
+            }
           }
           if (
             typeof delta.reasoning_content === 'string' &&
@@ -189,6 +200,14 @@ export class OpenAiCompletionsAdapter implements ProviderAdapter {
       yield { type: 'error', message: `stream error: ${errMessage(err)}` };
       yield { type: 'done', stopReason: 'error' };
       return;
+    }
+
+    // Release any tail the sanitizer held back (a marker prefix that turned out
+    // to be a false alarm) as text/thinking before closing out the turn.
+    for (const part of sanitizer.flush()) {
+      yield part.kind === 'thinking'
+        ? { type: 'thinking', delta: part.delta }
+        : { type: 'text', delta: part.delta };
     }
 
     // Close any open tool calls. For an index that received args but never a

--- a/src/core/providers/streamSanitizer.ts
+++ b/src/core/providers/streamSanitizer.ts
@@ -1,0 +1,192 @@
+/**
+ * StreamSanitizer — strip leaked chat-template control tokens from streamed
+ * `content` deltas and route reasoning-channel text to 'thinking'.
+ *
+ * Field problem: a misconfigured local server (e.g. LM Studio serving a community
+ * QAT build with a wrong/missing chat template) leaks the model's raw channel
+ * markers into the `content` stream as plain text — transcripts literally show
+ * `<|channel|>thought <|channel|>` fragments between tool calls. Rendered verbatim
+ * that junk pollutes verdict-JSON parsing and gate evidence, and reasoning that
+ * should be collapsible arrives as visible text.
+ *
+ * This is a defensive *sanitizer*, not a faithful Harmony decoder. It sits between
+ * raw content deltas and the emitted StreamEvents as a tiny state machine:
+ *
+ *   - Mode is either 'text' or 'thinking'. Recognized markers flip the mode and
+ *     are always stripped from the output.
+ *   - A holdback buffer keeps a small trailing tail unflushed ONLY while it could
+ *     still grow into a marker (a partial `<`, `<|…`, `<th…`, `</th…`). Ordinary
+ *     text — including HTML like `<div>` and a lone `<` mid-line — flushes right
+ *     away; streaming latency matters. `flush()` releases any held tail verbatim.
+ *
+ * No vscode, no deps — pure and allocation-light.
+ */
+
+export interface SanitizedPart {
+  kind: 'text' | 'thinking';
+  delta: string;
+}
+
+type Mode = 'text' | 'thinking';
+
+/** Harmony channel names that route subsequent content to 'thinking'. */
+const THINKING_CHANNELS = new Set(['thought', 'thinking', 'analysis', 'reflection']);
+
+/** Inline think-tag pairs (also strip the tags themselves). */
+const THINK_TAGS: Array<{ tag: string; mode: Mode }> = [
+  { tag: '<thinking>', mode: 'thinking' },
+  { tag: '<think>', mode: 'thinking' },
+  { tag: '</thinking>', mode: 'text' },
+  { tag: '</think>', mode: 'text' },
+];
+
+/** Inner-token shape for orphan control tokens (`im_start`, `endoftext`, …). */
+const ORPHAN_INNER_RE = /^[\w/.-]{1,32}$/;
+
+/**
+ * Upper bound on the held tail. The longest legitimate marker is well under this
+ * (`<|channel|>reflection` = 21 chars, an orphan token ≤ 36); past the cap an
+ * unclosed `<|…` is treated as literal text so a stray pipe never wedges output.
+ */
+const MAX_HOLDBACK = 48;
+
+/**
+ * Result of probing the text starting at a `<`:
+ *  - consume: a recognized marker; drop `length` chars, optionally flip mode.
+ *  - partial: could still grow into a marker — hold the tail (non-final only).
+ *  - literal: the leading `<` is ordinary text; emit it and scan past it.
+ */
+type MarkerMatch =
+  | { kind: 'consume'; length: number; setMode?: Mode }
+  | { kind: 'partial' }
+  | { kind: 'literal' };
+
+export class StreamSanitizer {
+  private mode: Mode = 'text';
+  private hold = '';
+
+  /** Feed a raw content delta; returns the sanitized parts ready to emit now. */
+  pushText(delta: string): SanitizedPart[] {
+    return this.process(this.hold + delta, false);
+  }
+
+  /** Release any held tail at stream end (a held prefix that never completed). */
+  flush(): SanitizedPart[] {
+    const parts = this.process(this.hold, true);
+    this.hold = '';
+    return parts;
+  }
+
+  private process(buffer: string, isFinal: boolean): SanitizedPart[] {
+    this.hold = '';
+    const parts: SanitizedPart[] = [];
+    let runStart = 0; // start of the current same-mode text run
+    let pos = 0;
+
+    while (pos < buffer.length) {
+      const lt = buffer.indexOf('<', pos);
+      if (lt === -1) break; // no more markers possible — rest is a plain run
+
+      const m = matchMarker(buffer.slice(lt), isFinal);
+
+      if (m.kind === 'literal') {
+        // The '<' is ordinary text; leave it in the run and keep scanning.
+        pos = lt + 1;
+        continue;
+      }
+
+      if (m.kind === 'partial') {
+        // Emit up to the '<' and hold the rest until more text (or flush) arrives.
+        this.emit(parts, buffer.slice(runStart, lt));
+        this.hold = buffer.slice(lt);
+        return parts;
+      }
+
+      // consume: emit the pre-marker run (in the old mode), then flip + strip.
+      this.emit(parts, buffer.slice(runStart, lt));
+      if (m.setMode) this.mode = m.setMode;
+      pos = lt + m.length;
+      runStart = pos;
+    }
+
+    this.emit(parts, buffer.slice(runStart));
+    return parts;
+  }
+
+  /** Append text in the current mode, coalescing with the last same-mode part. */
+  private emit(parts: SanitizedPart[], text: string): void {
+    if (text.length === 0) return;
+    const last = parts[parts.length - 1];
+    if (last && last.kind === this.mode) last.delta += text;
+    else parts.push({ kind: this.mode, delta: text });
+  }
+}
+
+/** Probe `s` (guaranteed to start with `<`) for a control marker. */
+function matchMarker(s: string, isFinal: boolean): MarkerMatch {
+  // --- Pipe tokens: <|channel|>, <|message|>, <|end|>, orphan <|…|> ---------
+  if (s.startsWith('<|')) {
+    const close = s.indexOf('|>', 2);
+    if (close === -1) {
+      // No terminator yet: could still complete on the next delta.
+      if (!isFinal && s.length <= MAX_HOLDBACK) return { kind: 'partial' };
+      return { kind: 'literal' };
+    }
+    const inner = s.slice(2, close);
+    const tokenEnd = close + 2; // index just past `|>`
+
+    if (inner === 'channel') return matchChannel(s, tokenEnd, isFinal);
+    // Per spec these terminate a reasoning run back to visible text.
+    if (inner === 'message' || inner === 'end') {
+      return { kind: 'consume', length: tokenEnd, setMode: 'text' };
+    }
+    // Any other well-formed control token (im_start, endoftext, return, …) is an
+    // orphan: strip it, leave the mode unchanged.
+    if (ORPHAN_INNER_RE.test(inner)) return { kind: 'consume', length: tokenEnd };
+    // `<|…|>` with an implausible inner (spaces, too long) — treat `<` as literal.
+    return { kind: 'literal' };
+  }
+
+  // --- Inline think tags ----------------------------------------------------
+  for (const { tag, mode } of THINK_TAGS) {
+    if (s.startsWith(tag)) return { kind: 'consume', length: tag.length, setMode: mode };
+  }
+  if (!isFinal) {
+    // A partial that could still become a think tag (e.g. '<', '<t', '<th',
+    // '</thi'). NOT '<div' — no think tag starts with it, so it flushes.
+    for (const { tag } of THINK_TAGS) {
+      if (tag.startsWith(s)) return { kind: 'partial' };
+    }
+  }
+  return { kind: 'literal' };
+}
+
+/**
+ * Classify a `<|channel|>` marker by the channel name that follows it.
+ * `tokenEnd` indexes the char just past `<|channel|>`.
+ */
+function matchChannel(s: string, tokenEnd: number, isFinal: boolean): MarkerMatch {
+  const after = s.slice(tokenEnd);
+  const named = /^[ \t]*([A-Za-z]+)/.exec(after);
+  if (named) {
+    const consumedLen = tokenEnd + named[0].length;
+    // The name letters run to the end of the buffer — more may follow (a split
+    // name like `<|channel|>tho` + `ught`). Hold unless this is the final flush.
+    if (!isFinal && consumedLen === s.length) return { kind: 'partial' };
+    const name = named[1].toLowerCase();
+    const mode: Mode = THINKING_CHANNELS.has(name) ? 'thinking' : 'text';
+    return { kind: 'consume', length: consumedLen, setMode: mode };
+  }
+
+  // No name letters immediately after the marker.
+  const ws = /^[ \t]*/.exec(after)![0];
+  if (ws.length === after.length) {
+    // Only whitespace so far (possibly empty): a name might still arrive.
+    if (!isFinal) return { kind: 'partial' };
+    // Stream ended on a bare `<|channel|>` → absent name → back to text.
+    return { kind: 'consume', length: tokenEnd + ws.length, setMode: 'text' };
+  }
+  // Whitespace then a non-letter (e.g. the next marker's `<`): bare channel with
+  // an absent name → back to text, consuming the swallowed whitespace too.
+  return { kind: 'consume', length: tokenEnd + ws.length, setMode: 'text' };
+}

--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -88,6 +88,7 @@ import {
 } from '../core/conversation/tree';
 import { toJSON, toMarkdown } from '../core/conversation/serialize';
 import {
+  findUnparsedModelHints,
   isDirectiveOnly,
   matchModels,
   parseModelMentions,
@@ -521,6 +522,18 @@ export class SessionCore {
 
     const settings = await this.ensureSettings();
     const mentions = parseModelMentions(text);
+
+    // Near-miss guard: a token that names a configured model, sits outside every
+    // recognized directive span, in a message that uses role vocabulary, looks
+    // like a steering attempt the grammar didn't catch. Warn so it never fails
+    // silently (the message still runs / applies normally below).
+    for (const hint of findUnparsedModelHints(text, mentions, settings.providers)) {
+      this.toast(
+        'warn',
+        `"${hint}" looks like a model directive but didn't match a known phrasing — try "${hint} is the builder" or "builder: ${hint}"`,
+      );
+    }
+
     const assignments: string[] = [];
     const queue: { role: MentionRole; query: string; candidates: ModelMatch[] }[] = [];
 

--- a/test/extension-session.test.ts
+++ b/test/extension-session.test.ts
@@ -1180,6 +1180,39 @@ describe('ambiguous chat mention', () => {
   });
 });
 
+describe('near-miss model directive warning', () => {
+  it('warns when a message names a model + role word but matches no phrasing', async () => {
+    const { session, posted } = makeCustomSession({
+      harness: { defaultMode: 'solo', qasRetryBudget: 1 },
+    });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'qwen handles the building please' });
+
+    expect(
+      posted.some(
+        (m) =>
+          m.type === 'toast' &&
+          m.level === 'warn' &&
+          m.message.includes('qwen') &&
+          m.message.includes("didn't match a known phrasing"),
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT warn when the directive actually parsed', async () => {
+    const { session, posted } = makeCustomSession({
+      harness: { defaultMode: 'solo', qasRetryBudget: 1 },
+    });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'build with m-builder' });
+
+    expect(posted.some((m) => m.type === 'toast' && m.message.includes("didn't match a known phrasing"))).toBe(false);
+    // Sanity: the directive applied.
+    const conv = lastConversation(posted)!;
+    expect(conv.roleModelOverrides?.builder).toEqual({ providerId: 'p1', modelId: 'm-builder' });
+  });
+});
+
 describe('conversation-level model directive persists (JSON round-trip)', () => {
   it('keeps roleModelOverrides through a history save/load', async () => {
     const history = new FakeHistory();

--- a/test/modelMentions.test.ts
+++ b/test/modelMentions.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from 'vitest';
 import type { ProviderConfig } from '../src/shared/types';
 import {
+  findUnparsedModelHints,
   isDirectiveOnly,
   matchModels,
   parseModelMentions,
@@ -164,6 +165,86 @@ describe('parseModelMentions — role directives', () => {
     expect(parseModelMentions('it should be the builder that runs')).toEqual([]);
     expect(parseModelMentions('we should build the builder with care')).toEqual([]);
     expect(parseModelMentions('the app should be the best')).toEqual([]);
+  });
+
+  it('modal + bare verb: "<name> should/will build" → role(s) from the verb', () => {
+    expect(parseModelMentions('qwen should build')).toEqual([{ role: 'builder', query: 'qwen' }]);
+    expect(parseModelMentions('gemma will review and audit')).toEqual([
+      { role: 'inspector', query: 'gemma' },
+      { role: 'sentry', query: 'gemma' },
+    ]);
+    // "also" is tolerated between the modal and the verb.
+    expect(parseModelMentions('glm must also plan')).toEqual([{ role: 'scout', query: 'glm' }]);
+  });
+
+  it('the exact field failure: copula + modal-verb in one message', () => {
+    expect(
+      parseModelMentions('gemma should be the orchestrator and planner and qwen should build'),
+    ).toEqual([
+      { role: 'scout', query: 'gemma' },
+      { role: 'builder', query: 'qwen' },
+    ]);
+  });
+
+  it('copula still wins over modal-verb for "should be the <role-person>"', () => {
+    expect(parseModelMentions('gemma should be the builder')).toEqual([{ role: 'builder', query: 'gemma' }]);
+  });
+
+  it('modal-verb guards: prose with pronoun/noun subjects never triggers', () => {
+    expect(parseModelMentions('it should build on the existing design')).toEqual([]);
+    expect(parseModelMentions('this should build quickly')).toEqual([]);
+    expect(parseModelMentions('we must implement caching')).toEqual([]);
+    expect(parseModelMentions('code should build cleanly')).toEqual([]);
+  });
+
+  it('reversed assignment: "(set|assign) [the] <role> to <name>"', () => {
+    expect(parseModelMentions('set the orchestrator to gemma')).toEqual([{ role: 'scout', query: 'gemma' }]);
+    expect(parseModelMentions('assign the builder to qwen')).toEqual([{ role: 'builder', query: 'qwen' }]);
+    expect(parseModelMentions('set planning to gemma')).toEqual([{ role: 'scout', query: 'gemma' }]);
+    // A chained role list before "to" dedupes to one mention.
+    expect(parseModelMentions('set the orchestrator and planner to gemma')).toEqual([
+      { role: 'scout', query: 'gemma' },
+    ]);
+  });
+
+  it('reversed assignment composes with a following clause', () => {
+    expect(parseModelMentions('set the orchestrator and planner to gemma and qwen to build')).toEqual([
+      { role: 'scout', query: 'gemma' },
+      { role: 'builder', query: 'qwen' },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findUnparsedModelHints — near-miss detection
+// ---------------------------------------------------------------------------
+
+describe('findUnparsedModelHints', () => {
+  it('fires for a model token + role word that the grammar did not parse', () => {
+    const text = 'qwen handles the building please';
+    const mentions = parseModelMentions(text);
+    expect(mentions).toEqual([]); // grammar missed it
+    expect(findUnparsedModelHints(text, mentions, PROVIDERS)).toEqual(['qwen']);
+  });
+
+  it('is silent when the directive DID parse (token is inside a claimed span)', () => {
+    const text = 'qwen to build';
+    const mentions = parseModelMentions(text);
+    expect(findUnparsedModelHints(text, mentions, PROVIDERS)).toEqual([]);
+  });
+
+  it('is silent for a fully-parsed modal-verb directive', () => {
+    const text = 'qwen should build';
+    const mentions = parseModelMentions(text);
+    expect(findUnparsedModelHints(text, mentions, PROVIDERS)).toEqual([]);
+  });
+
+  it('is silent for a model named in ordinary prose with no role word', () => {
+    expect(findUnparsedModelHints('qwen wrote this yesterday', [], PROVIDERS)).toEqual([]);
+  });
+
+  it('is silent when no token matches a configured model', () => {
+    expect(findUnparsedModelHints('please review the design', [], PROVIDERS)).toEqual([]);
   });
 });
 

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -192,6 +192,63 @@ describe('OpenAiCompletionsAdapter', () => {
     expect(asst.tool_calls).toBeUndefined();
   });
 
+  it('sanitizes leaked channel markers in content into ordered thinking + text events', async () => {
+    // A misconfigured local server leaks Harmony channel markers into `content`.
+    // The adapter routes them through the StreamSanitizer: reasoning-channel text
+    // becomes 'thinking', markers are stripped, and visible text stays 'text'.
+    const chunks = [
+      'data: {"choices":[{"delta":{"content":"Here goes <|channel|>"}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":"analysis let me think"}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":"<|end|>the answer is 42"}}]}\n\n',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+      'data: [DONE]\n\n',
+    ];
+    vi.stubGlobal('fetch', vi.fn(async () => sseResponse(chunks)));
+    const adapter = createAdapter('openai-completions');
+    const events = await collect(adapter.chat({ ...baseReq, baseUrl: 'http://x/v1' }));
+
+    const text = events
+      .filter((e) => e.type === 'text')
+      .map((e) => (e as { delta: string }).delta)
+      .join('');
+    const thinking = events
+      .filter((e) => e.type === 'thinking')
+      .map((e) => (e as { delta: string }).delta)
+      .join('');
+
+    expect(text).toBe('Here goes the answer is 42');
+    expect(thinking).toBe(' let me think');
+    // No raw marker text survives into any emitted delta.
+    expect(text + thinking).not.toContain('<|');
+
+    // Ordering: the thinking event sits between the two text events.
+    const kinds = events.filter((e) => e.type === 'text' || e.type === 'thinking').map((e) => e.type);
+    expect(kinds).toEqual(['text', 'thinking', 'text']);
+    expect(events.at(-1)).toEqual({ type: 'done', stopReason: 'end' });
+  });
+
+  it('leaves reasoning_content mapping to thinking (bypasses the sanitizer)', async () => {
+    // The separate reasoning_content channel is already clean and keeps mapping
+    // to 'thinking' verbatim, even when it contains marker-looking text.
+    const chunks = [
+      'data: {"choices":[{"delta":{"reasoning_content":"pondering <|not touched|>"}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":"visible"}}]}\n\n',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+      'data: [DONE]\n\n',
+    ];
+    vi.stubGlobal('fetch', vi.fn(async () => sseResponse(chunks)));
+    const adapter = createAdapter('openai-completions');
+    const events = await collect(adapter.chat({ ...baseReq, baseUrl: 'http://x/v1' }));
+
+    expect(events.find((e) => e.type === 'thinking')).toEqual({
+      type: 'thinking',
+      delta: 'pondering <|not touched|>',
+    });
+    expect(
+      events.filter((e) => e.type === 'text').map((e) => (e as { delta: string }).delta).join(''),
+    ).toBe('visible');
+  });
+
   it('emits an error event with a body snippet on non-2xx', async () => {
     vi.stubGlobal(
       'fetch',

--- a/test/streamSanitizer.test.ts
+++ b/test/streamSanitizer.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+
+import { StreamSanitizer } from '../src/core/providers/streamSanitizer';
+import type { SanitizedPart } from '../src/core/providers/streamSanitizer';
+
+// --- helpers ---------------------------------------------------------------
+
+/** Feed each delta through a fresh sanitizer, then flush; return all parts. */
+function run(deltas: string[]): SanitizedPart[] {
+  const s = new StreamSanitizer();
+  const parts: SanitizedPart[] = [];
+  for (const d of deltas) parts.push(...s.pushText(d));
+  parts.push(...s.flush());
+  return parts;
+}
+
+const textOf = (parts: SanitizedPart[]) =>
+  parts.filter((p) => p.kind === 'text').map((p) => p.delta).join('');
+const thinkingOf = (parts: SanitizedPart[]) =>
+  parts.filter((p) => p.kind === 'thinking').map((p) => p.delta).join('');
+/** Concatenation of every part's delta, in order (nothing dropped except markers). */
+const allOf = (parts: SanitizedPart[]) => parts.map((p) => p.delta).join('');
+
+// --- Harmony channels ------------------------------------------------------
+
+describe('StreamSanitizer — harmony channels', () => {
+  it('routes a named thinking channel to thinking and strips the markers', () => {
+    const parts = run(['before <|channel|>analysis reasoning here<|end|> after']);
+    expect(textOf(parts)).toBe('before  after');
+    expect(thinkingOf(parts)).toBe(' reasoning here');
+    expect(allOf(parts)).not.toContain('<|');
+  });
+
+  it('strips the exact leaked field fragment `<|channel|>thought <|channel|>`', () => {
+    const parts = run(['<|channel|>thought <|channel|>']);
+    // Every marker char is gone; nothing resembling a control token leaks.
+    expect(allOf(parts)).not.toContain('<|');
+    expect(allOf(parts)).not.toContain('channel');
+    // The trailing bare channel switched the mode back to text, so following
+    // content led by a non-letter delimiter renders as ordinary visible text.
+    const s = new StreamSanitizer();
+    s.pushText('<|channel|>thought <|channel|>');
+    const after = [...s.pushText('\nvisible'), ...s.flush()];
+    expect(textOf(after)).toBe('\nvisible');
+  });
+
+  it('treats a bare/unknown channel name as a switch back to text', () => {
+    const parts = run(['<|channel|>thinking secret<|channel|>weird now visible']);
+    // `weird` is not a reasoning channel → back to text.
+    expect(thinkingOf(parts)).toBe(' secret');
+    expect(textOf(parts)).toBe(' now visible');
+  });
+
+  it('honors channel terminators: final, message, end', () => {
+    // final
+    let parts = run(['<|channel|>thought hidden<|channel|>final shown']);
+    expect(thinkingOf(parts)).toBe(' hidden');
+    expect(textOf(parts)).toBe(' shown');
+
+    // message
+    parts = run(['<|channel|>reflection musing<|message|>answer']);
+    expect(thinkingOf(parts)).toBe(' musing');
+    expect(textOf(parts)).toBe('answer');
+
+    // end
+    parts = run(['<|channel|>thinking musing<|end|>answer']);
+    expect(thinkingOf(parts)).toBe(' musing');
+    expect(textOf(parts)).toBe('answer');
+  });
+});
+
+// --- Inline think tags -----------------------------------------------------
+
+describe('StreamSanitizer — think tags', () => {
+  it('routes a think-tag pair inside one delta to thinking, tags stripped', () => {
+    const parts = run(['a<think>secret</think>b']);
+    expect(textOf(parts)).toBe('ab');
+    expect(thinkingOf(parts)).toBe('secret');
+    expect(allOf(parts)).not.toContain('<think');
+  });
+
+  it('handles the <thinking> long form too', () => {
+    const parts = run(['x<thinking>deep</thinking>y']);
+    expect(textOf(parts)).toBe('xy');
+    expect(thinkingOf(parts)).toBe('deep');
+  });
+
+  it('recognizes a think tag split across three deltas mid-tag', () => {
+    const parts = run(['before<th', 'ink>inner th', 'oughts</thi', 'nk>after']);
+    expect(textOf(parts)).toBe('beforeafter');
+    expect(thinkingOf(parts)).toBe('inner thoughts');
+  });
+
+  it('keeps everything after an unclosed think tag as thinking through flush', () => {
+    const parts = run(['visible<think>dangling reasoning with no close']);
+    expect(textOf(parts)).toBe('visible');
+    expect(thinkingOf(parts)).toBe('dangling reasoning with no close');
+  });
+});
+
+// --- Orphan control tokens -------------------------------------------------
+
+describe('StreamSanitizer — orphan tokens', () => {
+  it('strips standalone control tokens from text', () => {
+    const parts = run(['<|im_start|>hello<|im_end|> world<|endoftext|>!']);
+    expect(textOf(parts)).toBe('hello world!');
+    expect(allOf(parts)).not.toContain('<|');
+  });
+
+  it('strips orphan tokens without altering the surrounding mode', () => {
+    const parts = run(['<think>a<|constrain|>b</think>c']);
+    expect(thinkingOf(parts)).toBe('ab');
+    expect(textOf(parts)).toBe('c');
+  });
+});
+
+// --- Clean passthrough -----------------------------------------------------
+
+describe('StreamSanitizer — clean passthrough', () => {
+  it('passes marker-free text through byte-identical (concatenated, in order)', () => {
+    const input = 'The quick brown fox.\nSecond line with punctuation: 1 < 2 && 3 > 2.';
+    const parts = run([input]);
+    expect(textOf(parts)).toBe(input);
+    expect(parts.every((p) => p.kind === 'text')).toBe(true);
+  });
+
+  it('flushes `<div>` HTML immediately within the same push (not held back)', () => {
+    const s = new StreamSanitizer();
+    // `<div>` is not a marker prefix beyond the leading `<`, so a single push
+    // yields it whole with nothing held back for flush.
+    const emitted = s.pushText('a<div class="x">b</div>c');
+    expect(textOf(emitted)).toBe('a<div class="x">b</div>c');
+    expect(s.flush()).toEqual([]);
+  });
+
+  it('emits a mid-line lone `<` immediately; only a trailing `<` is briefly held', () => {
+    const mid = new StreamSanitizer();
+    expect(textOf(mid.pushText('3 < 5 is true'))).toBe('3 < 5 is true');
+
+    const trailing = new StreamSanitizer();
+    const first = trailing.pushText('value <'); // trailing '<' could start a marker
+    expect(textOf(first)).toBe('value '); // held back the '<'
+    expect(textOf(trailing.flush())).toBe('<'); // released verbatim on flush
+  });
+
+  it('preserves byte-identical text across arbitrary delta splits of clean input', () => {
+    const input = 'plain text <div> and 2<3 and a</span> tail';
+    for (let i = 0; i <= input.length; i++) {
+      const parts = run([input.slice(0, i), input.slice(i)]);
+      expect(textOf(parts)).toBe(input);
+    }
+  });
+});
+
+// --- Chunk-boundary safety -------------------------------------------------
+
+describe('StreamSanitizer — chunk-boundary safety', () => {
+  it('recognizes `<|channel|>` split at every possible boundary position', () => {
+    // Reasoning between markers must always land in thinking, visible text intact,
+    // no matter where the two-delta split falls.
+    const full = 'before<|channel|>thought more<|end|>after';
+    for (let i = 0; i <= full.length; i++) {
+      const parts = run([full.slice(0, i), full.slice(i)]);
+      expect(textOf(parts)).toBe('beforeafter');
+      expect(thinkingOf(parts)).toBe(' more');
+      expect(allOf(parts)).not.toContain('<|');
+    }
+  });
+
+  it('recognizes an orphan token split at every boundary position', () => {
+    const full = 'x<|im_end|>y';
+    for (let i = 0; i <= full.length; i++) {
+      const parts = run([full.slice(0, i), full.slice(i)]);
+      expect(textOf(parts)).toBe('xy');
+      expect(allOf(parts)).not.toContain('<|');
+    }
+  });
+
+  it('holds a split channel name until the remaining letters arrive', () => {
+    // `<|channel|>tho` must not be misread as channel name "tho" (→ text); the
+    // rest of "thought" arrives next and correctly opens thinking.
+    const parts = run(['<|channel|>tho', 'ught hidden<|end|>shown']);
+    expect(thinkingOf(parts)).toBe(' hidden');
+    expect(textOf(parts)).toBe('shown');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,6 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["src/**/*", "test/**/*"],
+  "include": ["src/**/*", "test/**/*", "e2e/liveHost.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Three commits:

**Live Playwright journey (`npm run e2e:coop`)** — the real `SessionCore` runs in the browser wired to the real webview bundle, with in-memory ports and a scripted dual-model adapter. 35 assertions + 10 screenshots walk a full PRD build: role directive, /prd with an @file mention, Foreman on the orchestrator model, clean story with diff apply, Inspector route-back (attempt 2), a deliberate runaway loop tripping the guard, clean-context retry, and completion. A call log proves Foreman/Scout calls hit the orchestrator model id and Builder calls hit the builder model id.

**Modal mention grammar + near-miss warning** — "qwen should build" (modal + bare verb, with chains) and "set/assign the orchestrator to gemma" now parse; copula priority preserved; new stopwords keep prose subjects inert. `findUnparsedModelHints` raises a warn toast whenever a configured model name appears outside every recognized directive span alongside role vocabulary — missed directives can no longer fail silently.

**Stream control-token sanitizer** — a stateful per-request sanitizer in the OpenAI-compatible adapter routes leaked harmony-style `<|channel|>thought` segments and `<think>` tags into proper thinking events, strips orphan `<|…|>` tokens, and handles markers split across streaming chunks, while clean output (including HTML) passes through byte-identical. Fixes garbled transcripts from local servers with mismatched chat templates.

Verification: `tsc --noEmit` clean, 329 unit tests, 102 + 35 e2e assertions, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG)_