### PR TITLE
Preview staged artifacts through the overlay before they touch disk

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,6 +42,7 @@ fowlplay/
 │   │   ├── staging/
 │   │   │   ├── overlay.ts    # virtual FS overlay; read-through; drift detection
 │   │   │   ├── changeset.ts  # edits → hunks; cumulative diff; revert; serialize
+│   │   │   ├── preview.ts    # artifact detection (best previewable entry file)
 │   │   │   └── rebase.ts     # 3-way rebase onto new disk state
 │   │   ├── agent/
 │   │   │   ├── loop.ts       # agentic loop: stream → tool calls → continue
@@ -62,11 +63,13 @@ fowlplay/
 │   │   ├── tabManager.ts     # webview panels; one session per tab
 │   │   ├── session.ts        # wires core loop ⇄ webview ⇄ workspace for one tab
 │   │   ├── workspaceIo.ts    # real FS + ripgrep-style search, .gitignore aware
+│   │   ├── previewServer.ts  # loopback overlay preview server (token-guarded)
+│   │   ├── previewHttp.ts    # pure request logic: path sanitizing + mime map
 │   │   ├── git.ts            # commit, co-author trailer, branch state via child git
 │   │   ├── secrets.ts        # SecretStorage for API keys
 │   │   └── historyStore.ts   # conversations in globalStorage (JSON files)
 │   └── webview/
-│       ├── index.tsx         # Preact root; view router (chat|diff|settings|history)
+│       ├── index.tsx         # Preact root; view router (chat|diff|preview|settings|history)
 │       ├── bridge.ts         # typed postMessage client; mockable for Playwright
 │       ├── theme.css         # ultramarine design tokens, light/dark/midnight
 │       └── components/      # Chat, Message, ThinkingBlock, ToolCallCard, GateCard,
@@ -105,6 +108,21 @@ fowlplay/
 6. **Persistence**: conversations + changesets serialized to JSON under
    `context.globalStorageUri`; keys in `context.secrets`; settings in
    `workspace.getConfiguration('fowlplay')` + a JSON blob for providers (sans keys).
+
+7. **Overlay preview server** (`previewServer.ts` + `previewHttp.ts`). Staged
+   artifacts (HTML/SVG pages and their sibling assets) are previewed *before* they
+   touch disk by serving them through the staging overlay. A tiny loopback
+   `node:http` server reads a `PreviewSource` (staged content wins; untracked paths
+   fall back to raw disk; staged deletes 404), so the "model never touches disk"
+   invariant holds. It binds `127.0.0.1` on an ephemeral port and mints one random
+   token per instance — every request must carry it as the first path segment
+   (`/<token>/…`) or it 404s, which keeps other local processes out. URLs go through
+   `vscode.env.asExternalUri` for remote/codespace port forwarding. Markdown entries
+   skip the server and render in the webview with the existing `Markdown` component.
+   Historical (frozen) previews are disk-backed best-effort — frozen hunks can't
+   reconstruct staged content, but the commit was applied to disk anyway. The
+   session talks to the server only through the `PreviewPort`/`PreviewSource` ports,
+   so it stays vscode-free and unit-testable.
 
 ## Build & test toolchain
 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -299,6 +299,25 @@ Click **Review Changes** (or the title-bar pill) to open the GitHub-style diff v
 - **Send Feedback** — sends your comments and reverts back as a new prompt; the model
   revises the changeset without re-applying what you reverted. Repeat until it's right.
 
+### Previewing changes
+
+When a changeset contains a renderable artifact — an HTML page, an SVG, a Markdown
+document, or a multi-file static site — a **Preview** button appears next to *Review
+Changes* (also on the diff viewer header, the Human review gate card, and historical
+commit blocks). Click it to see the artifact rendered *before* anything touches disk:
+
+- Markdown renders inline in the panel.
+- HTML/SVG (and their sibling CSS/JS/image assets) load in an embedded browser frame.
+  The preview is served through the staging overlay — staged edits win, with untracked
+  files read from disk — so you are looking at exactly what the model produced.
+- **Refresh** reloads the frame; **Open in Browser** opens the page in your real browser
+  (handy over a remote/codespace, where the URL is port-forwarded for you). **Esc** or ✕
+  closes the preview.
+
+FowlPlay auto-detects the entry file (an `index.html` wins over other pages). Previews of
+*historical* commits are best-effort and read from disk, since the frozen snapshot doesn't
+retain full staged content.
+
 ---
 
 ## 9. Applying changes

--- a/src/core/harness/coop.ts
+++ b/src/core/harness/coop.ts
@@ -71,7 +71,7 @@ export interface RoleRunner {
 /** Read-only view of the currently staged changeset. */
 export interface ChangesetInspector {
   unifiedDiff(): string;
-  summary(): { filesChanged: number; additions: number; deletions: number };
+  summary(): { filesChanged: number; additions: number; deletions: number; previewPath?: string };
 }
 
 // ---------------------------------------------------------------------------
@@ -588,6 +588,8 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
       title: 'Human review',
       status: 'awaiting',
       evidence: 'Awaiting your diff review — you are the final gate.',
+      // Surface a Preview button on the card when the changeset has a previewable entry.
+      previewPath: inspector.summary().previewPath,
     }),
   );
 

