### PR TITLE
Kill zombie turns: supersession epochs + node-addressed gate updates

### DIFF
--- a/e2e/mockBridge.js
+++ b/e2e/mockBridge.js
@@ -577,13 +577,13 @@
     steps.push(() => emit({ type: 'stream', event: { type: 'tool_call_start', id: 't1', name: 'search' } }));
     steps.push(() => emit({ type: 'stream', event: { type: 'tool_call_args', id: 't1', delta: '{"query":"function login"}' } }));
     steps.push(() => emit({ type: 'stream', event: { type: 'tool_call_end', id: 't1' } }));
-    steps.push(() => emit({ type: 'gateUpdate', card: { ...scoutGate, status: 'running' } }));
-    steps.push(() => emit({ type: 'gateUpdate', card: scoutGate }));
+    steps.push(() => emit({ type: 'gateUpdate', nodeId: 'a1', card: { ...scoutGate, status: 'running' } }));
+    steps.push(() => emit({ type: 'gateUpdate', nodeId: 'a1', card: scoutGate }));
     'Refactored `login()` to return a `Session` and added `AuthError`. Tests cover both paths.'.match(/.{1,10}/g).forEach((chunk) => {
       steps.push(() => emit({ type: 'stream', event: { type: 'text', delta: chunk } }));
     });
-    steps.push(() => emit({ type: 'gateUpdate', card: inspectorGate }));
-    steps.push(() => emit({ type: 'gateUpdate', card: sentryGate }));
+    steps.push(() => emit({ type: 'gateUpdate', nodeId: 'a1', card: inspectorGate }));
+    steps.push(() => emit({ type: 'gateUpdate', nodeId: 'a1', card: sentryGate }));
     steps.push(() => emit({ type: 'stream', event: { type: 'usage', usage: { inputTokens: 8450, outputTokens: 1120, cachedTokens: 6000 } } }));
     steps.push(() => emit({ type: 'stream', event: { type: 'done', stopReason: 'end' } }));
     // Real host order: turnFinished fires BEFORE the authoritative conversation

