### PR TITLE
Enforce story scope in PRD builds; Mark done reconciliation

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -265,10 +265,20 @@ review between each.
      that story's spec file. Each story — including a retry — runs from its **spec alone in a
      fresh context window**, not the running chat history, so a retry is a genuine clean
      restart and no earlier story's transcript pollutes it. Earlier stories' work is already
-     on disk (staged or applied), and the Builder is told to read those files rather than
-     assume.
+     on disk (staged or applied) and **may be read** to integrate correctly — but the story's
+     spec is its **entire scope**. The Builder is told not to open the PRD or implement other
+     stories, and (when the PRD came in as a file) reading the PRD document back during a story
+     build returns a short "this is out of scope" stub instead of its text. The Inspector, for
+     its part, treats work that clearly reaches beyond the story's criteria as a **finding**
+     (route-back), not bonus work — so one story can't quietly build the whole product.
    - If a story was **cancelled** mid-build (it shows as pending), **Resume story N** re-runs
-     it — nothing is skipped that never happened.
+     it — nothing is skipped that never happened. If the cancelled build had already **staged
+     changes**, the outcome says so: those changes stay in the changeset, so you can either
+     Resume (re-run from the spec) or review/apply what's staged and press **Mark done**.
+   - **Mark done** (offered on a pending or failed cursor story) is the human reconciliation
+     for a story that reality outran: it marks the story done and advances the cursor **without**
+     building anything, for when the staged changes already satisfy it. The spec file notes it
+     was *marked done by user*.
 6. A **pinned PRD bar** sits just above the composer for the whole build: it shows
    "N of M done · story K …" and repeats the current story's action buttons, so you can
    retry, skip, or continue without scrolling back up to the plan block after a story has

--- a/e2e/mockBridge.js
+++ b/e2e/mockBridge.js
@@ -58,6 +58,11 @@
       if (msg && msg.type === 'retryStory') {
         /* no-op ack — protocol stays mirrored */
       }
