### PR TITLE
Rebase always reports its outcome; fix silent conflict paths

### DIFF
--- a/src/core/staging/rebase.ts
+++ b/src/core/staging/rebase.ts
@@ -29,14 +29,36 @@ export async function detectDrift(overlay: StagingOverlay, disk: DiskReader): Pr
   return { needed: drifted.length > 0, conflictedPaths: drifted };
 }
 
+/** Outcome of a rebase pass, split by how each drifted file was reconciled. */
+export interface RebaseResult {
+  /** Drifted modifies whose base->staged hunks cleanly replayed onto new disk. */
+  rebasedPaths: string[];
+  /**
+   * Staged deletes whose target changed on disk. The delete intent is kept
+   * (deleting a changed file is still a delete) and its base is re-based to the
+   * new disk content, so the drift clears. Surfaced so the human knows the file
+   * changed before it is deleted.
+   */
+  changedDeletes: string[];
+  /**
+   * Files that could not be reconciled mechanically and need a model-assisted
+   * merge: a staged create whose path has since appeared on disk, or a drifted
+   * modify whose hunks no longer locate cleanly.
+   */
+  conflictedPaths: string[];
+  /** Merged content by path for the cleanly-rebased modifies (for callers/tests). */
+  merged: Record<string, string>;
+}
+
 /**
- * 3-way rebase. Cleanly-mergeable drifted files are restaged against the new
- * disk content as their base; unmergeable ones are returned as conflicts.
+ * 3-way rebase. Cleanly-mergeable drifted modifies are restaged against the new
+ * disk content as their base; staged deletes of a changed file are kept as
+ * deletes (re-based); creates-onto-existing and unmergeable modifies are returned
+ * as conflicts for the caller to route to the model.
  */