--- a/e2e/run.mjs
+++ b/e2e/run.mjs
@@ -450,6 +450,7 @@ await open('chat');
 await page.evaluate(() =>
   window.__host.emit({
     type: 'gateUpdate',
+    nodeId: 'a1',
     card: {
       id: 'gate-builder-model',
       role: 'builder',

--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -194,6 +194,14 @@ export class SessionCore {
   private changeset: ChangeSet;
   private settingsCache: FowlPlaySettings | null = null;
   private abort: AbortController | null = null;
+  /**
+   * Monotonically increasing turn counter. Every turn captures its epoch at the
+   * moment it starts; all posts it makes (stream/gate/turnStarted/turnFinished)
+   * and its finalization run through {@link postForTurn} / an epoch check, so the
+   * instant a newer turn or a conversation switch bumps the epoch, the old turn
+   * goes dark — even while its underlying model fetch is still unwinding.
+   */
+  private turnEpoch = 0;
   /** Monotonic counter for disk-only applies that have no commit sha. */
   private appliedSeq = 0;
 
@@ -488,6 +496,33 @@ export class SessionCore {
     }
   }
 
+  /**
+   * Post a message on behalf of a turn, dropping it if that turn has been
+   * superseded (its captured `epoch` no longer matches the live `turnEpoch`).
+   * Every stream / gate / turnStarted / turnFinished emission for a turn routes
+   * through here, so a runaway turn's progress ticker and role-call streams go
+   * dark the instant it is superseded — even before its fetch actually dies.
+   */
+  private postForTurn(epoch: number, msg: HostToWebview): void {
+    if (epoch !== this.turnEpoch) return;
+    this.deps.post(msg);
+  }
+
+  /**
+   * Supersede any in-flight turn before clearing / switching the conversation.
+   * Bumps the epoch FIRST (so the old turn's late posts are dropped immediately,
+   * even while its fetch is still unwinding), aborts its controller so the model
+   * call cancels, and posts a `stream done/cancelled` so the webview's streaming
+   * flag clears if it was mid-turn. A no-op when nothing is running.
+   */
+  private supersedeInFlightTurn(): void {
+    if (!this.abort) return;
+    this.turnEpoch += 1;
+    this.abort.abort();
+    this.abort = null;
+    this.deps.post({ type: 'stream', event: { type: 'done', stopReason: 'cancelled' } });
+  }
+
   // -------------------------------------------------------------------------
   // Turn flow
   // -------------------------------------------------------------------------
@@ -703,11 +738,22 @@ export class SessionCore {
     imageParts: WireUserPart[] = [],
     opts: { prd?: boolean; storyIndex?: number } = {},
   ): Promise<void> {
+    // Supersede any still-running turn: abort its controller (so its model call
+    // unwinds) and bump the epoch (so its late posts + finalization are dropped
+    // even before the fetch dies). Capture this turn's epoch for its closures.
+    if (this.abort) this.abort.abort();
+    this.turnEpoch += 1;
+    const epoch = this.turnEpoch;
+    this.abort = new AbortController();
+    const signal = this.abort.signal;
+
     const settings = await this.ensureSettings();
     const resolved = await this.resolveModel();
     if (!resolved) {
       this.toast('error', 'No model configured. Add a provider and pick a model first.');
       this.sendConversation();
+      // Release this turn's controller unless a newer turn already replaced it.
+      if (epoch === this.turnEpoch) this.abort = null;
       return;
     }
 
@@ -745,28 +791,25 @@ export class SessionCore {
     const assistant = appendAssistant(this.conv, [], { parentId: userNodeId, model: this.conv.model ?? undefined });
     this.conv = assistant.conv;
     const assistantId = assistant.nodeId;
-    this.deps.post({ type: 'turnStarted', nodeId: assistantId });
-
-    this.abort = new AbortController();
-    const signal = this.abort.signal;
+    this.postForTurn(epoch, { type: 'turnStarted', nodeId: assistantId });
 
     let blocks: ContentBlock[] = [];
     let usage: TokenUsage = emptyUsage();
     try {
       if (opts.prd) {
-        const out = await this.runPrd(userText, imageParts, resolved, settings.harness, signal, contextDigest);
+        const out = await this.runPrd(userText, imageParts, resolved, settings.harness, signal, epoch, assistantId, contextDigest);
         blocks = out.blocks;
         usage = out.usage;
       } else if (opts.storyIndex !== undefined) {
-        const out = await this.runStory(opts.storyIndex, resolved, settings.harness, signal, contextDigest);
+        const out = await this.runStory(opts.storyIndex, resolved, settings.harness, signal, epoch, assistantId, contextDigest);
         blocks = out.blocks;
         usage = out.usage;
       } else if (this.conv.harnessMode === 'coop') {
-        const out = await this.runCoop(userText, imageParts, baseWire, resolved, settings.harness, signal, contextDigest);
+        const out = await this.runCoop(userText, imageParts, baseWire, resolved, settings.harness, signal, epoch, assistantId, contextDigest);
         blocks = out.blocks;
         usage = out.usage;
       } else {
-        const out = await this.runSolo(userText, imageParts, baseWire, resolved, assistantId, signal);
+        const out = await this.runSolo(userText, imageParts, baseWire, resolved, assistantId, signal, epoch);
         blocks = out.blocks;
         usage = out.usage;
       }
@@ -774,8 +817,14 @@ export class SessionCore {
       blocks = [{ type: 'error', message: errMessage(err) }];
     }
 
+    // Superseded mid-flight (a newer turn, or a conversation switch/clear): this
+    // turn must NOT finalize — `this.conv` now points at a different conversation,
+    // and every late post is already being dropped. Bail without mutating state
+    // or nulling the newer turn's controller.
+    if (epoch !== this.turnEpoch) return;
+
     if (signal.aborted) {
-      this.deps.post({ type: 'stream', event: { type: 'done', stopReason: 'cancelled' } });
+      this.postForTurn(epoch, { type: 'stream', event: { type: 'done', stopReason: 'cancelled' } });
     }
 
     // Append a "Review Changes" block when the turn left staged edits.
@@ -787,9 +836,10 @@ export class SessionCore {
     this.snapshotOverlay(assistantId);
     await this.persist();
 
-    this.deps.post({ type: 'turnFinished', nodeId: assistantId, usage });
+    this.postForTurn(epoch, { type: 'turnFinished', nodeId: assistantId, usage });
     this.sendConversation();
-    this.abort = null;
+    // Release the controller unless the persist await let a newer turn replace it.
+    if (epoch === this.turnEpoch) this.abort = null;
   }
 
   private async runSolo(
@@ -799,6 +849,7 @@ export class SessionCore {
     resolved: ResolvedModel,
     assistantId: string,
     signal: AbortSignal,
+    epoch: number,
   ): Promise<{ blocks: ContentBlock[]; usage: TokenUsage }> {
     const settings = await this.ensureSettings();
     const fullHistory: WireMessage[] = [
@@ -834,7 +885,7 @@ export class SessionCore {
       history: sent,
       tools: this.toolsWithSkills(),
       toolHost: this.toolHost(),
-      onEvent: (e) => this.deps.post({ type: 'stream', event: e }),
+      onEvent: (e) => this.postForTurn(epoch, { type: 'stream', event: e }),
       signal,
     });
 
@@ -851,10 +902,12 @@ export class SessionCore {
     resolved: ResolvedModel,
     harness: HarnessSettings,
     signal: AbortSignal,
+    epoch: number,
+    nodeId: string,
     contextDigest?: string,
   ): Promise<{ blocks: ContentBlock[]; usage: TokenUsage }> {
     const cards: GateCard[] = [];
-    const result = await this.runCoopCore(userText, imageParts, baseWire, resolved, harness, signal, cards, contextDigest);
+    const result = await this.runCoopCore(userText, imageParts, baseWire, resolved, harness, signal, cards, epoch, nodeId, contextDigest);
 
     const blocks: ContentBlock[] = cards.map((card) => ({ type: 'gate', card }));
     const text = this.coopOutcomeText(result);
@@ -876,6 +929,8 @@ export class SessionCore {
     harness: HarnessSettings,
     signal: AbortSignal,
     cards: GateCard[],
+    epoch: number,
+    nodeId: string,
     contextDigest?: string,
   ): Promise<CoopResult> {
     const settings = await this.ensureSettings();
@@ -956,7 +1011,7 @@ export class SessionCore {
           history,
           tools: this.toolsWithSkills(),
           toolHost: this.toolHost(),
-          onEvent: this.progressOnEvent((e) => this.deps.post({ type: 'stream', event: e }), onProgress),
+          onEvent: this.progressOnEvent((e) => this.postForTurn(epoch, { type: 'stream', event: e }), onProgress),
           signal: s,
         });
       } catch (err) {
@@ -981,7 +1036,7 @@ export class SessionCore {
       settings: harness,
       onGate: (card) => {
         upsertCard(cards, card);
-        this.deps.post({ type: 'gateUpdate', card });
+        this.postForTurn(epoch, { type: 'gateUpdate', card, nodeId });
       },
       modelLabelFor: (role) => this.roleModelLabel(settings, role),
       diffBudgetFor: (role) => this.payloadBudget(settings, role),
@@ -1025,6 +1080,8 @@ export class SessionCore {
     resolved: ResolvedModel,
     harness: HarnessSettings,
     signal: AbortSignal,
+    epoch: number,
+    nodeId: string,
     contextDigest?: string,
   ): Promise<{ blocks: ContentBlock[]; usage: TokenUsage }> {
     const settings = await this.ensureSettings();
@@ -1032,7 +1089,7 @@ export class SessionCore {
     const cards: GateCard[] = [];
     const emit = (card: GateCard): GateCard => {
       upsertCard(cards, card);
-      this.deps.post({ type: 'gateUpdate', card });
+      this.postForTurn(epoch, { type: 'gateUpdate', card, nodeId });
       return card;
     };
     const gateBlocks = (): ContentBlock[] => cards.map((card) => ({ type: 'gate', card }));
@@ -1114,7 +1171,7 @@ export class SessionCore {
     );
 
     // --- Build story 1 immediately, within this same turn ---
-    const story1 = await this.runStory(0, resolved, harness, signal, contextDigest);
+    const story1 = await this.runStory(0, resolved, harness, signal, epoch, nodeId, contextDigest);
     addUsageInPlace(usage, story1.usage);
 
     // Blocks: Foreman gate, the plan marker (renders live), then story 1's cards + outcome.
@@ -1131,6 +1188,8 @@ export class SessionCore {
     resolved: ResolvedModel,
     harness: HarnessSettings,
     signal: AbortSignal,
+    epoch: number,
+    nodeId: string,
     contextDigest?: string,
   ): Promise<{ blocks: ContentBlock[]; usage: TokenUsage }> {
     const plan = this.conv.prdPlan;
@@ -1152,7 +1211,7 @@ export class SessionCore {
     // "Retry story" is mechanically a clean-context restart. The Scout still
     // receives the cheap contextDigest for user clarifications.
     const cards: GateCard[] = [];
-    const result = await this.runCoopCore(userPrompt, [], [], resolved, harness, signal, cards, contextDigest);
+    const result = await this.runCoopCore(userPrompt, [], [], resolved, harness, signal, cards, epoch, nodeId, contextDigest);
 
     const status: PrdStory['status'] =
       result.outcome === 'ready-for-review' ? 'awaiting-review' : result.outcome === 'cancelled' ? 'pending' : 'failed';
@@ -1575,6 +1634,9 @@ export class SessionCore {
   }
 
   private async onNewConversation(): Promise<void> {
+    // Kill any in-flight turn before swapping the conversation out from under it,
+    // so its late gate/stream posts can't graft onto the fresh conversation.
+    this.supersedeInFlightTurn();
     const settings = await this.ensureSettings();
     this.conv = createConversation(settings.defaultModel, settings.harness.defaultMode);
     this.overlay = new StagingOverlay(this.deps.io);
@@ -1585,6 +1647,9 @@ export class SessionCore {
   }
 
   private async onOpenConversation(id: string): Promise<void> {
+    // Kill any in-flight turn before loading a different conversation, so its
+    // late gate/stream posts can't graft onto the one we switch to.
+    this.supersedeInFlightTurn();
     const loaded = await this.deps.history.load(id);
     if (!loaded) {
       this.toast('error', 'Conversation not found.');

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -94,7 +94,10 @@ export type HostToWebview =
   | { type: 'conversation'; conversation: Conversation }
   // streaming during a turn
   | { type: 'stream'; event: StreamEvent }
-  | { type: 'gateUpdate'; card: GateCard }
+  // `nodeId` is the assistant node the card belongs to — authoritative routing so
+  // a late update from a superseded turn can be dropped rather than grafted onto
+  // whatever node is newest.
+  | { type: 'gateUpdate'; card: GateCard; nodeId: string }
   | { type: 'turnStarted'; nodeId: string }                       // assistant node created
   | { type: 'selectionContext'; context: SelectionContext | null } // scoped editor selection (null clears the chip)
   | { type: 'turnFinished'; nodeId: string; usage: TokenUsage }

--- a/src/webview/components/store.tsx
+++ b/src/webview/components/store.tsx
@@ -159,7 +159,7 @@ class Store {
         this.applyStream(msg.event);
         break;
       case 'gateUpdate':
-        this.upsertGate(msg.card);
+        this.upsertGate(msg.nodeId, msg.card);
         break;
       case 'turnFinished':
         this.finishTurn(msg.nodeId, msg.usage);
@@ -330,15 +330,18 @@ class Store {
     return -1;
   }
 
-  private upsertGate(card: import('../../shared/types').GateCard) {
-    const id = this.state.streamNodeId ?? this.state.conversation?.currentLeafId ?? null;
+  private upsertGate(nodeId: string, card: import('../../shared/types').GateCard) {
+    // Route strictly by the authoritative nodeId: apply the card to that node if
+    // it exists in the CURRENT conversation, otherwise drop the update silently.
+    // A late card from a superseded turn (whose node isn't in the conversation we
+    // switched to) must never graft onto whatever node is newest.
     const conv = this.cloneConversation();
-    if (!conv || !id || !conv.nodes[id]) return;
-    const node: MessageNode = { ...conv.nodes[id], blocks: [...conv.nodes[id].blocks] };
+    if (!conv || !conv.nodes[nodeId]) return;
+    const node: MessageNode = { ...conv.nodes[nodeId], blocks: [...conv.nodes[nodeId].blocks] };
     const idx = node.blocks.findIndex((b) => b.type === 'gate' && b.card.id === card.id);
     if (idx >= 0) node.blocks[idx] = { type: 'gate', card };
     else node.blocks.push({ type: 'gate', card });
-    conv.nodes[id] = node;
+    conv.nodes[nodeId] = node;
     this.patch({ conversation: conv });
   }
 

--- a/test/extension-session.test.ts
+++ b/test/extension-session.test.ts
@@ -683,6 +683,234 @@ describe('coop pipeline', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Zombie-turn supersession + late-post suppression
+// ---------------------------------------------------------------------------
+
+/**
+ * A coop adapter whose Builder edit round blocks on `blocker` (so a turn hangs
+ * mid-pipeline, its abort controller live), recording the Builder call's signal.
+ * Scout/Inspector/Sentry approve; the Builder finishes once unblocked.
+ */
+function makeBlockingCoop() {
+  let unblock: () => void = () => {};
+  const blocker = new Promise<void>((res) => {
+    unblock = res;
+  });
+  const state: { builderSignal?: AbortSignal } = {};
+  const io = new FakeIo();
+  const posted: HostToWebview[] = [];
+  const history = new FakeHistory();
+  const adapter: ProviderAdapter = {
+    chat(request: ChatRequest) {
+      let events: StreamEvent[];
+      let block = false;
+      if (request.system.includes('SCOUT')) events = textEvents(JSON.stringify({ criteria: ['x'], plan: [], ambiguous: false }));
+      else if (request.system.includes('INSPECTOR') || request.system.includes('SENTRY')) events = textEvents(JSON.stringify({ verdict: 'approve', findings: [] }));
+      else {
+        const hasToolResult = request.messages.some((m) => m.role === 'tool');
+        events = hasToolResult ? textEvents('done') : editEvents('foo.txt', 'x\n');
+        if (!hasToolResult) {
+          block = true; // the Builder's first (edit) round hangs
+          state.builderSignal = request.signal;
+        }
+      }
+      return (async function* () {
+        if (block) await blocker;
+        for (const e of events) yield e;
+      })();
+    },
+  };
+  const deps: SessionDeps = {
+    io,
+    secrets: new FakeSecrets(),
+    settings: new FakeSettings('coop'),
+    history,
+    git: fakeGit,
+    post: (m) => posted.push(m),
+    createAdapter: () => adapter,
+    fetchModels: async () => [{ id: 'm1' }],
+    clock: () => Date.now(),
+  };
+  const session = createSessionCore(deps);
+  return { session, posted, io, history, state, unblock: () => unblock() };
+}
+
+/** Spin the microtask queue until `cond` holds (or a bounded number of ticks). */
+async function flushUntil(cond: () => boolean, ticks = 200): Promise<void> {
+  for (let i = 0; i < ticks; i += 1) {
+    if (cond()) return;
+    await new Promise((r) => setTimeout(r, 0));
+  }
+}
+
+describe('zombie-turn supersession', () => {
+  it('newConversation mid-turn aborts the old turn and suppresses its late posts', async () => {
+    const { session, posted, state, unblock } = makeBlockingCoop();
+    await session.handle({ type: 'ready' });
+
+    const turn = session.handle({ type: 'sendPrompt', text: 'build a feature' });
+    await flushUntil(() => posted.some((m) => m.type === 'gateUpdate' && m.card.role === 'builder'));
+    expect(posted.some((m) => m.type === 'gateUpdate' && m.card.role === 'builder')).toBe(true);
+
+    // Switch to a fresh conversation while the Builder call is still blocked.
+    await session.handle({ type: 'newConversation' });
+    const freshConv = lastConversation(posted)!;
+    const boundary = posted.length;
+
+    // Release the old turn's builder call and let it fully unwind.
+    unblock();
+    await turn;
+
+    // No late gate/stream/turnFinished posts arrived after the newConversation boundary.
+    const late = posted.slice(boundary);
+    expect(late.some((m) => m.type === 'gateUpdate')).toBe(false);
+    expect(late.some((m) => m.type === 'stream')).toBe(false);
+    expect(late.some((m) => m.type === 'turnFinished')).toBe(false);
+
+    // this.conv is the fresh conversation, untouched by the old turn.
+    const finalConv = session.conversation;
+    expect(finalConv.id).toBe(freshConv.id);
+    expect(Object.keys(finalConv.nodes).length).toBe(0);
+    expect(finalConv.usageTotals.inputTokens).toBe(0);
+
+    // The old turn's model call was aborted.
+    expect(state.builderSignal?.aborted).toBe(true);
+
+    // The conversation switch cleared the webview's streaming flag.
+    expect(posted.some((m) => m.type === 'stream' && m.event.type === 'done' && m.event.stopReason === 'cancelled')).toBe(true);
+  });
+
+  it('openConversation mid-turn aborts the old turn and switches without grafting its cards', async () => {
+    const { session, posted, history, state, unblock } = makeBlockingCoop();
+    // Seed a second conversation to switch to.
+    const other: Conversation = {
+      id: 'other-conv',
+      title: 'Other',
+      nodes: {
+        n1: { id: 'n1', parentId: null, role: 'user', blocks: [{ type: 'text', text: 'hi' }], createdAt: 1 },
+      },
+      rootIds: ['n1'],
+      currentLeafId: 'n1',
+      model: { providerId: 'p1', modelId: 'm1' },
+      harnessMode: 'coop',
+      createdAt: 1,
+      updatedAt: 1,
+      usageTotals: { inputTokens: 0, outputTokens: 0, cachedTokens: 0 },
+    };
+    await history.save(other);
+    await session.handle({ type: 'ready' });
+
+    const turn = session.handle({ type: 'sendPrompt', text: 'build a feature' });
+    await flushUntil(() => posted.some((m) => m.type === 'gateUpdate' && m.card.role === 'builder'));
+
+    await session.handle({ type: 'openConversation', id: 'other-conv' });
+    const boundary = posted.length;
+
+    unblock();
+    await turn;
+
+    const late = posted.slice(boundary);
+    expect(late.some((m) => m.type === 'gateUpdate')).toBe(false);
+    expect(late.some((m) => m.type === 'stream')).toBe(false);
+    expect(late.some((m) => m.type === 'turnFinished')).toBe(false);
+
+    // The loaded conversation is intact — no gate blocks grafted onto its node.
+    const finalConv = session.conversation;
+    expect(finalConv.id).toBe('other-conv');
+    expect(Object.keys(finalConv.nodes)).toEqual(['n1']);
+    expect(finalConv.nodes.n1.blocks.some((b) => b.type === 'gate')).toBe(false);
+    expect(state.builderSignal?.aborted).toBe(true);
+  });
+
+  it('a second prompt mid-turn aborts the first, and only the second turn finalizes', async () => {
+    const io = new FakeIo();
+    const posted: HostToWebview[] = [];
+    let unblock: () => void = () => {};
+    const blocker = new Promise<void>((res) => {
+      unblock = res;
+    });
+    let calls = 0;
+    let firstSignal: AbortSignal | undefined;
+    // Solo mode: the FIRST model call (the first turn's edit round) blocks; every
+    // later call runs immediately so the second turn completes.
+    const adapter: ProviderAdapter = {
+      chat(request: ChatRequest) {
+        const n = (calls += 1);
+        const hasToolResult = request.messages.some((m) => m.role === 'tool');
+        const events = hasToolResult ? textEvents('done') : editEvents('foo.txt', 'x\n');
+        const block = n === 1;
+        if (block) firstSignal = request.signal;
+        return (async function* () {
+          if (block) await blocker;
+          for (const e of events) yield e;
+        })();
+      },
+    };
+    const deps: SessionDeps = {
+      io,
+      secrets: new FakeSecrets(),
+      settings: new FakeSettings('solo'),
+      history: new FakeHistory(),
+      git: fakeGit,
+      post: (m) => posted.push(m),
+      createAdapter: () => adapter,
+      fetchModels: async () => [{ id: 'm1' }],
+      clock: () => Date.now(),
+    };
+    const session = createSessionCore(deps);
+    await session.handle({ type: 'ready' });
+
+    const turn1 = session.handle({ type: 'sendPrompt', text: 'FIRSTPROMPT do a thing' });
+    await flushUntil(() => firstSignal !== undefined);
+
+    const boundary = posted.length;
+    const turn2 = session.handle({ type: 'sendPrompt', text: 'SECONDPROMPT do another thing' });
+    unblock();
+    await Promise.all([turn1, turn2]);
+
+    // The first turn's model call was aborted by the superseding second turn.
+    expect(firstSignal?.aborted).toBe(true);
+
+    // Exactly one turn finalized (the second) — the first's turnFinished was dropped.
+    const finishes = posted.slice(boundary).filter((m) => m.type === 'turnFinished');
+    expect(finishes).toHaveLength(1);
+
+    // The final conversation carries the second prompt and a finalized assistant leaf.
+    const conv = session.conversation;
+    const userTexts = Object.values(conv.nodes)
+      .filter((nn) => nn.role === 'user')
+      .flatMap((nn) => nn.blocks.map((b) => (b.type === 'text' ? b.text : '')));
+    expect(userTexts.some((t) => t.includes('SECONDPROMPT'))).toBe(true);
+    const leaf = assistantLeaf(conv)!;
+    expect(leaf.role).toBe('assistant');
+    expect(leaf.blocks.some((b) => b.type === 'changes')).toBe(true);
+  });
+
+  it('cancelResponse of the CURRENT turn still finalizes with a cancelled state', async () => {
+    const { session, posted, unblock } = makeBlockingCoop();
+    await session.handle({ type: 'ready' });
+
+    const turn = session.handle({ type: 'sendPrompt', text: 'build a feature' });
+    await flushUntil(() => posted.some((m) => m.type === 'gateUpdate' && m.card.role === 'builder'));
+
+    // Cancel the current turn (epoch unchanged — this is not a supersession).
+    await session.handle({ type: 'cancelResponse' });
+    unblock();
+    await turn;
+
+    // The turn still finalized: a cancelled stream-done and a turnFinished were posted.
+    expect(posted.some((m) => m.type === 'stream' && m.event.type === 'done' && m.event.stopReason === 'cancelled')).toBe(true);
+    expect(posted.some((m) => m.type === 'turnFinished')).toBe(true);
+
+    // The assistant node exists on the (same) conversation with a cancelled outcome.
+    const conv = lastConversation(posted)!;
+    const leaf = assistantLeaf(conv)!;
+    expect(leaf.role).toBe('assistant');
+    expect(leaf.blocks.some((b) => b.type === 'text' && b.text.includes('Cancelled'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Hard context-window management
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes the field bug where a cancelled Coop build's model call survived `/clear` and grafted a live "Builder — implementation" card (with a climbing token counter) onto a fresh solo conversation.

- Starting a new turn, `/clear`, or opening/deleting a conversation now aborts any in-flight turn; the orphaned-controller hole (`runAssistantTurn` overwriting `this.abort` mid-flight) is closed with a monotonic turn epoch
- Every post a turn emits (stream events, gateUpdate including the progress ticker, turnStarted/turnFinished) is epoch-guarded — a superseded turn goes dark immediately and can never finalize into a conversation it no longer owns
- `gateUpdate` now carries the assistant `nodeId` it belongs to; the webview applies it only to that node and silently drops updates for foreign nodes, removing the `currentLeafId` fallback graft
- User-initiated cancel of the current turn is unchanged

Tests: 4 new zombie-supersession scenarios (mid-flight `/clear`, overlapping prompts, mid-flight open-conversation, cancel unchanged). Verification: `tsc --noEmit` clean, 333 unit tests, 102 + 35 e2e assertions, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG)_