+      // markStoryDone (human marks the cursor story done + advances) is likewise
+      // acked as a no-op — no scripted scenario drives the per-story loop.
+      if (msg && msg.type === 'markStoryDone') {
+        /* no-op ack — protocol stays mirrored */
+      }
       // Composer `@` autocomplete: serve a small static file list, filtered by the
       // query (case-insensitive substring) exactly as the real host would.
       if (msg && msg.type === 'listFiles') {

--- a/src/core/harness/coop.ts
+++ b/src/core/harness/coop.ts
@@ -118,6 +118,12 @@ export interface CoopPipelineOptions {
    * preserves the exact single-call path — the extension supplies this.
    */
   diffBudgetFor?: (role: CoopRole) => number | undefined;
+  /**
+   * True when this pipeline run is building ONE story of a decomposed PRD. It tightens the
+   * Inspector's prompt so work reaching clearly beyond this story's criteria is a finding
+   * (route-back), not praised bonus work. Non-story Coop turns leave it false — unchanged.
+   */
+  storyMode?: boolean;
   signal?: AbortSignal;
 }
 
@@ -184,7 +190,7 @@ export interface CoopResult {
 // ---------------------------------------------------------------------------
 
 export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopResult> {
-  const { userPrompt, contextDigest, runner, inspector, buildStage, settings, onGate, modelLabelFor, diffBudgetFor, signal } = opts;
+  const { userPrompt, contextDigest, runner, inspector, buildStage, settings, onGate, modelLabelFor, diffBudgetFor, storyMode, signal } = opts;
   const labelFor = (role: CoopRole): string | undefined => modelLabelFor?.(role);
 
   const usage: TokenUsage = { inputTokens: 0, outputTokens: 0, cachedTokens: 0 };
@@ -474,7 +480,7 @@ export async function runCoopPipeline(opts: CoopPipelineOptions): Promise<CoopRe
     const inspectorReview = await runReview(
       'inspector',
       INSPECTOR_SYSTEM,
-      (chunk) => composeInspectorPrompt(scout.criteria, chunk),
+      (chunk) => composeInspectorPrompt(scout.criteria, chunk, storyMode),
       diff,
       (t) => bumpCard(inspectorCard, t),
     );

--- a/src/core/harness/prd.ts
+++ b/src/core/harness/prd.ts
@@ -206,7 +206,7 @@ function slug(title: string): string {
  * PRD, then the full spec markdown. `index`/`total` are 1-based.
  */
 export function composeStoryPrompt(specMarkdown: string, index: number, total: number): string {
-  return `Story ${index} of ${total} decomposed from a PRD. Implement ONLY this story. Earlier stories' work is already staged or applied in the workspace — read the files rather than assuming.
+  return `Story ${index} of ${total} decomposed from a PRD. Implement ONLY this story. Earlier stories' work is already in the workspace and may be READ to integrate correctly — but the spec below is the ENTIRE scope of this story. Do NOT open the PRD document, and do NOT implement other stories' features.
 
 ${specMarkdown.trim()}`;
 }

--- a/src/core/harness/roles.ts
+++ b/src/core/harness/roles.ts
@@ -299,14 +299,33 @@ ${findings.map((f, i) => `${i + 1}. ${f}`).join('\n')}
 Address every finding above. Keep the diff minimal and do not reintroduce prior defects.`;
 }
 
-/** Prompt handed to the Inspector: criteria + the fresh unified diff, no Builder notes. */
-export function composeInspectorPrompt(criteria: readonly string[], unifiedDiff: string): string {
+/**
+ * Prompt handed to the Inspector: criteria + the fresh unified diff, no Builder notes. In
+ * `storyScope` mode (a single story of a decomposed PRD) the Inspector also polices scope in
+ * the OTHER direction: work reaching clearly beyond this story's criteria is a finding, not
+ * bonus work — so a Builder that implemented the whole PRD gets routed back, not approved.
+ */
+export function composeInspectorPrompt(
+  criteria: readonly string[],
+  unifiedDiff: string,
+  storyScope = false,
+): string {
   const diff = unifiedDiff.trim() || '(the changeset is empty — no diff was produced)';
+  const scope = storyScope
+    ? `
+
+SCOPE — THIS IS ONE STORY OF A LARGER PRD
+The diff must satisfy the criteria above and stay within them. Changes clearly BEYOND this
+story's acceptance criteria — implementing other stories' features, building the rest of the
+product, opening and acting on the whole PRD — are OUT OF SCOPE. Report each as a finding
+("out of scope for this story: <what>") and REJECT; extra work is not bonus work to praise,
+it enlarges the diff and pre-empts stories the human has not reviewed yet.`
+    : '';
   return `Validate the following changeset against the acceptance criteria. You have not
 been given the Builder's reasoning — judge only from the diff.
 
 ACCEPTANCE CRITERIA
-${criteriaBlock(criteria)}
+${criteriaBlock(criteria)}${scope}
 
 UNIFIED DIFF
 ${diff}`;

--- a/src/extension/session.ts
+++ b/src/extension/session.ts
@@ -306,6 +306,9 @@ export class SessionCore {
       case 'retryStory':
         await this.rerunCursorStory('Retry');
         return;
+      case 'markStoryDone':
+        await this.onMarkStoryDone();
+        return;
       case 'cancelResponse':
         this.abort?.abort();
         return;
@@ -808,9 +811,25 @@ export class SessionCore {
         : this.conv.harnessMode === 'coop'
           ? 'builder'
           : undefined;
-    const userText = opts.storyIndex !== undefined
-      ? rawUserText
-      : await this.expandWireFileMentions(rawUserText, settings, budgetRole);
+    let userText: string;
+    let includedMentionPaths: string[] = [];
+    if (opts.storyIndex !== undefined) {
+      userText = rawUserText;
+    } else {
+      const expanded = await this.expandWireFileMentions(rawUserText, settings, budgetRole);
+      userText = expanded.text;
+      includedMentionPaths = expanded.includedPaths;
+    }
+    // A PRD that arrived as exactly one included markdown file records its path on the plan,
+    // so story builds can guard reads of it (a Builder must not re-open the whole PRD). A
+    // pasted-raw PRD, or one with multiple/zero markdown mentions, leaves sourcePath undefined
+    // and the guard stays inert.
+    const prdSourcePath = opts.prd
+      ? ((): string | undefined => {
+          const md = includedMentionPaths.filter((p) => /\.md$/i.test(p));
+          return md.length === 1 ? md[0] : undefined;
+        })()
+      : undefined;
     const baseWire = this.wireBaseFor(userNodeId);
     // Condensed prior-conversation context for the planning roles (Scout/Foreman),
     // so a terse follow-up or a clarification reply is judged against the real goal.
@@ -830,7 +849,7 @@ export class SessionCore {
     let usage: TokenUsage = emptyUsage();
     try {
       if (opts.prd) {
-        const out = await this.runPrd(userText, imageParts, resolved, settings.harness, signal, epoch, assistantId, contextDigest);
+        const out = await this.runPrd(userText, imageParts, resolved, settings.harness, signal, epoch, assistantId, contextDigest, prdSourcePath);
         blocks = out.blocks;
         usage = out.usage;
       } else if (opts.storyIndex !== undefined) {
@@ -965,8 +984,13 @@ export class SessionCore {
     epoch: number,
     nodeId: string,
     contextDigest?: string,
+    storyMode = false,
   ): Promise<CoopResult> {
     const settings = await this.ensureSettings();
+    // During a story build, guard the PRD source document: reading it through any read tool
+    // returns a stub so the Builder can't re-open the whole PRD and implement everything. The
+    // guard is inert when the plan has no recorded sourcePath (pasted-raw PRD).
+    const guardPath = storyMode ? this.conv.prdPlan?.sourcePath : undefined;
     const runner: RoleRunner = {
       run: async ({ role, system, userPrompt: rolePrompt, readOnly, signal: s, onProgress }) => {
         // Each role resolves its own model through the override chain, falling
@@ -981,7 +1005,7 @@ export class SessionCore {
           system,
           history: [{ role: 'user', content: [{ type: 'text', text: rolePrompt }] }],
           tools: readOnly ? this.readOnlyTools : this.allTools,
-          toolHost: this.toolHost(),
+          toolHost: this.toolHost(guardPath),
           // Role calls aren't streamed to the transcript, but we tally their
           // output so the RUNNING gate card shows a climbing token count.
           onEvent: this.progressOnEvent(() => {}, onProgress),
@@ -1043,7 +1067,7 @@ export class SessionCore {
           system: this.systemWithSkills(SOLO_SYSTEM),
           history,
           tools: this.toolsWithSkills(),
-          toolHost: this.toolHost(),
+          toolHost: this.toolHost(guardPath),
           onEvent: this.progressOnEvent((e) => this.postForTurn(epoch, { type: 'stream', event: e }), onProgress),
           signal: s,
         });
@@ -1073,6 +1097,7 @@ export class SessionCore {
       },
       modelLabelFor: (role) => this.roleModelLabel(settings, role),
       diffBudgetFor: (role) => this.payloadBudget(settings, role),
+      storyMode,
       signal,
     });
   }
@@ -1116,6 +1141,7 @@ export class SessionCore {
     epoch: number,
     nodeId: string,
     contextDigest?: string,
+    sourcePath?: string,
   ): Promise<{ blocks: ContentBlock[]; usage: TokenUsage }> {
     const settings = await this.ensureSettings();
     const usage: TokenUsage = emptyUsage();
@@ -1183,7 +1209,7 @@ export class SessionCore {
 
     // --- Build the plan + write each spec to disk (direct meta-artifacts) ---
     const total = stories.length;
-    const plan: PrdPlan = { stories: [], cursor: 0 };
+    const plan: PrdPlan = { stories: [], cursor: 0, ...(sourcePath ? { sourcePath } : {}) };
     for (let i = 0; i < total; i += 1) {
       const s = stories[i];
       const specPath = specRelPath(this.conv.id, i + 1, s.title);
@@ -1244,7 +1270,7 @@ export class SessionCore {
     // "Retry story" is mechanically a clean-context restart. The Scout still
     // receives the cheap contextDigest for user clarifications.
     const cards: GateCard[] = [];
-    const result = await this.runCoopCore(userPrompt, [], [], resolved, harness, signal, cards, epoch, nodeId, contextDigest);
+    const result = await this.runCoopCore(userPrompt, [], [], resolved, harness, signal, cards, epoch, nodeId, contextDigest, true);
 
     const status: PrdStory['status'] =
       result.outcome === 'ready-for-review' ? 'awaiting-review' : result.outcome === 'cancelled' ? 'pending' : 'failed';
@@ -1252,7 +1278,13 @@ export class SessionCore {
     await this.writeSpec(this.conv.prdPlan!.stories[storyIndex], storyIndex + 1, total);
 
     const blocks: ContentBlock[] = cards.map((card) => ({ type: 'gate', card }));
-    const text = this.coopOutcomeText(result);
+    // A story cancelled AFTER the Builder staged work leaves those changes in the changeset —
+    // say so honestly (the generic "Cancelled." reads as if nothing happened, and the plan
+    // otherwise loops "Resume story N" forever over a changeset that is already complete).
+    const text =
+      result.outcome === 'cancelled' && !this.overlay.isEmpty()
+        ? "Cancelled — this story's staged changes are still in the changeset. Resume re-runs the story from its spec, or review/apply what's staged and Mark done."
+        : this.coopOutcomeText(result);
     if (text) blocks.push({ type: 'text', text });
     return { blocks, usage: result.usage };
   }
@@ -1281,11 +1313,58 @@ export class SessionCore {
     }
 
     const skippedReview = current.status === 'failed';
+    const nextCursor = await this.advancePastCursorStory(skippedReview ? 'skipped review' : undefined);
+    if (nextCursor === null) return; // plan complete — the summary was appended
+
+    // Run the next story as a new turn, parented on a synthetic "Continue" user node.
+    const next = this.conv.prdPlan!.stories[nextCursor];
+    const { conv, nodeId } = appendUser(this.conv, [
+      { type: 'text', text: `Continue to story ${nextCursor + 1}: ${next.title}` },
+    ]);
+    this.conv = conv;
+    await this.runAssistantTurn(nodeId, [], { storyIndex: nextCursor });
+  }
+
+  /**
+   * Human reconciliation: mark the cursor story done and advance the cursor without running
+   * the next story. Ignored while a turn is streaming; acts only when the cursor story is
+   * `pending`, `failed`, or `awaiting-review` — the states where a human decides the story is
+   * genuinely done (e.g. the Builder's staged changes already satisfy it). The spec file
+   * records the `marked done by user` nuance. When it completes the plan, the shared advance
+   * helper appends the completion summary; otherwise the advanced (pending) cursor is surfaced.
+   */
+  private async onMarkStoryDone(): Promise<void> {
+    if (this.abort) return; // a turn is in flight — ignore
+    const plan = this.conv.prdPlan;
+    if (!plan) return;
+    const current = plan.stories[plan.cursor];
+    if (!current) return;
+    if (current.status !== 'pending' && current.status !== 'failed' && current.status !== 'awaiting-review') return;
+
+    const nextCursor = await this.advancePastCursorStory('marked done by user');
+    if (nextCursor !== null) {
+      // Plan not complete — surface the advanced cursor so the plan bar reflects it.
+      await this.persist();
+      this.sendConversation();
+    }
+  }
+
+  /**
+   * The single "advance past the cursor story" code path, shared by Continue and Mark done:
+   * mark the cursor story done, bump the cursor, and record `note` in the just-finished
+   * story's spec file. When that completes the plan, append the completion-summary assistant
+   * block (persisting + syncing) and return `null`; otherwise return the new cursor index for
+   * the caller to act on (Continue runs it; Mark done leaves it pending). Preserves the plan's
+   * other fields (e.g. `sourcePath`).
+   */
+  private async advancePastCursorStory(note: string | undefined): Promise<number | null> {
+    const plan = this.conv.prdPlan;
+    if (!plan) return null;
+    const i = plan.cursor;
     const stories = plan.stories.map((s, idx) => (idx === i ? { ...s, status: 'done' as const } : s));
     const nextCursor = i + 1;
-    this.conv = { ...this.conv, prdPlan: { stories, cursor: nextCursor } };
-    // Record the skipped-review nuance in the spec file only (state machine stays simple).
-    await this.writeSpec(stories[i], i + 1, stories.length, skippedReview ? 'skipped review' : undefined);
+    this.conv = { ...this.conv, prdPlan: { ...plan, stories, cursor: nextCursor } };
+    await this.writeSpec(stories[i], i + 1, stories.length, note);
 
     if (nextCursor >= stories.length) {
       // Plan complete — summarize the final statuses in a short assistant block.
@@ -1297,16 +1376,9 @@ export class SessionCore {
       this.conv = conv;
       await this.persist();
       this.sendConversation();
-      return;
+      return null;
     }
-
-    // Run the next story as a new turn, parented on a synthetic "Continue" user node.
-    const next = stories[nextCursor];
-    const { conv, nodeId } = appendUser(this.conv, [
-      { type: 'text', text: `Continue to story ${nextCursor + 1}: ${next.title}` },
-    ]);
-    this.conv = conv;
-    await this.runAssistantTurn(nodeId, [], { storyIndex: nextCursor });
+    return nextCursor;
   }
 
   /**
@@ -1922,10 +1994,17 @@ export class SessionCore {
    *
    * Reads through the staging overlay so a staged edit of a file wins over disk,
    * and runs at wire-composition time so edits/reruns re-read fresh content.
+   *
+   * Returns the expanded text plus the workspace-relative paths actually inlined (so a caller
+   * — the PRD flow — can record which document a plan came from).
    */
-  private async expandWireFileMentions(text: string, settings: FowlPlaySettings, budgetRole?: CoopRole): Promise<string> {
+  private async expandWireFileMentions(
+    text: string,
+    settings: FowlPlaySettings,
+    budgetRole?: CoopRole,
+  ): Promise<{ text: string; includedPaths: string[] }> {
     const { explicit, bare } = extractFileMentions(text);
-    if (explicit.length === 0 && bare.length === 0) return text;
+    if (explicit.length === 0 && bare.length === 0) return { text, includedPaths: [] };
 
     const budget = this.payloadBudget(settings, budgetRole);
     const cap = budget !== undefined ? Math.min(24_000, budget * 2) : 24_000;
@@ -1950,17 +2029,27 @@ export class SessionCore {
       await includePath(path, () => {}); // bare non-matches are just prose
     }
 
-    if (included.length === 0) return text;
+    if (included.length === 0) return { text, includedPaths: [] };
     this.toast('info', `Included ${toastParts.join(', ')}`);
-    return expandFileMentions(text, included);
+    return { text: expandFileMentions(text, included), includedPaths: included.map((f) => f.path) };
   }
 
-  private toolHost(): ToolHost {
+  /**
+   * The model-facing tool host for a turn. `guardPath` (set only for story builds) makes any
+   * read of the PRD source document return a scope stub instead of its content — so a story's
+   * Builder can't open the whole PRD and implement everything. Because `open_files` reads each
+   * path through `readFile`, decorating it covers both single and multi-path reads (the stub
+   * substitutes for just that path's section).
+   */
+  private toolHost(guardPath?: string): ToolHost {
     const overlay = this.overlay;
     const io = this.deps.io;
     const skills = this.turnSkills;
+    const PRD_SCOPE_STUB =
+      "[This PRD has been decomposed into stories. Your current story's spec is your entire scope — implement only it.]";
     return {
       async readFile(path: string): Promise<string> {
+        if (guardPath && path === guardPath) return PRD_SCOPE_STUB;
         const content = await overlay.read(path);
         if (content === null) throw new Error(`file not found: ${path}`);
         return content;

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -38,6 +38,10 @@ export type WebviewToHost =
   | { type: 'continueStoryLoop' }
   // Re-run the cursor story of a PRD build (a failed — or pending — story).
   | { type: 'retryStory' }
+  // Human reconciliation: mark the cursor story done and advance the cursor without building
+  // the next story. Acts on a 'pending', 'failed', or 'awaiting-review' cursor story — e.g.
+  // when the Builder's staged changes already satisfy it. Ignored while streaming.
+  | { type: 'markStoryDone' }
   | { type: 'clearSelection' }                                    // dismiss the pinned selection chip
   | { type: 'editMessage'; nodeId: string; text: string }        // branches
   | { type: 'rerunMessage'; nodeId: string }                      // sibling response

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -277,6 +277,14 @@ export interface PrdPlan {
   stories: PrdStory[];
   /** Index of the story the human is currently building / reviewing. */
   cursor: number;
+  /**
+   * Workspace-relative path of the PRD document this plan was decomposed from, when the PRD
+   * arrived via a file mention (exactly one markdown file included on the `prd: true` send).
+   * Undefined for a pasted-raw PRD. During story builds it drives a scope guard: reading this
+   * file through a read tool returns a stub, so a story's Builder can't re-open the whole PRD
+   * and implement everything. Plain JSON — persists with the conversation.
+   */
+  sourcePath?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/webview/components/blocks.tsx
+++ b/src/webview/components/blocks.tsx
@@ -286,8 +286,10 @@ const STORY_STATUS_WORD: Record<PrdStoryStatus, string> = {
  * The actions offered for a plan's cursor story — the single source of truth shared by the
  * plan block and the pinned bar so their buttons can't drift. Empty while streaming or when
  * the cursor story is not actionable (building/done). A failed story offers Retry (primary) +
- * Skip (secondary); pending offers Resume; awaiting-review offers Continue. Retry and Resume
- * both post `retryStory` — one host code path re-runs the cursor story.
+ * Skip + Mark done (secondary); pending offers Resume + Mark done; awaiting-review offers
+ * Continue. Retry and Resume both post `retryStory` — one host code path re-runs the cursor
+ * story. "Mark done" (posts `markStoryDone`) lets the human reconcile a story reality outran —
+ * e.g. a cancelled build whose staged changes already satisfy it.
  */
 export function planActions(plan: PrdPlan, streaming: boolean): PlanAction[] {
   if (streaming) return [];
@@ -298,9 +300,13 @@ export function planActions(plan: PrdPlan, streaming: boolean): PlanAction[] {
       return [
         { label: 'Retry story', message: { type: 'retryStory' }, variant: 'primary' },
         { label: 'Skip story', message: { type: 'continueStoryLoop' }, variant: 'secondary' },
+        { label: 'Mark done', message: { type: 'markStoryDone' }, variant: 'secondary' },
       ];
     case 'pending':
-      return [{ label: `Resume story ${plan.cursor + 1}`, message: { type: 'retryStory' }, variant: 'primary' }];
+      return [
+        { label: `Resume story ${plan.cursor + 1}`, message: { type: 'retryStory' }, variant: 'primary' },
+        { label: 'Mark done', message: { type: 'markStoryDone' }, variant: 'secondary' },
+      ];
     case 'awaiting-review':
       return [{ label: 'Continue — next story', message: { type: 'continueStoryLoop' }, variant: 'primary' }];
     default:

--- a/test/extension-session.test.ts
+++ b/test/extension-session.test.ts
@@ -167,6 +167,17 @@ function textEvents(text: string): StreamEvent[] {
   return [{ type: 'text', delta: text }, USAGE, { type: 'done', stopReason: 'end' }];
 }
 
+/** A single `open_files` tool call over `paths`, then a stop for tool use. */
+function openFilesEvents(paths: string[]): StreamEvent[] {
+  return [
+    { type: 'tool_call_start', id: 'o1', name: 'open_files' },
+    { type: 'tool_call_args', id: 'o1', delta: JSON.stringify({ paths }) },
+    { type: 'tool_call_end', id: 'o1' },
+    USAGE,
+    { type: 'done', stopReason: 'tool_use' },
+  ];
+}
+
 /** A 2-story Foreman decomposition, returned when `foreman: 'two'`. */
 const TWO_STORY_JSON = JSON.stringify({
   stories: [
@@ -2064,6 +2075,302 @@ describe('retryStory', () => {
 
     unblock();
     await turn;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PRD story scope guard (plan.sourcePath → stub reads of the PRD in story builds)
+// ---------------------------------------------------------------------------
+
+describe('PRD story scope guard', () => {
+  const PRD_BODY = 'PRD-BODY-MARKER: build the whole app in one go';
+
+  /**
+   * A coop session seeded with `prd.md`. The Builder (solo-style) opens `prd.md` on its first
+   * round, then finishes — so the tool result reveals whether the read hit the real PRD or the
+   * scope stub. Foreman/Scout/Inspector/Sentry are scripted normally.
+   */
+  function makeGuardSession() {
+    const io = new FakeIo();
+    io.files.set('prd.md', PRD_BODY);
+    const posted: HostToWebview[] = [];
+    const requests: ChatRequest[] = [];
+    const adapter: ProviderAdapter = {
+      chat(request: ChatRequest) {
+        requests.push(request);
+        let events: StreamEvent[];
+        if (request.system.includes('FOREMAN')) events = textEvents(TWO_STORY_JSON);
+        else if (request.system.includes('SCOUT')) events = textEvents(JSON.stringify({ criteria: ['x'], plan: [], ambiguous: false }));
+        else if (request.system.includes('INSPECTOR') || request.system.includes('SENTRY')) events = textEvents(JSON.stringify({ verdict: 'approve', findings: [] }));
+        else {
+          const hasToolResult = request.messages.some((m) => m.role === 'tool');
+          events = hasToolResult ? textEvents('read the spec — done') : openFilesEvents(['prd.md']);
+        }
+        return (async function* () {
+          for (const e of events) yield e;
+        })();
+      },
+    };
+    const deps: SessionDeps = {
+      io,
+      secrets: new FakeSecrets(),
+      settings: new FakeSettings('coop'),
+      history: new FakeHistory(),
+      git: fakeGit,
+      post: (m) => posted.push(m),
+      createAdapter: () => adapter,
+      fetchModels: async () => [{ id: 'm1' }],
+      clock: () => Date.now(),
+    };
+    return { session: createSessionCore(deps), posted, requests, io };
+  }
+
+  it('records sourcePath and stubs the PRD for the story Builder, while the Foreman sees it in full', async () => {
+    const { session, posted, requests } = makeGuardSession();
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'implement @prd.md', prd: true });
+
+    // The single included markdown file was recorded as the plan's source document.
+    const conv = lastConversation(posted)!;
+    expect(conv.prdPlan?.sourcePath).toBe('prd.md');
+
+    // The Foreman received the full PRD body inlined into its prompt (not the stub).
+    const foreman = requests.find((r) => r.system.includes('FOREMAN'))!;
+    expect(userWireText(foreman)).toContain('PRD-BODY-MARKER');
+
+    // The story-1 Builder's open_files read of prd.md returned the scope stub — NOT the PRD.
+    const builderCont = requests.find(
+      (r) => !isRolePrompt(r.system) && r.messages.some((m) => m.role === 'tool'),
+    )!;
+    expect(builderCont).toBeDefined();
+    const toolText = allWireText(builderCont);
+    expect(toolText).toContain('decomposed into stories');
+    expect(toolText).not.toContain('PRD-BODY-MARKER');
+  });
+
+  it('a normal (non-story) coop turn reads the real file content — the guard is story-only', async () => {
+    const { session, requests } = makeGuardSession();
+    await session.handle({ type: 'ready' });
+    // No `prd` flag and no plan → the Builder opens prd.md through an ordinary tool call.
+    await session.handle({ type: 'sendPrompt', text: 'open the requirements file and summarize it' });
+
+    const builderCont = requests.find(
+      (r) => !isRolePrompt(r.system) && r.messages.some((m) => m.role === 'tool'),
+    )!;
+    expect(builderCont).toBeDefined();
+    // Real content reaches the model, not the stub.
+    expect(allWireText(builderCont)).toContain('PRD-BODY-MARKER');
+  });
+
+  it('keeps sourcePath through a JSON save/load', async () => {
+    const { session } = makeGuardSession();
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'implement @prd.md', prd: true });
+
+    const saved = session.conversation;
+    const roundTripped: Conversation = JSON.parse(JSON.stringify(saved));
+    expect(roundTripped.prdPlan?.sourcePath).toBe('prd.md');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Human reconciliation — Mark done
+// ---------------------------------------------------------------------------
+
+describe('markStoryDone', () => {
+  it('marks the cursor story done and advances without building the next; completes on the last', async () => {
+    const { session, posted, io } = makeSession({ mode: 'coop', path: 'foo.txt', content: 'x\n' });
+    await session.handle({ type: 'ready' });
+    await session.handle({ type: 'sendPrompt', text: 'PRD text', prd: true });
+    // After the PRD turn: story 0 awaiting-review, story 1 pending, cursor 0.
+
+    // Mark the cursor story done → cursor advances to the (still pending) story 1, and NO
+    // new story build runs (unlike Continue — next story).
+    const before = posted.length;
+    await session.handle({ type: 'markStoryDone' });
+    let conv = lastConversation(posted)!;
+    expect(conv.prdPlan?.cursor).toBe(1);
+    expect(conv.prdPlan?.stories[0].status).toBe('done');
+    expect(conv.prdPlan?.stories[1].status).toBe('pending'); // not built
+    expect(posted.slice(before).some((m) => m.type === 'turnStarted')).toBe(false);
+    // The spec file records the human reconciliation.
+    const spec0 = [...io.files.keys()].filter((p) => p.startsWith('.fowlplay/specs/'))[0];
+    expect(io.files.get(spec0)).toContain('marked done by user');
+
+    // Mark the now-cursor pending story done → the plan completes with a summary block.
+    const before2 = posted.length;
+    await session.handle({ type: 'markStoryDone' });
+    conv = lastConversation(posted)!;
+    expect(conv.prdPlan?.cursor).toBe(2);
+    expect(conv.prdPlan?.stories.every((s) => s.status === 'done')).toBe(true);
+    expect(posted.slice(before2).some((m) => m.type === 'turnStarted')).toBe(false);
+    const leaf = assistantLeaf(conv)!;
+    expect(leaf.blocks.some((b) => b.type === 'text' && b.text.includes('PRD build complete'))).toBe(true);
+  });
+
+  it('ignores markStoryDone while a turn is streaming', async () => {
+    const io = new FakeIo();
+    const posted: HostToWebview[] = [];
+    let unblock: () => void = () => {};
+    const blocker = new Promise<void>((res) => {
+      unblock = res;
+    });
+    // Hang the story-1 Sentry call so a turn is in flight when markStoryDone arrives.
+    const adapter: ProviderAdapter = {
+      chat(request: ChatRequest) {
+        let events: StreamEvent[];
+        let block = false;
+        if (request.system.includes('FOREMAN')) events = textEvents(TWO_STORY_JSON);
+        else if (request.system.includes('SCOUT')) events = textEvents(JSON.stringify({ criteria: ['x'], plan: [], ambiguous: false }));
+        else if (request.system.includes('SENTRY')) {
+          events = textEvents(JSON.stringify({ verdict: 'approve', findings: [] }));
+          block = true;
+        } else if (request.system.includes('INSPECTOR')) {
+          events = textEvents(JSON.stringify({ verdict: 'approve', findings: [] }));
+        } else {
+          const hasToolResult = request.messages.some((m) => m.role === 'tool');
+          events = hasToolResult ? textEvents('done') : editEvents('foo.txt', 'x\n');
+        }
+        return (async function* () {
+          if (block) await blocker;
+          for (const e of events) yield e;
+        })();
+      },
+    };
+    const deps: SessionDeps = {
+      io,
+      secrets: new FakeSecrets(),
+      settings: new FakeSettings('coop'),
+      history: new FakeHistory(),
+      git: fakeGit,
+      post: (m) => posted.push(m),
+      createAdapter: () => adapter,
+      fetchModels: async () => [{ id: 'm1' }],
+      clock: () => Date.now(),
+    };
+    const session = createSessionCore(deps);
+    await session.handle({ type: 'ready' });
+
+    const turn = session.handle({ type: 'sendPrompt', text: 'PRD text', prd: true });
+    for (let i = 0; i < 100; i += 1) {
+      if (posted.some((m) => m.type === 'gateUpdate' && m.card.role === 'sentry')) break;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    expect(posted.some((m) => m.type === 'gateUpdate' && m.card.role === 'sentry')).toBe(true);
+
+    const before = posted.length;
+    await session.handle({ type: 'markStoryDone' });
+    expect(posted.length).toBe(before); // ignored while a turn is in flight
+
+    unblock();
+    await turn;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Honest cancel text — a story cancelled with staged changes says so
+// ---------------------------------------------------------------------------
+
+/**
+ * A PRD session whose story-1 pipeline hangs on `blockRole` (a role system-prompt substring),
+ * so a cancel lands mid-story. `blockRole: 'INSPECTOR'` cancels AFTER the Builder staged its
+ * edit (overlay non-empty); `blockRole: 'SCOUT'` cancels BEFORE the Builder runs (overlay empty).
+ */
+function makeCancelStorySession(blockRole: 'INSPECTOR' | 'SCOUT') {
+  const io = new FakeIo();
+  const posted: HostToWebview[] = [];
+  let unblock: () => void = () => {};
+  const blocker = new Promise<void>((res) => {
+    unblock = res;
+  });
+  const adapter: ProviderAdapter = {
+    chat(request: ChatRequest) {
+      let events: StreamEvent[];
+      let block = false;
+      if (request.system.includes('FOREMAN')) events = textEvents(TWO_STORY_JSON);
+      else if (request.system.includes('SCOUT')) {
+        events = textEvents(JSON.stringify({ criteria: ['x'], plan: [], ambiguous: false }));
+        if (blockRole === 'SCOUT') block = true;
+      } else if (request.system.includes('INSPECTOR')) {
+        events = textEvents(JSON.stringify({ verdict: 'approve', findings: [] }));
+        if (blockRole === 'INSPECTOR') block = true;
+      } else if (request.system.includes('SENTRY')) {
+        events = textEvents(JSON.stringify({ verdict: 'approve', findings: [] }));
+      } else {
+        const hasToolResult = request.messages.some((m) => m.role === 'tool');
+        events = hasToolResult ? textEvents('done') : editEvents('foo.txt', 'x\n');
+      }
+      return (async function* () {
+        if (block) await blocker;
+        for (const e of events) yield e;
+      })();
+    },
+  };
+  const deps: SessionDeps = {
+    io,
+    secrets: new FakeSecrets(),
+    settings: new FakeSettings('coop'),
+    history: new FakeHistory(),
+    git: fakeGit,
+    post: (m) => posted.push(m),
+    createAdapter: () => adapter,
+    fetchModels: async () => [{ id: 'm1' }],
+    clock: () => Date.now(),
+  };
+  return { session: createSessionCore(deps), posted, unblock: () => unblock() };
+}
+
+describe('cancelled story outcome text', () => {
+  it('says the staged changes remain when the story is cancelled after the Builder staged work', async () => {
+    const { session, posted, unblock } = makeCancelStorySession('INSPECTOR');
+    await session.handle({ type: 'ready' });
+
+    const turn = session.handle({ type: 'sendPrompt', text: 'PRD text', prd: true });
+    // Wait until the Inspector card is emitted — the Builder has already staged foo.txt.
+    for (let i = 0; i < 100; i += 1) {
+      if (posted.some((m) => m.type === 'gateUpdate' && m.card.role === 'inspector')) break;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    await session.handle({ type: 'cancelResponse' });
+    unblock();
+    await turn;
+
+    const conv = lastConversation(posted)!;
+    const leaf = assistantLeaf(conv)!;
+    const text = leaf.blocks
+      .filter((b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text')
+      .map((b) => b.text)
+      .join('\n');
+    expect(text).toContain("this story's staged changes are still in the changeset");
+    expect(text).toContain('Mark done');
+    // A changes block is present (the staged edit survived the cancel).
+    expect(leaf.blocks.some((b) => b.type === 'changes')).toBe(true);
+  });
+
+  it('a plain cancel with no staged changes keeps the bare "Cancelled." text', async () => {
+    const { session, posted, unblock } = makeCancelStorySession('SCOUT');
+    await session.handle({ type: 'ready' });
+
+    const turn = session.handle({ type: 'sendPrompt', text: 'PRD text', prd: true });
+    // Wait until the story-1 Scout card is emitted (the Builder has NOT run → nothing staged).
+    for (let i = 0; i < 100; i += 1) {
+      if (posted.some((m) => m.type === 'gateUpdate' && m.card.role === 'scout')) break;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    await session.handle({ type: 'cancelResponse' });
+    unblock();
+    await turn;
+
+    const conv = lastConversation(posted)!;
+    const leaf = assistantLeaf(conv)!;
+    const text = leaf.blocks
+      .filter((b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text')
+      .map((b) => b.text)
+      .join('\n');
+    expect(text).toContain('Cancelled.');
+    expect(text).not.toContain('staged changes are still in the changeset');
+    // No changes block — nothing was staged.
+    expect(leaf.blocks.some((b) => b.type === 'changes')).toBe(false);
   });
 });
 

--- a/test/harness.test.ts
+++ b/test/harness.test.ts
@@ -250,6 +250,56 @@ describe('runCoopPipeline — contextDigest', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Story-mode inspector scope policing
+// ---------------------------------------------------------------------------
+
+describe('runCoopPipeline — storyMode inspector scope', () => {
+  it('adds the out-of-scope findings instruction to the Inspector prompt in story mode', async () => {
+    const { runner, calls } = scriptedRunner({
+      scout: [scoutOk(['C1'])],
+      inspector: [approve],
+      sentry: [approve],
+    });
+
+    await runCoopPipeline({
+      userPrompt: 'build story 1',
+      runner,
+      inspector: fakeInspector(),
+      buildStage: vi.fn(async () => BUILDER_USAGE),
+      settings: settings(),
+      onGate: () => {},
+      storyMode: true,
+    });
+
+    const inspectorPrompt = calls.find((c) => c.role === 'inspector')!.userPrompt;
+    expect(inspectorPrompt).toContain('ONE STORY OF A LARGER PRD');
+    expect(inspectorPrompt).toContain('out of scope for this story');
+  });
+
+  it('leaves the Inspector prompt unchanged for a normal (non-story) coop turn', async () => {
+    const { runner, calls } = scriptedRunner({
+      scout: [scoutOk(['C1'])],
+      inspector: [approve],
+      sentry: [approve],
+    });
+
+    await runCoopPipeline({
+      userPrompt: 'build a feature',
+      runner,
+      inspector: fakeInspector(),
+      buildStage: vi.fn(async () => BUILDER_USAGE),
+      settings: settings(),
+      onGate: () => {},
+      // storyMode omitted → false
+    });
+
+    const inspectorPrompt = calls.find((c) => c.role === 'inspector')!.userPrompt;
+    expect(inspectorPrompt).not.toContain('ONE STORY OF A LARGER PRD');
+    expect(inspectorPrompt).not.toContain('out of scope for this story');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Ambiguous scout → blocked
 // ---------------------------------------------------------------------------
 

--- a/test/prd.test.ts
+++ b/test/prd.test.ts
@@ -166,9 +166,20 @@ describe('composeStoryPrompt', () => {
     const prompt = composeStoryPrompt(spec, 2, 5);
     expect(prompt).toContain('Story 2 of 5 decomposed from a PRD');
     expect(prompt).toContain('Implement ONLY this story');
-    expect(prompt).toContain('read the files rather than assuming');
     expect(prompt).toContain('# Add pagination');
     // The spec text follows the preamble.
     expect(prompt.indexOf('Story 2 of 5')).toBeLessThan(prompt.indexOf('# Add pagination'));
+  });
+
+  it('uses scope-tight wording: earlier work may be read, but do not open the PRD', () => {
+    const prompt = composeStoryPrompt('# Add pagination\n', 1, 3);
+    // The old "read the files rather than assuming" invitation is gone…
+    expect(prompt).not.toContain('rather than assuming');
+    // …replaced by scope-tight language: earlier work is readable, but the spec is the
+    // ENTIRE scope and the PRD document must not be opened.
+    expect(prompt).toContain('may be READ');
+    expect(prompt).toContain('ENTIRE scope');
+    expect(prompt).toMatch(/Do NOT open the PRD document/i);
+    expect(prompt).toMatch(/do NOT implement other stories/i);
   });
 });


### PR DESCRIPTION
Fixes the field failure where story 1's Builder re-opened the PRD file from the workspace and implemented the entire site while the plan "masqueraded" as an eight-story build, then a cancelled turn left "Resume story 1" dangling over completed work.

- **Mechanical scope guard**: the plan records the PRD's source path (from the file-mention machinery); during story builds every read tool returns a scope stub for that path — Foreman and normal turns keep full access; pasted-raw PRDs leave the guard inert
- **Inspector polices scope both ways** in story mode: changes beyond the story's acceptance criteria are findings warranting rejection, not bonus work
- **Story preamble hardened**: no longer invites re-reading; forbids opening the PRD and implementing other stories' features
- **Mark done**: secondary action on pending/failed cursor stories lets the human reconcile a plan that reality outran; the shared advance path now preserves `plan.sourcePath`
- A story cancelled with staged changes says so explicitly ("staged changes remain — Resume re-runs, or review/apply and Mark done")

Verification: `tsc --noEmit` clean, 384 unit tests, 102 + 35 e2e assertions, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFHdV5N7Tx9ATy3oDxyouG)_