--- a/src/core/harness/evidence.ts
+++ b/src/core/harness/evidence.ts
@@ -32,6 +32,8 @@ export interface GateCardInit {
   attempt?: number;
   /** Display label of the model that ran this role. */
   modelLabel?: string;
+  /** Workspace-relative entry point the changeset can be previewed from, when one was found. */
+  previewPath?: string;
 }
 
 /**
@@ -51,6 +53,7 @@ export function createCard(id: string, init: GateCardInit): GateCard {
   if (init.findings) card.findings = init.findings;
   if (init.attempt !== undefined) card.attempt = init.attempt;
   if (init.modelLabel) card.modelLabel = init.modelLabel;
+  if (init.previewPath) card.previewPath = init.previewPath;
   return card;
 }
 

--- a/src/core/staging/changeset.ts
+++ b/src/core/staging/changeset.ts
@@ -16,6 +16,7 @@ import type {
   FileOp,
 } from '../../shared/types';
 import { applyHunksToBase, computeFileDiff, renderHunkDiff } from '../diff/compute';
+import { detectPreviewEntry } from './preview';
 import type { StagingOverlay } from './overlay';
 
 interface HunkState {
@@ -61,7 +62,8 @@ export class ChangeSet {
       deletions += f.deletions;
       totalChanges += f.hunks.length;
     }
-    return { id: this.id, files, totalChanges, additions, deletions };
+    const previewPath = detectPreviewEntry(this.overlay.ops()) ?? undefined;
+    return { id: this.id, files, totalChanges, additions, deletions, previewPath };
   }
 
   private applyState(h: DiffHunk): DiffHunk {
@@ -169,6 +171,7 @@ export class ChangeSet {
       filesChanged: v.files.length,
       additions: v.additions,
       deletions: v.deletions,
+      previewPath: v.previewPath,
     };
   }
 }

--- a/src/core/staging/preview.ts
+++ b/src/core/staging/preview.ts
@@ -1,0 +1,66 @@
+/**
+ * Preview artifact detection — pick the best previewable entry file out of a set
+ * of staged ops.
+ *
+ * Pure and dependency-free (unit-tested in isolation): the ordering decides what
+ * the Preview button opens when the human doesn't name a path. HTML wins over SVG
+ * wins over Markdown; a page named `index.html` wins over its siblings; shallower
+ * paths win over deeper ones; ties break alphabetically. Deleted ops are never
+ * previewable.
+ */
+
+import type { FileOp } from '../../shared/types';
+
+/** Extensions we know how to preview, most-preferred first. */
+const PREVIEW_EXT_PRIORITY = ['.html', '.htm', '.svg', '.md'];
+
+/** The lower-cased extension of a path (including the dot), or '' if none. */
+function extOf(path: string): string {
+  const base = path.slice(path.lastIndexOf('/') + 1);
+  const dot = base.lastIndexOf('.');
+  return dot > 0 ? base.slice(dot).toLowerCase() : '';
+}
+
+/** Basename of a path, lower-cased. */
+function baseOf(path: string): string {
+  return path.slice(path.lastIndexOf('/') + 1).toLowerCase();
+}
+
+/** Depth of a path = number of `/` separators (shallower sorts first). */
+function depthOf(path: string): number {
+  let n = 0;
+  for (const c of path) if (c === '/') n += 1;
+  return n;
+}
+
+/**
+ * Order candidate paths: ext priority, then `index.html`-ish first, then shallower
+ * path, then alpha. Paths whose extension isn't previewable are dropped.
+ */
+export function previewCandidates(paths: string[]): string[] {
+  const previewable = paths.filter((p) => PREVIEW_EXT_PRIORITY.includes(extOf(p)));
+  return previewable.sort((a, b) => {
+    const ea = PREVIEW_EXT_PRIORITY.indexOf(extOf(a));
+    const eb = PREVIEW_EXT_PRIORITY.indexOf(extOf(b));
+    if (ea !== eb) return ea - eb;
+    // Within html candidates, prefer an index page.
+    const ia = isIndex(a) ? 0 : 1;
+    const ib = isIndex(b) ? 0 : 1;
+    if (ia !== ib) return ia - ib;
+    const da = depthOf(a);
+    const db = depthOf(b);
+    if (da !== db) return da - db;
+    return a.localeCompare(b);
+  });
+}
+
+/** Best previewable entry among non-deleted overlay ops, or null. */
+export function detectPreviewEntry(ops: FileOp[]): string | null {
+  const live = ops.filter((op) => op.kind !== 'delete').map((op) => op.path);
+  return previewCandidates(live)[0] ?? null;
+}
+
+function isIndex(path: string): boolean {
+  const b = baseOf(path);
+  return b === 'index.html' || b === 'index.htm';
+}

--- a/src/extension/previewHttp.ts
+++ b/src/extension/previewHttp.ts
@@ -1,0 +1,78 @@
+/**
+ * Preview HTTP request logic — pure, no `vscode` / `node:http` (unit-tested).
+ *
+ * The overlay server serves workspace files over a loopback port. Two concerns
+ * live here so they can be tested without a server:
+ *  - {@link sanitizePreviewPath}: turn a raw request URL into a safe,
+ *    workspace-relative path (or reject it), enforcing the per-server token and
+ *    blocking traversal.
+ *  - {@link mimeFor}: pick a Content-Type from a path's extension.
+ */
+
+/**
+ * Strip query/hash, decode, require the `/<token>/` prefix, reject `..`/NUL/
+ * backslash; '' resolves to `entryPath`. Returns the workspace-relative path or
+ * null (→ 404). The token prefix is the server's only auth, so an absent or wrong
+ * token must fail before anything else is considered.
+ */
+export function sanitizePreviewPath(urlPath: string, token: string, entryPath: string): string | null {
+  // Drop query string / fragment.
+  let raw = urlPath.split('?')[0].split('#')[0];
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    return null; // malformed percent-encoding
+  }
+
+  const prefix = `/${token}/`;
+  if (!decoded.startsWith(prefix)) return null;
+  let rel = decoded.slice(prefix.length);
+
+  // Empty (the entry URL itself, e.g. `/<token>/`) serves the entry point.
+  if (rel === '') rel = entryPath;
+
+  // Reject traversal, NUL, and backslash outright — the containment check
+  // downstream is a backstop, but these never belong in a legitimate request.
+  if (rel.includes('\0') || rel.includes('\\')) return null;
+  if (rel.split('/').some((seg) => seg === '..')) return null;
+
+  // Normalize leading slashes / empty segments to a clean relative path.
+  const clean = rel.split('/').filter(Boolean).join('/');
+  return clean === '' ? null : clean;
+}
+
+/** Content-Type by extension; text types get `; charset=utf-8`. */
+export function mimeFor(path: string): string {
+  const base = path.slice(path.lastIndexOf('/') + 1);
+  const dot = base.lastIndexOf('.');
+  const ext = dot > 0 ? base.slice(dot + 1).toLowerCase() : '';
+  const type = MIME[ext];
+  if (!type) return 'application/octet-stream';
+  return TEXT_TYPES.has(ext) ? `${type}; charset=utf-8` : type;
+}
+
+const MIME: Record<string, string> = {
+  html: 'text/html',
+  htm: 'text/html',
+  svg: 'image/svg+xml',
+  css: 'text/css',
+  js: 'text/javascript',
+  mjs: 'text/javascript',
+  json: 'application/json',
+  md: 'text/plain',
+  txt: 'text/plain',
+  xml: 'application/xml',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  ico: 'image/x-icon',
+  woff: 'font/woff',
+  woff2: 'font/woff2',
+  wasm: 'application/wasm',
+};
+
+/** Extensions whose Content-Type should carry a utf-8 charset. */
+const TEXT_TYPES = new Set(['html', 'htm', 'svg', 'css', 'js', 'mjs', 'json', 'md', 'txt', 'xml']);