-export async function rebase(
-  overlay: StagingOverlay,
-  disk: DiskReader,
-): Promise<{ ok: boolean; conflictedPaths: string[]; merged: Record<string, string> }> {
+export async function rebase(overlay: StagingOverlay, disk: DiskReader): Promise<RebaseResult> {
+  const rebasedPaths: string[] = [];
+  const changedDeletes: string[] = [];
   const conflictedPaths: string[] = [];
   const merged: Record<string, string> = {};
 
@@ -52,8 +74,11 @@ export async function rebase(
     if (currentContent === op.base) continue; // no drift for this file
 
     if (op.kind === 'delete') {
-      // The file we intended to delete changed externally — surface for review.
-      conflictedPaths.push(op.path);
+      // The file we intended to delete changed externally. Deleting a changed
+      // file is still a delete: keep the intent and re-base onto the new disk
+      // content so the drift clears; surface it so the human is not surprised.
+      overlay.setOp({ kind: 'delete', path: op.path, base: currentContent });
+      changedDeletes.push(op.path);
       continue;
     }
 
@@ -65,10 +90,11 @@ export async function rebase(
       continue;
     }
     merged[op.path] = result;
+    rebasedPaths.push(op.path);
     overlay.setOp({ kind: 'modify', path: op.path, base: currentContent, staged: result });
   }
 
-  return { ok: conflictedPaths.length === 0, conflictedPaths, merged };
+  return { rebasedPaths, changedDeletes, conflictedPaths, merged };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -1554,33 +1554,92 @@ export class SessionCore {
     }
   }
 
+  /**
+   * Reconcile staged edits with drifted disk content. Every invocation ends in a
+   * VISIBLE outcome — a success / partial / failure toast — in addition to always
+   * re-posting the rebase banner state and the refreshed changeset. The banner
+   * disappearing is never the only signal.
+   */
   private async onRebase(): Promise<void> {
     const result = await coreRebase(this.overlay, this.deps.io);
+
+    let merge: { resolved: string[]; unresolved: string[]; modelLabel?: string } = { resolved: [], unresolved: [] };
     if (result.conflictedPaths.length > 0) {
-      await this.resolveConflictsWithModel(result.conflictedPaths);
+      merge = await this.resolveConflictsWithModel(result.conflictedPaths);
     }
+
     this.changeset = new ChangeSet(this.overlay, 'changeset');
     const drift = await detectDrift(this.overlay, this.deps.io);
     this.deps.post({ type: 'rebaseState', state: drift });
     this.sendChangeset();
+
+    this.reportRebaseOutcome(result, merge);
   }
 
-  /** Best-effort model-assisted merge for files the 3-way rebase could not merge. */
-  private async resolveConflictsWithModel(paths: string[]): Promise<void> {
-    const resolved = await this.resolveModel();
-    if (!resolved) {
-      this.toast('warn', `Could not auto-merge ${paths.length} file(s); no model available to resolve conflicts.`);
+  /** Turn a rebase pass into a single, human-legible toast (never silent). */
+  private reportRebaseOutcome(
+    result: { rebasedPaths: string[]; changedDeletes: string[] },
+    merge: { resolved: string[]; unresolved: string[]; modelLabel?: string },
+  ): void {
+    const parts: string[] = [];
+    const mechanical = result.rebasedPaths.length + result.changedDeletes.length;
+    if (mechanical > 0) parts.push(`Rebased ${mechanical} file(s)`);
+    if (merge.resolved.length > 0) {
+      const via = merge.modelLabel ? ` with ${merge.modelLabel}` : '';
+      parts.push(`${merge.resolved.length} conflict(s) auto-merged${via}`);
+    }
+    if (result.changedDeletes.length > 0) {
+      parts.push(`${result.changedDeletes.length} changed file(s) will still be deleted: ${result.changedDeletes.join(', ')}`);
+    }
+
+    if (merge.unresolved.length > 0) {
+      // At least one file is still in conflict — the banner persists. Say so, and
+      // name the files so the human can edit them or discard the change.
+      const prefix = parts.length > 0 ? `${parts.join('; ')}. ` : '';
+      this.toast(
+        'warn',
+        `${prefix}${merge.unresolved.length} conflict(s) could not be resolved: ${merge.unresolved.join(', ')} — edit the files or discard the change.`,
+      );
       return;
     }
+
+    if (parts.length === 0) {
+      // Nothing drifted (or nothing to do) — reassure rather than stay silent.
+      this.toast('info', 'Nothing to rebase — the staged edits are already up to date.');
+      return;
+    }
+    this.toast('info', `${parts.join('; ')}.`);
+  }
+
+  /**
+   * Model-assisted merge for files the 3-way rebase could not reconcile: a staged
+   * create whose path has since appeared on disk, or a drifted modify whose hunks
+   * no longer locate. Both become a `modify` against current disk (a create can
+   * never clear drift as a create — the file already exists). Deletes are NOT
+   * routed here; they are re-based as deletes in the core. Returns which paths were
+   * resolved vs left in conflict so the caller can report a precise outcome.
+   */
+  private async resolveConflictsWithModel(
+    paths: string[],
+  ): Promise<{ resolved: string[]; unresolved: string[]; modelLabel?: string }> {
+    const model = await this.resolveModel();
+    if (!model) {
+      // No model to merge with — every conflict is left for the human.
+      return { resolved: [], unresolved: [...paths] };
+    }
+    const settings = await this.ensureSettings();
+    const modelLabel = this.roleModelLabel(settings);
+    const resolved: string[] = [];
+    const unresolved: string[] = [];
     for (const path of paths) {
       const current = (await this.deps.io.read(path)) ?? '';
       const staged = (await this.overlay.read(path)) ?? '';
       try {
         const controller = new AbortController();
-        const stream = resolved.adapter.chat({
-          baseUrl: resolved.baseUrl,
-          apiKey: resolved.apiKey,
-          modelId: resolved.modelId,
+        const stream = model.adapter.chat({
+          baseUrl: model.baseUrl,
+          apiKey: model.apiKey,
+          modelId: model.modelId,
           system: 'You merge code. Given the current on-disk file and an intended edited version, produce a single merged file that preserves the intended change on top of the current content. Reply with ONLY the full merged file contents, no fences, no commentary.',
           messages: [
             {
@@ -1598,11 +1657,15 @@ export class SessionCore {
         const merged = stripFences(text);
         if (merged.trim()) {
           this.overlay.setOp({ kind: 'modify', path, base: current, staged: merged });
+          resolved.push(path);
+        } else {
+          unresolved.push(path); // empty response — leave the conflict for the human
         }
       } catch {
-        /* leave the conflict for the human */
+        unresolved.push(path); // merge call failed — leave the conflict for the human
       }
     }
+    return { resolved, unresolved, modelLabel };
   }
 
   // -------------------------------------------------------------------------

--- a/test/extension-session.test.ts
+++ b/test/extension-session.test.ts
@@ -2251,3 +2251,241 @@ describe('deterministic file references in prompts', () => {
     expect(posted.some((m) => m.type === 'toast' && m.level === 'info' && m.message.startsWith('Included'))).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Rebase button — every conflict path ends in a visible outcome (never silent)
+// ---------------------------------------------------------------------------
+
+/** One edit spec turned into a single-tool-call build turn. */
+type RebaseEdit = { path: string; find?: string; replace?: string; create?: string; delete?: boolean };
+
+/**
+ * Adapter that stages `edit` on a build turn, finishes once tool results arrive,
+ * and — on a conflict-merge call (the "You merge code" system prompt) — returns
+ * `mergeReply` (a string, or a function so a test can vary/throw). This exercises
+ * the model-assisted conflict resolution deterministically.
+ */
+function rebaseAdapter(edit: RebaseEdit, mergeReply: string | (() => string)): ProviderAdapter {
+  return {
+    chat(req: ChatRequest) {
+      let events: StreamEvent[];
+      if (req.system.includes('You merge code')) {
+        const t = typeof mergeReply === 'function' ? mergeReply() : mergeReply;
+        events = [{ type: 'text', delta: t }, { type: 'done', stopReason: 'end' }];
+      } else {
+        const hasToolResult = req.messages.some((m) => m.role === 'tool');
+        events = hasToolResult
+          ? textEvents('done')
+          : [
+              { type: 'tool_call_start', id: 't1', name: 'edit_files' },
+              { type: 'tool_call_args', id: 't1', delta: JSON.stringify({ edits: [edit] }) },
+              { type: 'tool_call_end', id: 't1' },
+              USAGE,
+              { type: 'done', stopReason: 'tool_use' },
+            ];
+      }
+      return (async function* () {
+        for (const e of events) yield e;
+      })();
+    },
+  };
+}
+
+function makeRebaseSession(edit: RebaseEdit, opts: { mergeReply?: string | (() => string); noModel?: boolean } = {}) {
+  const io = new FakeIo();
+  const posted: HostToWebview[] = [];
+  const adapter = rebaseAdapter(edit, opts.mergeReply ?? '');
+  const settings = new FakeSettings('solo');
+  const deps: SessionDeps = {
+    io,
+    secrets: new FakeSecrets(),
+    settings,
+    history: new FakeHistory(),
+    git: fakeGit,
+    post: (m) => posted.push(m),
+    createAdapter: () => adapter,
+    fetchModels: async () => [{ id: 'm1' }],
+    clock: () => Date.now(),
+  };
+  const session = createSessionCore(deps);
+  // A helper to strip the model AFTER staging (so the turn can still run first):
+  // clearing providers makes the conversation model unresolvable.
+  const dropModel = () => {
+    settings.providers = [];
+  };
+  return { session, posted, io, settings, dropModel };
+}
+
+const lastRebaseState = (posted: HostToWebview[]) =>
+  [...posted].reverse().find((m): m is Extract<HostToWebview, { type: 'rebaseState' }> => m.type === 'rebaseState');
+const rebaseToasts = (posted: HostToWebview[]) =>
+  posted.filter((m): m is Extract<HostToWebview, { type: 'toast' }> => m.type === 'toast');
+
+describe('rebase button — happy path', () => {
+  it('cleanly rebases a drifted modify, clears the banner, re-posts the changeset, and toasts success', async () => {
+    const { session, posted, io } = makeRebaseSession({ path: 'foo.txt', find: 'b', replace: 'B' });
+    io.files.set('foo.txt', 'a\nb\nc\n');
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'edit foo' });
+
+    // Drift: an unrelated trailing line appears on disk after staging.
+    io.files.set('foo.txt', 'a\nb\nc\nd\n');
+    await session.handle({ type: 'applyToDisk' }); // drift path posts rebaseState needed
+    expect(lastRebaseState(posted)!.state.needed).toBe(true);
+
+    const before = posted.length;
+    await session.handle({ type: 'rebase' });
+
+    // Banner cleared, changeset re-posted, and a visible success toast.
+    expect(lastRebaseState(posted)!.state.needed).toBe(false);
+    expect(posted.slice(before).some((m) => m.type === 'changeset')).toBe(true);
+    const t = rebaseToasts(posted.slice(before));
+    expect(t).toHaveLength(1);
+    expect(t[0]).toMatchObject({ level: 'info' });
+    expect(t[0].message).toMatch(/Rebased 1 file/);
+
+    // Applying now writes the merged content (staged edit replayed onto new disk).
+    await session.handle({ type: 'applyToDisk' });
+    expect(io.files.get('foo.txt')).toBe('a\nB\nc\nd\n');
+  });
+});
+
+describe('rebase button — staged DELETE of a changed file', () => {
+  it('keeps the delete (does NOT resurrect the file), clears the banner, and names the changed file', async () => {
+    const { session, posted, io } = makeRebaseSession({ path: 'foo.txt', delete: true }, { mergeReply: 'a\nMERGED\nc\n' });
+    io.files.set('foo.txt', 'a\nb\nc\n');
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'delete foo' });
+
+    io.files.set('foo.txt', 'a\nCHANGED\nc\n'); // the file we meant to delete changed
+    await session.handle({ type: 'applyToDisk' });
+    const before = posted.length;
+    await session.handle({ type: 'rebase' });
+
+    expect(lastRebaseState(posted)!.state.needed).toBe(false);
+    const t = rebaseToasts(posted.slice(before));
+    expect(t).toHaveLength(1);
+    expect(t[0].message).toMatch(/will still be deleted: foo\.txt/);
+
+    // Applying honors the DELETE — the file is removed, NOT rewritten with model output.
+    await session.handle({ type: 'applyToDisk' });
+    expect(io.files.has('foo.txt')).toBe(false);
+  });
+
+  it('is not a silent no-op even when a model is present and returns empty', async () => {
+    const { session, posted, io } = makeRebaseSession({ path: 'foo.txt', delete: true }, { mergeReply: '' });
+    io.files.set('foo.txt', 'a\nb\nc\n');
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'delete foo' });
+
+    io.files.set('foo.txt', 'a\nCHANGED\nc\n');
+    await session.handle({ type: 'applyToDisk' });
+    const before = posted.length;
+    await session.handle({ type: 'rebase' });
+
+    // The delete never routes to the model, so an empty reply is irrelevant: the
+    // banner clears and a toast fires.
+    expect(lastRebaseState(posted)!.state.needed).toBe(false);
+    expect(rebaseToasts(posted.slice(before))).toHaveLength(1);
+    await session.handle({ type: 'applyToDisk' });
+    expect(io.files.has('foo.txt')).toBe(false);
+  });
+});
+
+describe('rebase button — staged CREATE whose path appeared on disk', () => {
+  it('model merge succeeds: banner clears, applies merged content, toasts auto-merge with the model', async () => {
+    const { session, posted, io } = makeRebaseSession({ path: 'new.txt', create: 'created\n' }, { mergeReply: 'merged-create\n' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'create new' });
+
+    io.files.set('new.txt', 'appeared\n'); // the file now exists → create conflict
+    await session.handle({ type: 'applyToDisk' });
+    const before = posted.length;
+    await session.handle({ type: 'rebase' });
+
+    expect(lastRebaseState(posted)!.state.needed).toBe(false);
+    const t = rebaseToasts(posted.slice(before));
+    expect(t).toHaveLength(1);
+    expect(t[0]).toMatchObject({ level: 'info' });
+    expect(t[0].message).toMatch(/auto-merged with m1/);
+
+    await session.handle({ type: 'applyToDisk' });
+    expect(io.files.get('new.txt')).toBe('merged-create');
+  });
+
+  it('model returns empty: keeps the conflict, banner persists, and warns with the path', async () => {
+    const { session, posted, io } = makeRebaseSession({ path: 'new.txt', create: 'created\n' }, { mergeReply: '' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'create new' });
+
+    io.files.set('new.txt', 'appeared\n');
+    await session.handle({ type: 'applyToDisk' });
+    const before = posted.length;
+    await session.handle({ type: 'rebase' });
+
+    expect(lastRebaseState(posted)!.state.needed).toBe(true);
+    const t = rebaseToasts(posted.slice(before));
+    expect(t).toHaveLength(1);
+    expect(t[0]).toMatchObject({ level: 'warn' });
+    expect(t[0].message).toMatch(/could not be resolved: new\.txt/);
+  });
+
+  it('no model configured: keeps the conflict, banner persists, and warns', async () => {
+    const { session, posted, io, dropModel } = makeRebaseSession({ path: 'new.txt', create: 'created\n' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'create new' });
+
+    io.files.set('new.txt', 'appeared\n');
+    await session.handle({ type: 'applyToDisk' });
+    dropModel(); // remove the provider so resolveConflictsWithModel finds no model
+    const before = posted.length;
+    await session.handle({ type: 'rebase' });
+
+    expect(lastRebaseState(posted)!.state.needed).toBe(true);
+    const t = rebaseToasts(posted.slice(before));
+    expect(t.some((x) => x.level === 'warn' && /could not be resolved: new\.txt/.test(x.message))).toBe(true);
+  });
+});
+
+describe('rebase button — drifted MODIFY whose hunks cannot apply', () => {
+  it('model merge succeeds: banner clears and toasts auto-merge', async () => {
+    const { session, posted, io } = makeRebaseSession(
+      { path: 'foo.txt', find: 'TARGET', replace: 'CHANGED' },
+      { mergeReply: 'A\nB\nresolved\n' },
+    );
+    io.files.set('foo.txt', 'A\nB\nTARGET\nC\nD\n');
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'edit foo' });
+
+    io.files.set('foo.txt', 'totally\ndifferent\nbody\n'); // context gone → conflict
+    await session.handle({ type: 'applyToDisk' });
+    const before = posted.length;
+    await session.handle({ type: 'rebase' });
+
+    expect(lastRebaseState(posted)!.state.needed).toBe(false);
+    expect(rebaseToasts(posted.slice(before))[0].message).toMatch(/auto-merged with m1/);
+    await session.handle({ type: 'applyToDisk' });
+    expect(io.files.get('foo.txt')).toBe('A\nB\nresolved'); // stripFences trims trailing newline
+  });
+
+  it('model returns empty: not silent — banner persists with a warn toast naming the file', async () => {
+    const { session, posted, io } = makeRebaseSession(
+      { path: 'foo.txt', find: 'TARGET', replace: 'CHANGED' },
+      { mergeReply: '   ' },
+    );
+    io.files.set('foo.txt', 'A\nB\nTARGET\nC\nD\n');
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'edit foo' });
+
+    io.files.set('foo.txt', 'totally\ndifferent\nbody\n');
+    await session.handle({ type: 'applyToDisk' });
+    const before = posted.length;
+    await session.handle({ type: 'rebase' });
+
+    expect(lastRebaseState(posted)!.state.needed).toBe(true);
+    const t = rebaseToasts(posted.slice(before));
+    expect(t).toHaveLength(1);
+    expect(t[0]).toMatchObject({ level: 'warn' });
+    expect(t[0].message).toMatch(/could not be resolved: foo\.txt/);
+  });
+});

--- a/test/staging.test.ts
+++ b/test/staging.test.ts
@@ -201,7 +201,8 @@ describe('rebase / drift detection', () => {
     await o.stageModify('a.ts', 'a\nB\nc');
     disk.files['a.ts'] = 'a\nb\nc\nd'; // appended after the edited region
     const res = await rebase(o, disk);
-    expect(res.ok).toBe(true);
+    expect(res.conflictedPaths).toHaveLength(0);
+    expect(res.rebasedPaths).toContain('a.ts');
     expect(res.merged['a.ts']).toBe('a\nB\nc\nd');
     // Overlay restaged against the new disk base.
     expect(o.ops()[0]).toMatchObject({ kind: 'modify', base: 'a\nb\nc\nd', staged: 'a\nB\nc\nd' });
@@ -213,7 +214,7 @@ describe('rebase / drift detection', () => {
     await o.stageModify('a.ts', 'a\nB\nc');
     disk.files['a.ts'] = 'header1\nheader2\na\nb\nc'; // shifted by 2 lines
     const res = await rebase(o, disk);
-    expect(res.ok).toBe(true);
+    expect(res.conflictedPaths).toHaveLength(0);
     expect(res.merged['a.ts']).toBe('header1\nheader2\na\nB\nc');
   });
 
@@ -223,8 +224,8 @@ describe('rebase / drift detection', () => {
     await o.stageModify('a.ts', 'a\nB\nc');
     disk.files['a.ts'] = 'totally\ndifferent\nfile\nbody'; // context gone
     const res = await rebase(o, disk);
-    expect(res.ok).toBe(false);
     expect(res.conflictedPaths).toContain('a.ts');
+    expect(res.rebasedPaths).not.toContain('a.ts');
   });
 
   it('R1: conflicts (not false-clean) when context is destroyed but a stray copy of the removed line survives', async () => {
@@ -237,7 +238,6 @@ describe('rebase / drift detection', () => {
     disk.files['a.ts'] = 'TARGET\nP\nQ\nR';
     const res = await rebase(o, disk);
     // Must be a conflict — must NOT silently rewrite the unrelated top line.
-    expect(res.ok).toBe(false);
     expect(res.conflictedPaths).toContain('a.ts');
     expect(res.merged['a.ts']).toBeUndefined();
   });
@@ -249,8 +249,41 @@ describe('rebase / drift detection', () => {
     // Unrelated lines prepended; the edit's real context (A/B/C/D) survives.
     disk.files['a.ts'] = 'H1\nH2\nA\nB\nTARGET\nC\nD';
     const res = await rebase(o, disk);
-    expect(res.ok).toBe(true);
+    expect(res.conflictedPaths).toHaveLength(0);
     expect(res.merged['a.ts']).toBe('H1\nH2\nA\nB\nCHANGED\nC\nD');
+  });
+
+  it('a staged create conflicts once the file appears on disk (model-merge path)', async () => {
+    const disk = new MockDisk();
+    const o = new StagingOverlay(disk);
+    await o.stageCreate('new.ts', 'staged content');
+    expect((await detectDrift(o, disk)).needed).toBe(false);
+    disk.files['new.ts'] = 'someone else created this'; // file appeared
+    const res = await rebase(o, disk);
+    // A create-onto-existing cannot be merged mechanically — it is a conflict for
+    // the caller to route to the model; the overlay op is left untouched.
+    expect(res.conflictedPaths).toContain('new.ts');
+    expect(res.rebasedPaths).toHaveLength(0);
+    expect(res.changedDeletes).toHaveLength(0);
+    expect(o.ops()[0]).toMatchObject({ kind: 'create', path: 'new.ts', staged: 'staged content' });
+  });
+
+  it('a staged delete of a changed file stays a delete, re-based onto new disk', async () => {
+    const disk = new MockDisk({ 'a.ts': 'original' });
+    const o = new StagingOverlay(disk);
+    await o.stageDelete('a.ts');
+    expect((await detectDrift(o, disk)).needed).toBe(false);
+    disk.files['a.ts'] = 'changed externally'; // the file we meant to delete changed
+    const res = await rebase(o, disk);
+    // Deleting a changed file is still a delete — kept as a delete, base re-based,
+    // reported as a changed-delete (NOT a model conflict).
+    expect(res.changedDeletes).toContain('a.ts');
+    expect(res.conflictedPaths).toHaveLength(0);
+    expect(o.ops()[0]).toEqual({ kind: 'delete', path: 'a.ts', base: 'changed externally' });
+    // The drift is cleared: the delete now bases on current disk.
+    expect((await detectDrift(o, disk)).needed).toBe(false);
+    // read still reflects the delete intent.
+    expect(await o.read('a.ts')).toBeNull();
   });
 });
 


### PR DESCRIPTION
Reproduced the "Rebase button does nothing" field report with tests driving the real SessionCore. Findings: the button always worked at the protocol level, but three conflict paths ended in silence — and one destroyed intent: a staged DELETE of an externally-changed file was routed to the model merge, which either silently converted the delete into a modify with model-invented content, or silently left the drift banner up. Unmergeable modifies and staged creates whose file had appeared on disk also failed without feedback when the merge model errored or returned nothing. The git-repo correlation was coincidental — rebase never touches git; non-git scratch folders are just where files get hand-edited outside the tool, which is what creates drift.

- `rebase()` returns a structured result; a delete of a changed file stays a delete (re-based onto current disk content so drift clears), surfaced as a heads-up rather than model-merged
- `resolveConflictsWithModel` treats empty replies and errors as unresolved and reports what it merged and with which model
- Every rebase click now ends in a precise toast: "Rebased N file(s)", auto-merged conflicts with the model named, changed-file deletion notices, or unresolved paths with what to do next

Verification: `tsc --noEmit` clean, 343 unit tests (10 new rebase-path scenarios), 102 + 35 e2e assertions, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG)_