--- a/src/extension/previewServer.ts
+++ b/src/extension/previewServer.ts
@@ -1,0 +1,144 @@
+/**
+ * PreviewServer — the overlay-backed preview HTTP server (the `PreviewPort` impl).
+ *
+ * A tiny loopback `node:http` server that serves a staged artifact (and its
+ * sibling assets) THROUGH the staging overlay: staged content wins, with a raw
+ * disk fallback for untracked paths. This preserves the "model never touches
+ * disk" invariant — the preview reads the same virtual filesystem the agent wrote
+ * to, not the real workspace.
+ *
+ * Security: the server binds `127.0.0.1` on an ephemeral port and mints one random
+ * token per instance. Every request must carry that token as its first path
+ * segment (`/<token>/…`) or it 404s, so other local processes and drive-by web
+ * pages can't read the workspace. The URL is run through `vscode.env.asExternalUri`
+ * so remote / codespace setups get port forwarding for free.
+ */
+
+import * as vscode from 'vscode';
+import * as http from 'node:http';
+import { randomBytes } from 'node:crypto';
+import type { PreviewPort, PreviewSource } from './session';
+import { mimeFor, sanitizePreviewPath } from './previewHttp';
+
+export class PreviewServer implements PreviewPort {
+  private server: http.Server | null = null;
+  private port = 0;
+  private readonly token = randomBytes(16).toString('hex');
+  /** The source + entry the server currently reads through; swapped on re-`open`. */
+  private target: { source: PreviewSource; entry: string } | null = null;
+
+  constructor(private readonly root: vscode.Uri) {}
+
+  /** (Re)point the server at a source + entry; returns the externally reachable URL of the entry. */
+  async open(source: PreviewSource, entryPath: string): Promise<{ url: string }> {
+    this.target = { source, entry: entryPath };
+    await this.ensureStarted();
+    const rel = entryPath.split('/').map(encodeURIComponent).join('/');
+    const local = vscode.Uri.parse(`http://127.0.0.1:${this.port}/${this.token}/${rel}`);
+    const external = await vscode.env.asExternalUri(local);
+    return { url: external.toString() };
+  }
+
+  close(): void {
+    this.server?.close();
+    this.server = null;
+    this.port = 0;
+    this.target = null;
+  }
+
+  openExternal(url: string): void {
+    void vscode.env.openExternal(vscode.Uri.parse(url));
+  }
+
+  /** Start the server (once) on an ephemeral loopback port. */
+  private ensureStarted(): Promise<void> {
+    if (this.server) return Promise.resolve();
+    return new Promise((resolve, reject) => {
+      const server = http.createServer((req, res) => {
+        // Any exception in the async handler becomes a 500 — never an unhandled rejection.
+        this.handle(req, res).catch(() => {
+          if (!res.headersSent) res.writeHead(500);
+          res.end();
+        });
+      });
+      server.on('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        const addr = server.address();
+        this.port = typeof addr === 'object' && addr ? addr.port : 0;
+        this.server = server;
+        resolve();
+      });
+    });
+  }
+
+  private async handle(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const target = this.target;
+    if (!target) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    const rel = sanitizePreviewPath(req.url ?? '', this.token, target.entry);
+    if (rel === null) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+
+    const staged = await target.source.staged(rel);
+    if (staged) {
+      if (staged.content === null) {
+        // Tracked as a staged DELETE — must 404, never fall through to disk.
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+      this.send(res, mimeFor(rel), Buffer.from(staged.content, 'utf-8'));
+      return;
+    }
+
+    // Untracked → raw disk fallback, confined to the workspace root.
+    const uri = this.resolveInRoot(rel);
+    if (!uri) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    try {
+      const bytes = await vscode.workspace.fs.readFile(uri);
+      this.send(res, mimeFor(rel), Buffer.from(bytes));
+    } catch {
+      res.writeHead(404);
+      res.end();
+    }
+  }
+
+  /** Write a 200 with the standard hardening headers. */
+  private send(res: http.ServerResponse, contentType: string, body: Buffer): void {
+    res.writeHead(200, {
+      'Content-Type': contentType,
+      'Cache-Control': 'no-store',
+      'X-Content-Type-Options': 'nosniff',
+    });
+    res.end(body);
+  }
+
+  /**
+   * Resolve a workspace-relative path to a URI inside the root, or null if it
+   * escapes. Mirrors `WorkspaceIo.uri()`'s containment check (kept local so this
+   * module stays independent of WorkspaceIo).
+   */
+  private resolveInRoot(path: string): vscode.Uri | null {
+    const resolved = vscode.Uri.joinPath(this.root, ...path.split('/').filter(Boolean));
+    const rootPath = this.root.path.replace(/\/+$/, '');
+    const resolvedPath = resolved.path.replace(/\/+$/, '');
+    if (
+      resolved.scheme !== this.root.scheme ||
+      resolved.authority !== this.root.authority ||
+      !(resolvedPath === rootPath || resolvedPath.startsWith(rootPath + '/'))
+    ) {
+      return null;
+    }
+    return resolved;
+  }
+}

--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -49,6 +49,7 @@ import { estimateTokens, trimWireToBudget, wireTokens } from '../core/agent/cont
 import { capFileContent, expandFileMentions, extractFileMentions, fencedBlock } from '../core/agent/fileMentions';
 import { StagingOverlay, type DiskReader } from '../core/staging/overlay';
 import { ChangeSet } from '../core/staging/changeset';
+import { detectPreviewEntry } from '../core/staging/preview';
 import { detectDrift, rebase as coreRebase } from '../core/staging/rebase';
 import { renderHunkDiff } from '../core/diff/compute';
 import {
@@ -139,12 +140,32 @@ export interface GitPort {
   head(): Promise<{ sha: string; branch: string } | null>;
 }
 
+/** Read-only view of the staging layer for the preview server. */
+export interface PreviewSource {
+  /**
+   * Staged content for a workspace-relative path.
+   * - `{ content: string }`  → path is tracked; serve this.
+   * - `{ content: null }`    → tracked as a staged DELETE; must 404 (never fall back to disk).
+   * - `null`                 → untracked; the server falls back to raw disk bytes.
+   */
+  staged(path: string): Promise<{ content: string | null } | null>;
+}
+
+export interface PreviewPort {
+  /** (Re)point the server at a source + entry; returns the externally reachable URL of the entry. */
+  open(source: PreviewSource, entryPath: string): Promise<{ url: string }>;
+  close(): void;
+  openExternal(url: string): void;
+}
+
 export interface SessionDeps {
   io: DiskIo;
   secrets: SecretsPort;
   settings: SettingsPort;
   history: HistoryPort;
   git?: GitPort;
+  /** Overlay-backed preview server (absent when there is no workspace folder). */
+  preview?: PreviewPort;
   /** Emit a message to the webview. */
   post(msg: HostToWebview): void;
   /**
@@ -204,6 +225,9 @@ export class SessionCore {
   private turnEpoch = 0;
   /** Monotonic counter for disk-only applies that have no commit sha. */
   private appliedSeq = 0;
+
+  /** The externally reachable URL of the current page preview, for "Open in Browser". */
+  private lastPreviewUrl: string | null = null;
 
   /** A highlighted editor region pinned as scoped context for the NEXT prompt. */
   private pendingSelection: SelectionContext | null = null;
@@ -350,6 +374,15 @@ export class SessionCore {
         return;
       case 'rebase':
         await this.onRebase();
+        return;
+      case 'openPreview':
+        await this.onOpenPreview(msg.path, msg.changesetId);
+        return;
+      case 'closePreview':
+        this.closePreview();
+        return;
+      case 'openPreviewExternal':
+        if (this.lastPreviewUrl) this.deps.preview?.openExternal(this.lastPreviewUrl);
         return;
       case 'listConversations':
         this.deps.post({ type: 'conversationList', items: await this.deps.history.list(msg.query) });
@@ -963,7 +996,7 @@ export class SessionCore {
       unifiedDiff: () => renderUnifiedDiff(this.changeset.view()),
       summary: () => {
         const s = this.changeset.summary();
-        return { filesChanged: s.filesChanged, additions: s.additions, deletions: s.deletions };
+        return { filesChanged: s.filesChanged, additions: s.additions, deletions: s.deletions, previewPath: s.previewPath };
       },
     };
 
@@ -1455,6 +1488,7 @@ export class SessionCore {
       message: commitInfo?.message ?? 'Applied to disk',
       changesetId: id,
       filesChanged,
+      previewPath: frozen.previewPath,
     });
 
     // Applied changes are on disk now — no longer staged.
@@ -1669,6 +1703,77 @@ export class SessionCore {
   }
 
   // -------------------------------------------------------------------------
+  // Preview
+  // -------------------------------------------------------------------------
+
+  /**
+   * Open a preview of a staged (or historical) artifact. Markdown entries render
+   * in the webview directly; everything else is served through the overlay preview
+   * server and rendered in an iframe.
+   *
+   * Live mode reads through the overlay (staged wins, disk fallback). History mode
+   * (`changesetId` naming a frozen committed changeset) can only serve pure disk —
+   * frozen hunks don't carry full file content — so it is best-effort; the commit
+   * was applied to disk anyway.
+   */
+  private async onOpenPreview(path?: string, changesetId?: string): Promise<void> {
+    const frozen = changesetId ? this.conv.committedChangesets?.[changesetId] : undefined;
+
+    let source: PreviewSource;
+    let entry: string | null;
+    if (frozen) {
+      // History mode: pure disk (frozen hunks can't reconstruct staged content).
+      source = { staged: async () => null };
+      entry = path ?? frozen.previewPath ?? null;
+    } else {
+      // Live mode: read through the overlay.
+      source = {
+        staged: async (p) => (this.overlay.has(p) ? { content: await this.overlay.read(p) } : null),
+      };
+      entry = path ?? detectPreviewEntry(this.overlay.ops());
+    }
+
+    if (!entry) {
+      this.toast('warn', 'Nothing previewable in this changeset.');
+      return;
+    }
+
+    if (entry.toLowerCase().endsWith('.md')) {
+      const content = frozen ? await this.deps.io.read(entry) : await this.overlay.read(entry);
+      if (content === null) {
+        this.toast('error', `Could not read ${entry}.`);
+        return;
+      }
+      this.deps.post({ type: 'preview', state: { kind: 'markdown', path: entry, content } });
+      return;
+    }
+
+    if (!this.deps.preview) {
+      this.toast('warn', "Preview isn't available in this environment.");
+      return;
+    }
+    try {
+      const { url } = await this.deps.preview.open(source, entry);
+      this.lastPreviewUrl = url;
+      this.deps.post({ type: 'preview', state: { kind: 'page', url, path: entry } });
+    } catch (err) {
+      this.toast('error', `Could not start the preview server: ${errMessage(err)}`);
+    }
+  }
+
+  /** Tear down the current preview: close the server (if any) and clear the view. */
+  private closePreview(): void {
+    this.deps.preview?.close();
+    this.lastPreviewUrl = null;
+    this.deps.post({ type: 'preview', state: null });
+  }
+
+  /** Release host resources when the owning webview is disposed. */
+  dispose(): void {
+    this.deps.preview?.close();
+  }
+
+  // -------------------------------------------------------------------------
   // Branch / conversation ops
   // -------------------------------------------------------------------------
 
@@ -1700,6 +1805,8 @@ export class SessionCore {
     // Kill any in-flight turn before swapping the conversation out from under it,
     // so its late gate/stream posts can't graft onto the fresh conversation.
     this.supersedeInFlightTurn();
+    // A preview of this conversation's overlay must not survive into the next one.
+    this.closePreview();
     const settings = await this.ensureSettings();
     this.conv = createConversation(settings.defaultModel, settings.harness.defaultMode);
     this.overlay = new StagingOverlay(this.deps.io);
@@ -1718,6 +1825,8 @@ export class SessionCore {
       this.toast('error', 'Conversation not found.');
       return;
     }
+    // A preview of the previous conversation's overlay must not survive the switch.
+    this.closePreview();
     this.conv = loaded;
     this.wireByNode.clear();
     this.restoreOverlayFor(loaded.currentLeafId);

--- a/src/extension/tabManager.ts
+++ b/src/extension/tabManager.ts
@@ -14,6 +14,7 @@ import type { Conversation, SelectionContext, SerializedOverlay } from '../share
 import type { WebviewToHost } from '../shared/protocol';
 import { createSessionCore, type SessionCore, type SessionDeps } from './session';
 import { WorkspaceIo } from './workspaceIo';
+import { PreviewServer } from './previewServer';
 import { SecretsStore } from './secrets';
 import { SettingsStore } from './settingsStore';
 import { HistoryStore } from './historyStore';
@@ -68,6 +69,7 @@ export class TabManager {
     panel.onDidDispose(() => {
       this.panels.delete(panel);
       this.liveSessions.delete(session);
+      session.dispose();
     });
     return panel;
   }
@@ -85,6 +87,7 @@ export class TabManager {
     this.homeSession = session;
     view.onDidDispose(() => {
       this.liveSessions.delete(session);
+      session.dispose();
       if (this.homeView === view) {
         this.homeView = null;
         this.homeSession = null;
@@ -200,6 +203,7 @@ export class TabManager {
 
   private attachSession(webview: vscode.Webview, seed?: Seed): SessionCore {
     const io = WorkspaceIo.forActiveWorkspace();
+    const folderUri = vscode.workspace.workspaceFolders?.[0]?.uri;
     // `session` is referenced by the onSettingsChanged closure below; it is
     // assigned before any message (hence any mutation) can arrive.
     let session: SessionCore;
@@ -209,6 +213,7 @@ export class TabManager {
       settings: this.settings,
       history: this.history,
       git: Git.forActiveWorkspace() ?? undefined,
+      preview: folderUri ? new PreviewServer(folderUri) : undefined,
       post: (msg) => {
         void webview.postMessage(msg);
       },
@@ -235,6 +240,8 @@ export class TabManager {
       `font-src ${webview.cspSource} data:`,
       `style-src ${webview.cspSource} 'unsafe-inline'`,
       `script-src 'nonce-${nonce}'`,
+      // The preview iframe loads from the local overlay server (and forwarded https URLs).
+      `frame-src http://localhost:* http://127.0.0.1:* https:`,
     ].join('; ');
     return `<!DOCTYPE html>
 <html lang="en">

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -14,6 +14,7 @@ import type {
   GateCard,
   HarnessMode,
   ModelRef,
+  PreviewState,
   ProviderConfig,
   RebaseState,
   SelectionContext,
@@ -60,6 +61,10 @@ export type WebviewToHost =
   | { type: 'applyAndCommit'; message?: string; coAuthor: boolean }
   | { type: 'requestCommitMessage' }                              // auto-generate
   | { type: 'rebase' }
+  // preview
+  | { type: 'openPreview'; path?: string; changesetId?: string }  // omit path = auto-detect; changesetId = frozen/history (disk-backed, best effort)
+  | { type: 'closePreview' }
+  | { type: 'openPreviewExternal' }                               // open current preview URL in the OS browser
   // history
   | { type: 'listConversations'; query?: string }
   | { type: 'openConversation'; id: string }
@@ -103,6 +108,7 @@ export type HostToWebview =
   | { type: 'turnFinished'; nodeId: string; usage: TokenUsage }
   // diff review
   | { type: 'changeset'; view: ChangeSetView | null }
+  | { type: 'preview'; state: PreviewState | null }
   | { type: 'rebaseState'; state: RebaseState }
   | { type: 'commitMessage'; message: string }
   | { type: 'applied'; committed: boolean; sha?: string; error?: string }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -86,6 +86,8 @@ export interface ChangesSummary {
   filesChanged: number;
   additions: number;
   deletions: number;
+  /** Workspace-relative entry point the changeset can be previewed from, when artifact detection found one. */
+  previewPath?: string;
 }
 
 export interface CommitRecord {
@@ -93,6 +95,8 @@ export interface CommitRecord {
   message: string;
   changesetId: string;
   filesChanged: number;
+  /** Workspace-relative entry point the changeset can be previewed from, when artifact detection found one. */
+  previewPath?: string;
 }
 
 /** A node in the conversation tree. */
@@ -197,12 +201,19 @@ export interface ChangeSetView {
   totalChanges: number;        // number of hunks
   additions: number;
   deletions: number;
+  /** Workspace-relative entry point the changeset can be previewed from, when artifact detection found one. */
+  previewPath?: string;
 }
 
 export interface RebaseState {
   needed: boolean;
   conflictedPaths: string[];
 }
+
+/** What the Preview view renders. */
+export type PreviewState =
+  | { kind: 'page'; url: string; path: string }          // iframe → overlay server
+  | { kind: 'markdown'; path: string; content: string }; // in-webview render
 
 // ---------------------------------------------------------------------------
 // Coop harness
@@ -231,6 +242,8 @@ export interface GateCard {
   attempt?: number;            // builder/inspector retry round
   /** Token usage this role spent (shown dimmed in the card footer). */
   usage?: TokenUsage;
+  /** Workspace-relative entry point the changeset can be previewed from, when artifact detection found one. */
+  previewPath?: string;
 }
 
 export interface HarnessSettings {

--- a/src/webview/components/DiffViewer.tsx
+++ b/src/webview/components/DiffViewer.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { ChangeSetView, FileDiff, DiffHunk, RebaseState } from '../../shared/types';
 import { Dropdown, Modal } from './common';
 import { post, store } from './store';
-import { IconX, IconChevronDown, IconFile, IconCheck, IconGit, IconAlert } from './icons';
+import { IconX, IconChevronDown, IconFile, IconCheck, IconGit, IconAlert, IconEye } from './icons';
 
 interface FlatHunk {
   file: FileDiff;
@@ -95,6 +95,15 @@ export function DiffViewer({
         <span class="fp-tokens" style={{ fontSize: '13px' }}>
           <span class="fp-add">+{view.additions}</span> <span class="fp-del">-{view.deletions}</span>
         </span>
+        {view.previewPath && (
+          <button
+            type="button"
+            class="fp-btn fp-btn-secondary fp-btn-sm"
+            onClick={() => store.openPreview(view.previewPath, readOnly ? view.id : undefined)}
+          >
+            <IconEye size={14} /> Preview
+          </button>
+        )}
         <button type="button" class="fp-icon-btn" onClick={close} aria-label="Close diff (Esc)"><IconX /></button>
       </div>
 

--- a/src/webview/components/PreviewPanel.tsx
+++ b/src/webview/components/PreviewPanel.tsx
@@ -1,0 +1,58 @@
+/** Full-screen preview of a staged artifact: an overlay-served page, or rendered Markdown. */
+import { useEffect, useState } from 'preact/hooks';
+import type { PreviewState } from '../../shared/types';
+import { Markdown } from './common';
+import { post } from './store';
+import { IconX, IconFile, IconRefresh, IconExternalLink } from './icons';
+
+export function PreviewPanel({ state }: { state: PreviewState }) {
+  // Bumping this remounts the iframe, forcing a reload without changing the URL.
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const close = () => post({ type: 'closePreview' });
+
+  // Esc closes (mirrors the diff viewer, minus its j/k navigation).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === 'TEXTAREA' || tag === 'INPUT') return;
+      if (e.key === 'Escape') close();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, []);
+
+  return (
+    <div class="fp-preview">
+      <div class="fp-preview-header">
+        <IconFile size={15} />
+        <span class="fp-preview-path">{state.path}</span>
+        <div class="fp-spacer" />
+        {state.kind === 'page' && (
+          <>
+            <button type="button" class="fp-btn fp-btn-secondary fp-btn-sm" onClick={() => setReloadKey((k) => k + 1)}>
+              <IconRefresh size={14} /> Refresh
+            </button>
+            <button type="button" class="fp-btn fp-btn-secondary fp-btn-sm" onClick={() => post({ type: 'openPreviewExternal' })}>
+              <IconExternalLink size={14} /> Open in Browser
+            </button>
+          </>
+        )}
+        <button type="button" class="fp-icon-btn" onClick={close} aria-label="Close preview (Esc)"><IconX /></button>
+      </div>
+
+      {state.kind === 'page' ? (
+        <iframe
+          key={reloadKey}
+          class="fp-preview-frame"
+          src={state.url}
+          sandbox="allow-scripts allow-same-origin allow-forms"
+        />
+      ) : (
+        <div class="fp-preview-md">
+          <Markdown text={state.content} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/webview/components/blocks.tsx
+++ b/src/webview/components/blocks.tsx
@@ -41,6 +41,11 @@ function fmtTokens(n: number): string {
   return String(n);
 }
 
+/** Last path segment, for compact Preview button labels. */
+function basename(path: string): string {
+  return path.slice(path.lastIndexOf('/') + 1);
+}
+
 export function ThinkingBlock({ text, durationMs }: { text: string; durationMs?: number }) {
   return (
     <Collapsible
@@ -175,9 +180,16 @@ export function GateCardView({ card }: { card: GateCard }) {
           </div>
         )}
         {card.role === 'hitl' && (
-          <button type="button" class="fp-btn fp-btn-primary fp-btn-sm" onClick={() => store.openReview()} style={{ alignSelf: 'flex-start' }}>
-            <IconDiff size={15} /> Review Changes
-          </button>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <button type="button" class="fp-btn fp-btn-primary fp-btn-sm" onClick={() => store.openReview()}>
+              <IconDiff size={15} /> Review Changes
+            </button>
+            {card.previewPath && (
+              <button type="button" class="fp-btn fp-btn-secondary fp-btn-sm" onClick={() => store.openPreview(card.previewPath)}>
+                <IconEye size={15} /> Preview {basename(card.previewPath)}
+              </button>
+            )}
+          </div>
         )}
         {card.usage && (card.usage.inputTokens > 0 || card.usage.outputTokens > 0) && (
           <div
@@ -195,7 +207,7 @@ export function GateCardView({ card }: { card: GateCard }) {
 export function ChangesBlock({
   summary,
 }: {
-  summary: { changesetId: string; filesChanged: number; additions: number; deletions: number };
+  summary: { changesetId: string; filesChanged: number; additions: number; deletions: number; previewPath?: string };
 }) {
   return (
     <div class="fp-changes">
@@ -207,6 +219,11 @@ export function ChangesBlock({
           <span class="fp-add">+{summary.additions}</span> <span class="fp-del">-{summary.deletions}</span>
         </div>
       </div>
+      {summary.previewPath && (
+        <button type="button" class="fp-btn fp-btn-secondary" onClick={() => store.openPreview(summary.previewPath)}>
+          <IconEye size={16} /> Preview
+        </button>
+      )}
       <button type="button" class="fp-btn fp-btn-primary" onClick={() => store.openReview(summary.changesetId)}>
         <IconDiff size={16} /> Review Changes
       </button>
@@ -217,7 +234,7 @@ export function ChangesBlock({
 export function CommitBlock({
   commit,
 }: {
-  commit: { sha: string; message: string; changesetId: string; filesChanged: number };
+  commit: { sha: string; message: string; changesetId: string; filesChanged: number; previewPath?: string };
 }) {
   return (
     <div class="fp-commit">
@@ -227,9 +244,16 @@ export function CommitBlock({
         <span style={{ color: 'var(--fp-fg-muted)', fontSize: '12px' }}>{commit.filesChanged} files</span>
       </div>
       <div class="fp-commit-msg">{commit.message}</div>
-      <button type="button" class="fp-btn-ghost" onClick={() => store.openReview(commit.changesetId, true)} style={{ padding: 0, color: 'var(--fp-accent)' }}>
-        View Changes <IconArrowRight size={14} />
-      </button>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+        <button type="button" class="fp-btn-ghost" onClick={() => store.openReview(commit.changesetId, true)} style={{ padding: 0, color: 'var(--fp-accent)' }}>
+          View Changes <IconArrowRight size={14} />
+        </button>
+        {commit.previewPath && (
+          <button type="button" class="fp-btn-ghost" onClick={() => store.openPreview(commit.previewPath, commit.changesetId)} style={{ padding: 0, color: 'var(--fp-accent)' }}>
+            <IconEye size={14} /> Preview
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/webview/components/icons.tsx
+++ b/src/webview/components/icons.tsx
@@ -41,6 +41,8 @@ export const IconTrash = (p: P) => svg(<><path d="M3 6h18M19 6v14a2 2 0 0 1-2 2H
 export const IconCopy = (p: P) => svg(<><rect x="9" y="9" width="13" height="13" rx="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></>, p);
 export const IconFile = (p: P) => svg(<><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6" /></>, p);
 export const IconDiff = (p: P) => svg(<><path d="M12 3v18M5 8l-3 3 3 3M19 8l3 3-3 3" /></>, p);
+export const IconExternalLink = (p: P) => svg(<><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" /><path d="M15 3h6v6" /><path d="M10 14L21 3" /></>, p);
+export const IconRefresh = (p: P) => svg(<><path d="M23 4v6h-6" /><path d="M1 20v-6h6" /><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" /></>, p);
 export const IconGit = (p: P) => svg(<><circle cx="12" cy="5" r="2" /><circle cx="6" cy="19" r="2" /><circle cx="18" cy="12" r="2" /><path d="M12 7v6a4 4 0 0 0 4 4M6 17V7" /></>, p);
 export const IconWrench = (p: P) => svg(<path d="M14.7 6.3a4 4 0 0 0-5.4 5.4L3 18l3 3 6.3-6.3a4 4 0 0 0 5.4-5.4l-2.6 2.6-2.4-.6-.6-2.4z" />, p);
 export const IconShield = (p: P) => svg(<><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" /></>, p);

--- a/src/webview/components/store.tsx
+++ b/src/webview/components/store.tsx
@@ -8,6 +8,7 @@ import type {
   Conversation,
   ChangeSetView,
   CoopRole,
+  PreviewState,
   RebaseState,
   ConversationSummary,
   FowlPlaySettings,
@@ -21,7 +22,7 @@ import type {
 import type { HostToWebview, WebviewToHost } from '../../shared/protocol';
 import { getBridge } from '../bridge';
 
-export type View = 'chat' | 'diff' | 'settings' | 'history' | 'onboarding';
+export type View = 'chat' | 'diff' | 'preview' | 'settings' | 'history' | 'onboarding';
 
 export interface Toast {
   id: number;
@@ -46,6 +47,7 @@ export interface AppState {
   selectionContext: SelectionContext | null;
   changeset: ChangeSetView | null;
   diffReadOnly: boolean;
+  preview: PreviewState | null;
   rebase: RebaseState;
   commitMessage: string;
   historyItems: ConversationSummary[];
@@ -69,6 +71,7 @@ const initialState: AppState = {
   selectionContext: null,
   changeset: null,
   diffReadOnly: false,
+  preview: null,
   rebase: { needed: false, conflictedPaths: [] },
   commitMessage: '',
   historyItems: [],
@@ -112,6 +115,15 @@ class Store {
   openReview(changesetId?: string, readOnly = false) {
     this.patch({ view: 'diff', diffReadOnly: readOnly });
     getBridge().post({ type: 'openDiff', changesetId });
+  }
+
+  /**
+   * Ask the host to open a preview. The view switch happens only when the host
+   * answers with a `preview` message — the host may instead toast "nothing
+   * previewable", so we do NOT switch optimistically.
+   */
+  openPreview(path?: string, changesetId?: string) {
+    getBridge().post({ type: 'openPreview', path, changesetId });
   }
 
   /** Drop the mention picker without answering (the user moved on to a new prompt). */
@@ -171,6 +183,13 @@ class Store {
         // The changeset went away (e.g. applied/discarded) while reviewing it →
         // don't strand the user on an empty diff view.
         if (!msg.view && this.state.view === 'diff') this.patch({ view: 'chat' });
+        break;
+      case 'preview':
+        this.patch({ preview: msg.state });
+        // Host answered an openPreview → show the preview view.
+        if (msg.state && this.state.view !== 'preview') this.patch({ view: 'preview' });
+        // Preview closed while viewing it → return to chat.
+        if (!msg.state && this.state.view === 'preview') this.patch({ view: 'chat' });
         break;
       case 'rebaseState':
         this.patch({ rebase: msg.state });

--- a/src/webview/index.tsx
+++ b/src/webview/index.tsx
@@ -6,6 +6,7 @@ import type { Conversation } from '../shared/types';
 import { activePath, initStore, post, store, useStore } from './components/store';
 import { Chat } from './components/Chat';
 import { DiffViewer } from './components/DiffViewer';
+import { PreviewPanel } from './components/PreviewPanel';
 import { Settings } from './components/Settings';
 import { HistoryPanel } from './components/HistoryPanel';
 import { Onboarding } from './components/Onboarding';
@@ -30,6 +31,7 @@ function App() {
   const conversation = useStore((s) => s.conversation);
   const streaming = useStore((s) => s.streaming);
   const changeset = useStore((s) => s.changeset);
+  const preview = useStore((s) => s.preview);
   const rebase = useStore((s) => s.rebase);
   const diffReadOnly = useStore((s) => s.diffReadOnly);
   const commitMessage = useStore((s) => s.commitMessage);
@@ -53,6 +55,12 @@ function App() {
           <DiffViewer view={changeset} rebase={rebase} readOnly={diffReadOnly} commitMessage={commitMessage} />
         ) : (
           <div class="fp-empty" style={{ marginTop: 80 }}>No changeset to review.</div>
+        ))}
+      {view === 'preview' &&
+        (preview ? (
+          <PreviewPanel state={preview} />
+        ) : (
+          <div class="fp-empty" style={{ marginTop: 80 }}>Nothing to preview.</div>
         ))}
       {view === 'chat' && (
         <Chat conv={conversation} settings={settings} streaming={streaming} changeCount={changeCount} />

--- a/src/webview/theme.css
+++ b/src/webview/theme.css
@@ -671,6 +671,16 @@ table.fp-difftable { width: 100%; border-collapse: collapse; font-family: var(--
 .fp-banner-readonly { background: var(--fp-bg-sunken); color: var(--fp-fg-muted); border-bottom: 1px solid var(--fp-border); }
 
 /* =====================================================================
+   Preview
+   ===================================================================== */
+.fp-preview { display: flex; flex-direction: column; flex: 1; overflow: hidden; }
+.fp-preview-header { display: flex; align-items: center; gap: 10px; padding: 10px 16px; border-bottom: 1px solid var(--fp-border); flex-shrink: 0; }
+.fp-preview-path { font-family: var(--fp-font); font-weight: 700; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.fp-preview-frame { flex: 1; width: 100%; border: 0; background: #fff; }
+.fp-preview-md { flex: 1; overflow-y: auto; padding: 24px; }
+.fp-preview-md > * { max-width: 820px; margin-left: auto; margin-right: auto; }
+
+/* =====================================================================
    History
    ===================================================================== */
 .fp-history-search { margin-bottom: 16px; }

--- a/test/extension-session.test.ts
+++ b/test/extension-session.test.ts
@@ -28,6 +28,8 @@ import {
   type DiskIo,
   type GitPort,
   type HistoryPort,
+  type PreviewPort,
+  type PreviewSource,
   type SecretsPort,
   type SessionDeps,
   type SettingsPort,
@@ -2487,5 +2489,150 @@ describe('rebase button — drifted MODIFY whose hunks cannot apply', () => {
     expect(t).toHaveLength(1);
     expect(t[0]).toMatchObject({ level: 'warn' });
     expect(t[0].message).toMatch(/could not be resolved: foo\.txt/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Preview (overlay-backed)
+// ---------------------------------------------------------------------------
+
+/** A PreviewPort fake that records opens/closes and captures the source it is handed. */
+class FakePreview implements PreviewPort {
+  opened: { source: PreviewSource; entry: string }[] = [];
+  closed = 0;
+  external: string[] = [];
+  async open(source: PreviewSource, entryPath: string): Promise<{ url: string }> {
+    this.opened.push({ source, entry: entryPath });
+    return { url: `http://preview.test/${entryPath}` };
+  }
+  close() {
+    this.closed += 1;
+  }
+  openExternal(url: string) {
+    this.external.push(url);
+  }
+}
+
+/**
+ * A session wired with a FakePreview. `edits` is the single edit_files tool call the
+ * (solo) build turn stages, so a test can seed the overlay with exactly the ops it needs.
+ */
+function makePreviewSession(edits: unknown[]) {
+  const io = new FakeIo();
+  const posted: HostToWebview[] = [];
+  const preview = new FakePreview();
+  const adapter: ProviderAdapter = {
+    chat(request: ChatRequest) {
+      const hasToolResult = request.messages.some((m) => m.role === 'tool');
+      const events: StreamEvent[] = hasToolResult
+        ? textEvents('done')
+        : [
+            { type: 'tool_call_start', id: 't1', name: 'edit_files' },
+            { type: 'tool_call_args', id: 't1', delta: JSON.stringify({ edits }) },
+            { type: 'tool_call_end', id: 't1' },
+            USAGE,
+            { type: 'done', stopReason: 'tool_use' },
+          ];
+      return (async function* () {
+        for (const e of events) yield e;
+      })();
+    },
+  };
+  const deps: SessionDeps = {
+    io,
+    secrets: new FakeSecrets(),
+    settings: new FakeSettings('solo'),
+    history: new FakeHistory(),
+    git: fakeGit,
+    preview,
+    post: (m) => posted.push(m),
+    createAdapter: () => adapter,
+    fetchModels: async () => [{ id: 'm1' }],
+    clock: () => Date.now(),
+  };
+  return { session: createSessionCore(deps), posted, io, preview };
+}
+
+function lastPreview(posted: HostToWebview[]) {
+  for (let i = posted.length - 1; i >= 0; i--) {
+    const m = posted[i];
+    if (m.type === 'preview') return m.state;
+  }
+  return undefined;
+}
+
+describe('preview', () => {
+  it('opens the overlay server for a staged page and reads staged/deleted/untracked correctly', async () => {
+    const { session, posted, io, preview } = makePreviewSession([
+      { path: 'index.html', create: '<h1>hi</h1>' },
+      { path: 'old.txt', delete: true },
+    ]);
+    io.files.set('old.txt', 'goodbye'); // exists on disk so the delete stages
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'build a page' });
+
+    await session.handle({ type: 'openPreview' });
+
+    // Port opened with the detected html entry.
+    expect(preview.opened).toHaveLength(1);
+    expect(preview.opened[0].entry).toBe('index.html');
+
+    // The webview got a page preview carrying the returned URL.
+    const state = lastPreview(posted);
+    expect(state).toEqual({ kind: 'page', url: 'http://preview.test/index.html', path: 'index.html' });
+
+    // The captured source reads through the overlay: staged content, staged delete, untracked.
+    const source = preview.opened[0].source;
+    expect(await source.staged('index.html')).toEqual({ content: '<h1>hi</h1>' });
+    expect(await source.staged('old.txt')).toEqual({ content: null }); // staged delete → must 404
+    expect(await source.staged('never-touched.css')).toBeNull(); // untracked → disk fallback
+  });
+
+  it('renders a staged Markdown entry in-webview without opening the server', async () => {
+    const { session, posted, preview } = makePreviewSession([{ path: 'notes.md', create: '# Notes\n' }]);
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'write notes' });
+
+    await session.handle({ type: 'openPreview' });
+
+    expect(preview.opened).toHaveLength(0); // no server for markdown
+    expect(lastPreview(posted)).toEqual({ kind: 'markdown', path: 'notes.md', content: '# Notes\n' });
+  });
+
+  it('warns and posts no preview when nothing is previewable', async () => {
+    const { session, posted, preview } = makePreviewSession([{ path: 'main.ts', create: 'export {};\n' }]);
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'write code' });
+
+    const before = posted.length;
+    await session.handle({ type: 'openPreview' });
+
+    expect(preview.opened).toHaveLength(0);
+    expect(posted.slice(before).some((m) => m.type === 'preview')).toBe(false);
+    expect(posted.slice(before).some((m) => m.type === 'toast' && m.level === 'warn')).toBe(true);
+  });
+
+  it('closePreview closes the port and posts a null preview', async () => {
+    const { session, posted, preview } = makePreviewSession([{ path: 'index.html', create: '<h1>hi</h1>' }]);
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'build a page' });
+    await session.handle({ type: 'openPreview' });
+
+    const before = posted.length;
+    await session.handle({ type: 'closePreview' });
+
+    expect(preview.closed).toBeGreaterThan(0);
+    expect(lastPreview(posted.slice(before))).toBeNull();
+  });
+
+  it('newConversation closes the preview', async () => {
+    const { session, preview } = makePreviewSession([{ path: 'index.html', create: '<h1>hi</h1>' }]);
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'build a page' });
+    await session.handle({ type: 'openPreview' });
+
+    const before = preview.closed;
+    await session.handle({ type: 'newConversation' });
+    expect(preview.closed).toBeGreaterThan(before);
   });
 });

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { previewCandidates, detectPreviewEntry } from '../src/core/staging/preview';
+import { sanitizePreviewPath, mimeFor } from '../src/extension/previewHttp';
+import type { FileOp } from '../src/shared/types';
+
+describe('previewCandidates', () => {
+  it('orders by extension priority: html > htm > svg > md', () => {
+    const ordered = previewCandidates(['a.md', 'b.svg', 'c.htm', 'd.html']);
+    expect(ordered).toEqual(['d.html', 'c.htm', 'b.svg', 'a.md']);
+  });
+
+  it('prefers index.html over other html pages', () => {
+    const ordered = previewCandidates(['about.html', 'index.html', 'contact.html']);
+    expect(ordered[0]).toBe('index.html');
+  });
+
+  it('prefers a shallower path when extension and index-ness tie', () => {
+    const ordered = previewCandidates(['deep/nested/page.html', 'top.html']);
+    expect(ordered[0]).toBe('top.html');
+  });
+
+  it('breaks remaining ties alphabetically', () => {
+    const ordered = previewCandidates(['b.html', 'a.html']);
+    expect(ordered).toEqual(['a.html', 'b.html']);
+  });
+
+  it('drops non-previewable extensions', () => {
+    expect(previewCandidates(['main.ts', 'style.css', 'page.html'])).toEqual(['page.html']);
+  });
+
+  it('matches extensions case-insensitively', () => {
+    expect(previewCandidates(['PAGE.HTML'])).toEqual(['PAGE.HTML']);
+  });
+});
+
+describe('detectPreviewEntry', () => {
+  const create = (path: string): FileOp => ({ kind: 'create', path, staged: '' });
+
+  it('returns the best entry among non-deleted ops', () => {
+    const ops: FileOp[] = [create('notes.md'), create('index.html')];
+    expect(detectPreviewEntry(ops)).toBe('index.html');
+  });
+
+  it('excludes deleted ops', () => {
+    const ops: FileOp[] = [{ kind: 'delete', path: 'index.html', base: '<html/>' }, create('notes.md')];
+    expect(detectPreviewEntry(ops)).toBe('notes.md');
+  });
+
+  it('returns null when nothing is previewable', () => {
+    expect(detectPreviewEntry([create('main.ts')])).toBeNull();
+  });
+
+  it('returns null for an empty op list', () => {
+    expect(detectPreviewEntry([])).toBeNull();
+  });
+});
+
+describe('sanitizePreviewPath', () => {
+  const token = 'tok';
+
+  it('resolves the token root to the entry path', () => {
+    expect(sanitizePreviewPath('/tok/', token, 'site/index.html')).toBe('site/index.html');
+  });
+
+  it('returns the requested asset path under the token', () => {
+    expect(sanitizePreviewPath('/tok/site/style.css', token, 'site/index.html')).toBe('site/style.css');
+  });
+
+  it('rejects a missing token', () => {
+    expect(sanitizePreviewPath('/site/index.html', token, 'index.html')).toBeNull();
+  });
+
+  it('rejects a wrong token', () => {
+    expect(sanitizePreviewPath('/nope/index.html', token, 'index.html')).toBeNull();
+  });
+
+  it('rejects raw .. traversal', () => {
+    expect(sanitizePreviewPath('/tok/../secret.txt', token, 'index.html')).toBeNull();
+  });
+
+  it('rejects URL-encoded .. traversal', () => {
+    expect(sanitizePreviewPath('/tok/%2e%2e/secret.txt', token, 'index.html')).toBeNull();
+  });
+
+  it('rejects backslashes', () => {
+    expect(sanitizePreviewPath('/tok/..\\secret.txt', token, 'index.html')).toBeNull();
+  });
+
+  it('strips query strings', () => {
+    expect(sanitizePreviewPath('/tok/app.js?v=2', token, 'index.html')).toBe('app.js');
+  });
+
+  it('decodes %20', () => {
+    expect(sanitizePreviewPath('/tok/my%20page.html', token, 'index.html')).toBe('my page.html');
+  });
+});
+
+describe('mimeFor', () => {
+  it('serves html as text/html with charset', () => {
+    expect(mimeFor('index.html')).toBe('text/html; charset=utf-8');
+  });
+  it('serves svg as image/svg+xml with charset', () => {
+    expect(mimeFor('logo.svg')).toBe('image/svg+xml; charset=utf-8');
+  });
+  it('serves js as text/javascript with charset', () => {
+    expect(mimeFor('app.mjs')).toBe('text/javascript; charset=utf-8');
+  });
+  it('serves png without charset', () => {
+    expect(mimeFor('icon.png')).toBe('image/png');
+  });
+  it('falls back to octet-stream for unknown extensions', () => {
+    expect(mimeFor('data.bin')).toBe('application/octet-stream');
+  });
+});

--- a/test/staging.test.ts
+++ b/test/staging.test.ts
@@ -22,6 +22,24 @@ describe('StagingOverlay edge transitions', () => {
     expect(await o.read('a.ts')).toBe('staged');
   });
 
+  it('changeset view() and summary() expose the detected preview entry', async () => {
+    const disk = new MockDisk();
+    const o = new StagingOverlay(disk);
+    await o.stageCreate('src/main.ts', 'export {};');
+    await o.stageCreate('site/index.html', '<h1>hi</h1>');
+    const cs = new ChangeSet(o, 'cs');
+    expect(cs.view().previewPath).toBe('site/index.html');
+    expect(cs.summary().previewPath).toBe('site/index.html');
+  });
+
+  it('changeset previewPath is undefined when nothing is previewable', async () => {
+    const disk = new MockDisk();
+    const o = new StagingOverlay(disk);
+    await o.stageCreate('src/main.ts', 'export {};');
+    const cs = new ChangeSet(o, 'cs');
+    expect(cs.view().previewPath).toBeUndefined();
+  });
+
   it('modify captures base from disk on first touch', async () => {
     const disk = new MockDisk({ 'a.ts': 'original' });
     const o = new StagingOverlay(disk);


### PR DESCRIPTION
Adds a Preview capability to changesets: when staged ops contain a renderable entry point (html > svg > md, `index.html` preferred), a Preview button appears on the HITL gate card, the Review Changes block, commit blocks, and the diff viewer header.

Markdown renders in-webview with the existing Markdown component. Everything else is served by a loopback `node:http` overlay server that reads through the staging overlay — staged content wins, staged deletes 404, untracked paths fall back to disk — so multi-file static sites preview faithfully with zero disk writes. Binds 127.0.0.1 on an ephemeral port behind a per-instance random token path prefix; URLs go through `vscode.env.asExternalUri` so remote setups get port forwarding for free.

Verification: `tsc --noEmit` clean, 374 unit tests, 102 + 35 e2e assertions, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG)_